### PR TITLE
Convert GVF to annotation JSON

### DIFF
--- a/scripts/convert_gvf_to_annots.py
+++ b/scripts/convert_gvf_to_annots.py
@@ -32,7 +32,7 @@ lengths_GRCh38 = {
     "22": 50818468, "X": 156040895, "Y": 57227415
 }
 
-file_name = "estd214_1000_Genomes_Consortium_Phase_3.GRCh38.remap.all.germline.short.gvf"
+file_name = "../data/annotations/estd214_1000_Genomes_Consortium_Phase_3.GRCh38.remap.var.germline.gvf"
 file = open(file_name, "r").readlines()
 
 for chr in chrs:
@@ -48,11 +48,11 @@ for line in file[1:]:
 
     # E.g. NC_000001.11 -> 1
     # This RefSeq hack only works for human chromosomes 1-22
-    chr = chr.split(".")[0][-2:].replace("0", "")
+    chr = str(int(chr.split(".")[0][-2:]))
 
-    if chr == "22":
+    if chr == "23":
     	chr = "X"
-    elif chr == "23":
+    elif chr == "24":
     	chr = "Y"
 
     if chr not in chrs:
@@ -76,16 +76,9 @@ for line in file[1:]:
         1 # placeholder for future use
     ]
 
-    if chr == "X":
-        chr = 22
-    elif chr == "Y":
-        chr = 23
-    else:
-        chr = int(chr) - 1
-
     annots[chr]["annots"].append(annot)
 
 annots = json.dumps(annots)
 annots = '{"annots":' + annots + '}'
 
-open("dbvar_estd214.json", "w").write(annots)
+open("../data/annotations/dbvar_estd214.var.json", "w").write(annots)

--- a/scripts/convert_gvf_to_annots.py
+++ b/scripts/convert_gvf_to_annots.py
@@ -1,0 +1,91 @@
+''' Converts GVF data from dbVar to JSON-formatted annotations'''
+
+import re, json, random
+
+annots = []
+
+chrs = [
+    "1", "2", "3", "4", "5", "6", "7", "8", "9", "10",
+    "11", "12", "13", "14", "15", "16", "17", "18", "19", "20",
+    "21", "22", "X", "Y"
+]
+
+lengths_GRCh37 = {
+    "1": 249250621, "2": 243199373, "3": 198022430,
+    "4": 191154276, "5": 180915260, "6": 171115067,
+    "7": 159138663, "8": 146364022, "9": 141213431,
+    "10": 135534747, "11": 135006516, "12": 133851895,
+    "13": 115169878, "14": 107349540, "15": 102531392,
+    "16": 90354753, "17": 81195210, "18": 78077248,
+    "19": 59128983, "20": 63025520, "21": 48129895,
+    "22": 51304566, "X": 155270560, "Y": 59373566
+}
+
+lengths_GRCh38 = {
+    "1": 248956422, "2": 242193529, "3": 198295559,
+    "4": 190214555, "5": 181538259, "6": 170805979,
+    "7": 159345973, "8": 145138636, "9": 138394717,
+    "10": 133797422, "11": 135086622, "12": 133275309,
+    "13": 114364328, "14": 107043718, "15": 101991189,
+    "16": 90338345,	"17": 83257441, "18": 80373285,
+    "19": 58617616, "20": 64444167, "21": 46709983,
+    "22": 50818468, "X": 156040895, "Y": 57227415
+}
+
+file_name = "estd214_1000_Genomes_Consortium_Phase_3.GRCh38.remap.all.germline.short.gvf"
+file = open(file_name, "r").readlines()
+
+for chr in chrs:
+    annots.append({"chr": chr, "annots": []});
+
+for line in file[1:]:
+    if line[0] == "#":
+        continue
+
+    columns = line.strip().split("\t")
+
+    chr = columns[0]
+
+    # E.g. NC_000001.11 -> 1
+    # This RefSeq hack only works for human chromosomes 1-22
+    chr = chr.split(".")[0][-2:].replace("0", "")
+
+    if chr == "22":
+    	chr = "X"
+    elif chr == "23":
+    	chr = "Y"
+
+    if chr not in chrs:
+		# E.g. chrMT, alternate loci scaffolds
+        continue
+
+    name = ""
+    gff_attrs = columns[8].split(";")
+    for attr in gff_attrs:
+        tmp = attr.split("=")
+        if tmp[0] == "Name":
+            name = tmp[1]
+
+    start = int(columns[3])
+    stop = int(columns[4]) - start
+
+    annot = [
+        name,
+        start,
+        stop,
+        1 # placeholder for future use
+    ]
+
+    if chr == "X":
+        chr = 22
+    elif chr == "Y":
+        chr = 23
+    else:
+        chr = int(chr) - 1
+
+    annots[chr]["annots"].append(annot)
+
+annots = json.dumps(annots)
+annots = '{"annots":' + annots + '}'
+
+open("dbvar_estd214.json", "w").write(annots)


### PR DESCRIPTION
This script converts data in Genetic Variation Format (GVF) into Ideogram.js's native JSON format for annotations.  The current version is naive, but demonstrates the principle of modeling data from standard bioinformatics file formats in a genome-wide visualization.

The data used for this proof-of-concept is all large-scale, structural variants from the 1000 Genomes Project, Phase 3 mapped to human reference genome GRCh38.  

* Data overview: http://www.ncbi.nlm.nih.gov/dbvar/studies/estd214/
* Data download: ftp://ftp.ncbi.nlm.nih.gov/pub/dbVar/data/Homo_sapiens/by_study/estd214_1000_Genomes_Consortium_Phase_3