### PR TITLE
Fix chromosome labels in wide chromosomes

### DIFF
--- a/src/js/ideogram.js
+++ b/src/js/ideogram.js
@@ -383,7 +383,7 @@ Ideogram.prototype.drawChromosomeLabels = function(chromosomes) {
 
   chrs = ideo.chromosomesArray;
 
-  chrMargin2 = ideo.config.chrMargin - ideo.config.chrWidth - 2;
+  chrMargin2 = ideo.config.chrWidth/2 + ideo.config.chrMargin - 8;
   if (ideo.config.orientation === "vertical" && ideo.config.showBandLabels === true) {
     chrMargin2 = ideo.config.chrMargin + 8;
   }
@@ -449,7 +449,7 @@ Ideogram.prototype.drawChromosomeLabels = function(chromosomes) {
                 lines.push(arr[arr.length - 1]);
 
                 chrMargin = ideo.config.chrMargin * i;
-                y = (chrMargin + chrMargin2) + 9;
+                y = (chrMargin + chrMargin2);
 
                 for (var i = 0; i < lines.length; i++) {
 

--- a/src/js/ideogram.js
+++ b/src/js/ideogram.js
@@ -377,15 +377,16 @@ Ideogram.prototype.getChromosomeModel = function(bands, chromosomeName, taxid, c
 Ideogram.prototype.drawChromosomeLabels = function(chromosomes) {
 
   var i, chr, chrs, taxid, ideo,
-      chrMargin2;
-
-  ideo = this;
+      chrMargin2,
+      ideo = this,
+      chrMargin = ideo.config.chrMargin,
+      chrWidth = ideo.config.chrWidth;
 
   chrs = ideo.chromosomesArray;
 
-  chrMargin2 = ideo.config.chrWidth/2 + ideo.config.chrMargin - 8;
+  chrMargin2 = chrWidth/2 + chrMargin - 8;
   if (ideo.config.orientation === "vertical" && ideo.config.showBandLabels === true) {
-    chrMargin2 = ideo.config.chrMargin + 8;
+    chrMargin2 = chrMargin + 8;
   }
 
   if (ideo.config.orientation === "vertical") {
@@ -398,7 +399,7 @@ Ideogram.prototype.drawChromosomeLabels = function(chromosomes) {
         .attr("y", -16)
         .each(function (d, i) {
 
-          var i, chrMargin, x, cls;
+          var i, chrMarginI, x, cls;
           var arr = d.name.split(" ");
           var lines = [];
 
@@ -410,8 +411,8 @@ Ideogram.prototype.drawChromosomeLabels = function(chromosomes) {
                 i += 1;
               }
 
-              chrMargin = (ideo.config.chrMargin) * i;
-              x = -(chrMargin + chrMargin2) + 3 + ideo.config.annotTracksHeight * 2;
+              chrMarginI = chrMargin * i;
+              x = -(chrMarginI + chrMargin2 - chrWidth - 2) + ideo.config.annotTracksHeight * 2;
 
               for (var i = 0; i < lines.length; i++) {
 
@@ -439,7 +440,7 @@ Ideogram.prototype.drawChromosomeLabels = function(chromosomes) {
           .attr("x", -5)
           .each(function (d, i) {
 
-            var i, chrMargin, y, cls;
+            var i, chrMarginI, y, cls;
 
             var arr = d.name.split(" ");
             var lines = [];
@@ -448,8 +449,8 @@ Ideogram.prototype.drawChromosomeLabels = function(chromosomes) {
                 lines.push(arr.slice(0, arr.length - 1).join(" "))
                 lines.push(arr[arr.length - 1]);
 
-                chrMargin = ideo.config.chrMargin * i;
-                y = (chrMargin + chrMargin2);
+                chrMarginI = chrMargin * i;
+                y = (chrMarginI + chrMargin2);
 
                 for (var i = 0; i < lines.length; i++) {
 

--- a/src/js/ideogram.js
+++ b/src/js/ideogram.js
@@ -386,7 +386,7 @@ Ideogram.prototype.drawChromosomeLabels = function(chromosomes) {
 
   chrMargin2 = chrWidth/2 + chrMargin - 8;
   if (ideo.config.orientation === "vertical" && ideo.config.showBandLabels === true) {
-    chrMargin2 = chrMargin + 8;
+    chrMargin2 = chrMargin + 17;
   }
 
   if (ideo.config.orientation === "vertical") {

--- a/test/web-test.js
+++ b/test/web-test.js
@@ -582,8 +582,8 @@ describe("Ideogram", function() {
         var band, bandMiddle,
             chrLabel, chrLabelMiddle;
 
-        band = d3.select(".chromosome .band")[0][0].getBoundingClientRect();
-        chrLabel = d3.select(".chromosome .chrLabel")[0][0].getBoundingClientRect();
+        band = d3.selectAll(".chromosome .band")[0][0].getBoundingClientRect();
+        chrLabel = d3.selectAll(".chromosome .chrLabel")[0][0].getBoundingClientRect();
 
         bandMiddle = band.top + band.height/2;
         chrLabelMiddle = chrLabel.top + chrLabel.height/2;
@@ -619,8 +619,8 @@ describe("Ideogram", function() {
         var band, bandMiddle,
             chrLabel, chrLabelMiddle;
 
-        band = d3.select(".chromosome .band")[0][0].getBoundingClientRect();
-        chrLabel = d3.select(".chromosome .chrLabel")[0][0].getBoundingClientRect();
+        band = d3.selectAll(".chromosome .band")[0][0].getBoundingClientRect();
+        chrLabel = d3.selectAll(".chromosome .chrLabel")[0][0].getBoundingClientRect();
 
         bandMiddle = band.left + band.width/2;
         chrLabelMiddle = chrLabel.left + chrLabel.width/2;
@@ -651,5 +651,36 @@ describe("Ideogram", function() {
       config.onDrawAnnots = callback;
       var ideogram = new Ideogram(config);
     });
+
+
+    it("should align chr. label with band-labeled vertical chromosome", function(done) {
+      // Tests use case from ../examples/human.html
+
+      function callback() {
+
+        var band, bandMiddle,
+            chrLabel, chrLabelMiddle;
+
+        band = d3.select(".chromosome .band")[0][0].getBoundingClientRect();
+        chrLabel = d3.select(".chromosome .chrLabel")[0][0].getBoundingClientRect();
+
+        bandMiddle = band.left + band.width/2;
+        chrLabelMiddle = chrLabel.left + chrLabel.width/2;
+
+        labelsDiff = Math.abs(bandMiddle - chrLabelMiddle);
+
+        assert.isAtMost(labelsDiff, 1);
+        done();
+      }
+
+      var config = {
+        organism: "human",
+        showBandLabels: true,
+        chrHeight: 500
+      };
+      config.onLoad = callback;
+      var ideogram = new Ideogram(config);
+    });
+
 
 });

--- a/test/web-test.js
+++ b/test/web-test.js
@@ -569,7 +569,85 @@ describe("Ideogram", function() {
         "chr": "17",
         "start": 43044294,
         "stop": 43125482
-      }],
+      }];
+      config.onDrawAnnots = callback;
+      var ideogram = new Ideogram(config);
+    });
+
+
+    it("should align chr. label with thick horizontal chromosome", function(done) {
+      // Tests use case from ../examples/human.html
+
+      function callback() {
+        var band, bandMiddle,
+            chrLabel, chrLabelMiddle;
+
+        band = d3.select(".chromosome .band")[0][0].getBoundingClientRect();
+        chrLabel = d3.select(".chromosome .chrLabel")[0][0].getBoundingClientRect();
+
+        bandMiddle = band.top + band.height/2;
+        chrLabelMiddle = chrLabel.top + chrLabel.height/2;
+
+        labelsDiff = Math.abs(bandMiddle - chrLabelMiddle);
+
+        assert.isAtMost(labelsDiff, 1);
+        done();
+      }
+
+      config = {
+        organism: "human",
+        chrHeight: 600,
+        chrWidth: 20,
+        orientation: "horizontal",
+        chromosomes: ["17"],
+        annotations: [{
+          "name": "BRCA1",
+          "chr": "17",
+          "start": 43044294,
+          "stop": 43125482
+        }],
+        annotationHeight: 6
+      };
+      config.onDrawAnnots = callback;
+      var ideogram = new Ideogram(config);
+    });
+
+    it("should align chr. label with vertical chromosome", function(done) {
+      // Tests use case from ../examples/human.html
+
+      function callback() {
+        var band, bandMiddle,
+            chrLabel, chrLabelMiddle;
+
+        band = d3.select(".chromosome .band")[0][0].getBoundingClientRect();
+        chrLabel = d3.select(".chromosome .chrLabel")[0][0].getBoundingClientRect();
+
+        bandMiddle = band.left + band.width/2;
+        chrLabelMiddle = chrLabel.left + chrLabel.width/2;
+
+        labelsDiff = Math.abs(bandMiddle - chrLabelMiddle);
+
+        assert.isAtMost(labelsDiff, 1);
+        done();
+      }
+
+
+      var annotationTracks = [
+        {"id": "pathogenicTrack", "displayName": "Pathogenic", "color": "#F00"},
+        {"id": "likelyPathogenicTrack", "displayName": "Likely pathogenic", "color": "#DB9"},
+        {"id": "uncertainSignificanceTrack", "displayName": "Uncertain significance", "color": "#CCC"},
+        {"id": "likelyBenignTrack", "displayName": "Likely benign", "color": "#BD9"},
+        {"id": "benignTrack",  "displayName": "Benign", "color": "#8D4"}
+      ]
+
+      var config = {
+        organism: "human",
+        chrWidth: 20,
+        chrHeight: 500,
+        annotationsPath: "../data/annotations/1000_virtual_snvs.json",
+        annotationTracks: annotationTracks,
+        annotationHeight: 2.5
+      };
       config.onDrawAnnots = callback;
       var ideogram = new Ideogram(config);
     });


### PR DESCRIPTION
This aligns chromosomes and their labels when chromosome width (thickness) is greater than default.  It also adds three unit tests to guard against related regressions, which are often not obvious.