### PR TITLE
Server-side rendering performance optimizations

### DIFF
--- a/examples/server/server.js
+++ b/examples/server/server.js
@@ -113,6 +113,8 @@ ideogramDrawer = function(config) {
   var t1 = new Date().getTime();
   console.log("Time to rearrange annots: " + (t1-t0) + " ms");
 
+  d3.selectAll("*[style*='display: none']").remove();
+
   for (i = 0; i < rearrangedAnnots.length; i++) {
   //for (i = 0; i < 2; i++) { // DEBUG
     d3.selectAll(".annot").remove();

--- a/examples/server/server.js
+++ b/examples/server/server.js
@@ -116,7 +116,12 @@ ideogramDrawer = function(config) {
   // Typically takes < 300 ms for ~20000 annots
   //console.log("  (Time to rearrange annots: " + (t1-t0) + " ms)");
 
+  // Remove hidden elements.  Makes large batches ~30% faster (PR #23).
   d3.selectAll("*[style*='display: none']").remove();
+
+  // Remove JS hooks not used for static styling.
+  // Shrinks SVG ~16%; same PNG perf.
+  d3.selectAll(".band").attr("id", null).classed("band", null);
 
   for (i = 0; i < rearrangedAnnots.length; i++) {
   //for (i = 0; i < 2; i++) { // DEBUG
@@ -193,6 +198,8 @@ service = server.listen(port, function (request, response) {
     t0 = new Date().getTime();
 
     chrRect = {};
+
+    //fs.write("foo.svg", images[0][1]); // DEBUG
 
     for (var i = 0; i < images.length; i++) {
 

--- a/examples/server/server.js
+++ b/examples/server/server.js
@@ -42,7 +42,7 @@ ideogramDrawer = function(config) {
     //
     // The idea here is to enable the rendering pipeline to generate one
     // annotation per chromosome.  This way, often only 1 DOM write needs
-    // to happen for up to 24 different images, e.g. if we're running a batches
+    // to happen for up to 24 different images, e.g. if we're running a batch
     // job to generate one image for the location of each human gene.
     //
     // In practice, as we progress through the annotations, we end up with fewer
@@ -51,9 +51,10 @@ ideogramDrawer = function(config) {
     // chrY, so we end up omitting chrY in inner "ras" (arrays) in the
     // implementation.
     //
-    // That means this optimization will be less beneficial annotations are
-    // less evenly distributed among chromosomes.  This certainly affects human
-    // genes and variations, and probably all other kinds of annotation sets.
+    // That means this optimization will be less beneficial for annotations
+    // that are less evenly distributed among chromosomes.  This certainly
+    // affects human genes and variations, and probably all other kinds of
+    // annotation sets.
     //
     // Thus, while better than a completely naive implementation (1 DOM write
     // per annotation) for whole-genome annotation sets, this algorithm is not
@@ -77,8 +78,6 @@ ideogramDrawer = function(config) {
     // https://github.com/eweitz/ideogram/pull/23 for timing details.  It would
     // probably be better to focus on optimizing the "Render and write PNG to
     // disk" step, which takes about 480 seconds.
-
-    //annots = annots["annots"];
 
     var annot, chrs, chr, i, j, k, m,
         chrAnnots, totalAnnots,
@@ -134,14 +133,12 @@ ideogramDrawer = function(config) {
 
   }
 
-
   var rawAnnotsByChr, rearrangedAnnots, ra,
       ideogram,
       annot, annots, i,
       svg, id, ids, tmp,
       chrRects, rect, chrs, chr, chrID,
       images = [];
-
 
   ideogram = new Ideogram(config);
   ideogram.annots = ideogram.processAnnotData(config.rawAnnots.annots);
@@ -197,8 +194,8 @@ svgDrawer = function(svg) {
   //oldDiv.parentNode.replaceChild(newDiv, oldDiv);
 
   document.getElementsByTagName("body")[0].innerHTML = svg;
-
 }
+
 
 service = server.listen(port, function (request, response) {
 
@@ -222,7 +219,7 @@ service = server.listen(port, function (request, response) {
   page.open(url, function (status) {
 
     var tmp, chrRects, images, totalImages,
-        chrRect, chr, image, id, png,
+        chrRect, chr, image, id, png;
 
     t0 = new Date().getTime();
     tmp = page.evaluate(ideogramDrawer, ideoConfig);
@@ -262,9 +259,7 @@ service = server.listen(port, function (request, response) {
           timeC += t1c - t0c;
 
           totalImages += 1;
-
       });
-
     }
 
     console.log("Time to get SVG: " + time + " ms");

--- a/examples/server/server.js
+++ b/examples/server/server.js
@@ -207,7 +207,7 @@ service = server.listen(port, function (request, response) {
   console.log("")
 
   var totalTime1, totalTime,
-      min, sec, msec, totalTimeFriendly,
+      date, day, hour, min, sec, msec, totalTimeFriendly,
       t0, t1, time,
       t0a, t1a, timeA = 0,
       t1b, t1b, timeB = 0,
@@ -280,16 +280,30 @@ service = server.listen(port, function (request, response) {
 
     totalTime1 = new Date().getTime();
     totalTime = totalTime1 - totalTime0;
-    //min = Math.floor(totalTime/(60000)); // 60000 milliseconds = 1 minute
-    //sec = Math.floor(10-(600000-totalTime)/1000);
-    //msec =
-    //totalTimeFriendly = min + "m" + sec + "." + ms // Like Unix 'time' command
+
+    date = new Date(totalTime);
+    day = date.getUTCDate() - 1;
+    hour = date.getUTCHours();
+    min = date.getUTCMinutes();
+    sec = date.getUTCSeconds();
+    ms = date.getUTCMilliseconds();
+    // Like Unix 'time' command
+    totalTimeFriendly = min + "m" + sec + "." + ms + "s"
+    if (hour > 0) {
+      totalTimeFriendly = hour + "h" + totalTimeFriendly;
+    }
+    if (day > 0) {
+      totalTimeFriendly = day + "d" + totalTimeFriendly;
+    }
 
     // Will need to adjust when # annots != # ideograms
     ideoPerMs = (totalImages/totalTime).toFixed(5);
     msPerIdeo = Math.round(totalTime/totalImages);
 
-    console.log("Time to produce all images: " + totalTime + " ms");
+    console.log(
+      "Time to produce all images: " + totalTime + " ms " +
+      "(" + totalTimeFriendly + ")"
+    );
     console.log(
       "Performance: " +
       ideoPerMs + " ideogram/ms " +

--- a/examples/server/server.js
+++ b/examples/server/server.js
@@ -130,7 +130,7 @@ ideogramDrawer = function(config) {
 
     }
 
-    return [rearrangedAnnots, totalAnnots];
+    return rearrangedAnnots;
 
   }
 
@@ -139,7 +139,7 @@ ideogramDrawer = function(config) {
       ideogram,
       annot, annots, i,
       svg, id, ids, tmp,
-      chrRects, rect, chrs, chr, chrID, tmp, totalAnnots,
+      chrRects, rect, chrs, chr, chrID,
       images = [];
 
 
@@ -147,9 +147,7 @@ ideogramDrawer = function(config) {
   ideogram.annots = ideogram.processAnnotData(config.rawAnnots.annots);
 
   var t0 = new Date().getTime();
-  tmp = rearrangeAnnots(ideogram.annots);
-  rearrangedAnnots = tmp[0];
-  totalAnnots = tmp[1];
+  rearrangedAnnots = rearrangeAnnots(ideogram.annots);
   var t1 = new Date().getTime();
   // Typically takes < 300 ms for ~20000 annots
   //console.log("  (Time to rearrange annots: " + (t1-t0) + " ms)");
@@ -186,7 +184,7 @@ ideogramDrawer = function(config) {
     }
   }
 
-  images = [chrRects, images, totalAnnots]
+  images = [chrRects, images]
 
   return images;
 }
@@ -223,20 +221,20 @@ service = server.listen(port, function (request, response) {
 
   page.open(url, function (status) {
 
-    var tmp, chrRects, images, totalAnnots,
+    var tmp, chrRects, images, totalImages,
         chrRect, chr, image, id, png,
 
     t0 = new Date().getTime();
     tmp = page.evaluate(ideogramDrawer, ideoConfig);
     chrRects = tmp[0];
     images = tmp[1];
-    totalAnnots = tmp[2];
     t1 = new Date().getTime();
     time = t1 - t0;
 
     t0 = new Date().getTime();
 
     chrRect = {};
+    totalImages = 0;
 
     //fs.write("foo.svg", images[0][1]); // DEBUG
 
@@ -263,6 +261,8 @@ service = server.listen(port, function (request, response) {
           t1c = new Date().getTime();
           timeC += t1c - t0c;
 
+          totalImages += 1;
+
       });
 
     }
@@ -273,7 +273,7 @@ service = server.listen(port, function (request, response) {
     console.log("Time to render and write PNG to disk: " + timeC + " ms");
 
     console.log("");
-    console.log("Total images: " + totalAnnots);
+    console.log("Total images: " + totalImages);
 
     response.statusCode = 200;
     response.write("Done");
@@ -286,8 +286,8 @@ service = server.listen(port, function (request, response) {
     //totalTimeFriendly = min + "m" + sec + "." + ms // Like Unix 'time' command
 
     // Will need to adjust when # annots != # ideograms
-    ideoPerMs = (totalAnnots/totalTime).toFixed(5);
-    msPerIdeo = Math.round(totalTime/totalAnnots);
+    ideoPerMs = (totalImages/totalTime).toFixed(5);
+    msPerIdeo = Math.round(totalTime/totalImages);
 
     console.log("Time to produce all images: " + totalTime + " ms");
     console.log(


### PR DESCRIPTION
Further optimized server-side rendering performance, bringing time to produce produce ~21,800 images -- one for each human gene -- from 14-15 minutes to 10 minutes.

Below are performance test results before and after a 1-line change to remove hidden elements from the DOM,https://github.com/eweitz/ideogram/commit/86c2e83643f63ffcff52ab888e79850c432b91db.  The data shown were averaged across two samples in each test case.

_Times by pipeline step, in seconds_

| Test case | Get SVG | Write SVG to DOM | Render and write PNG to disk | Total |
| --------- |-----------| -----| ---------- | ------- |
| Before | 81 | 331 | 552 | 885 |
| After | 14 | 121 | 476 | 598 |
| Improvement (1-A/B) | 83% faster | 63% faster | 14% faster | 32% faster |

This demonstrates that removing SVG elements in the raw ideogram that have `style = "display: none;"` greatly reduces the time to generate the SVG and the time to write that SVG to the DOM.  It also significantly reduces time in the PNG render-and-write step -- all with no loss in image quality.  

The hardware used for these measurements is the same as that used in https://github.com/eweitz/ideogram/pull/22.
