### PR TITLE
Enable coloring cytogenetic arms

### DIFF
--- a/examples/annotations_colored_arms.html
+++ b/examples/annotations_colored_arms.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Annotations, colored arms | Ideogram</title>
+  <link type="text/css" rel="stylesheet" href="../src/css/ideogram.css"/>
+  <script type="text/javascript" src="../src/js/d3.min.js"></script>
+  <script type="text/javascript" src="../src/js/ideogram.js"></script>
+  <script type="text/javascript" src="../data/bands/native/ideogram_9606_GCF_000001305.14_850_V1.js"></script>
+</head>
+<body>
+  <h1>Annotations, colored arms | Ideogram</h1>
+  <a href=".">Back to overview</a>
+
+  <script type="text/javascript">
+
+    function onIdeogramLoad() {
+      d3.selectAll("g").on("click", function() {
+        ideogram.rotateAndToggleDisplay(this.id);
+      });
+    }
+
+    var config = {
+      organism: "human",
+      chrHeight: 500,
+      armColors: ["#D00", "#CCC"],
+      onLoad: onIdeogramLoad
+    };
+
+    var ideogram = new Ideogram(config);
+
+  </script>
+</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -26,6 +26,7 @@
 		  <li><a href="homology_interspecies.html">Homology, interspecies</a>.  Relations between two chromosomes, each from a different taxon.</li>
       <li><a href="annotations_basic.html">Annotations, basic</a>.  Placed features on chromosomes.</li>
       <li><a href="annotations_overlaid.html">Annotations, overlaid</a>.  Overlaid features on chromosomes.</li>
+      <li><a href="annotations_colored_arms.html">Annotations, colored arms</a>.  Cytogenetic arms filled with different colors.</li>
       <li><a href="annotations_tracks.html">Annotations, tracks</a>.  Stacked features on chromosomes.</li>
       <li><a href="annotations_histogram.html">Annotations, histogram</a>.  Dense feature distributions on chromosomes.</li>
       <li><a href="layout_small.html">Layout, small</a>.  Chromosomes surrounded by other content.</li>

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
   "devDependencies": {
     "chai": "^3.2.0",
     "eslint": "^2.11.1",
+    "eslint-config-google": "^0.5.0",
+    "eslint-config-standard": "^5.3.1",
     "eslint-plugin-standard": "^1.3.2",
     "gulp-mocha": "*",
     "gulp-mocha-phantomjs": "^0.11",

--- a/src/js/ideogram.js
+++ b/src/js/ideogram.js
@@ -296,6 +296,20 @@ Ideogram.prototype.colorArms = function(pArmColor, qArmColor) {
   });
   d3.selectAll(".p-ter.chromosomeBorder").style("fill", pArmColor);
   d3.selectAll(".q-ter.chromosomeBorder").style("fill", qArmColor);
+  d3.selectAll(".acen")[0].forEach(function(d){
+  console.log(d);
+  var chrID = d.id.split("-").slice(0,2).join("-");
+  console.log(chrID)
+  var r = d.getBoundingClientRect();
+  console.log(r);
+  d3.select("#" + chrID)
+    .append("line")
+      .attr("x1", r.top)
+      .attr("y1", r.left + r.width)
+      .attr("x2", r.top)
+      .attr("y2", r.left)
+      .style("stroke", "#0F0")
+  });
 };
 
 /**
@@ -2421,6 +2435,11 @@ function finishInit() {
 
     if (ideo.config.annotations) {
       ideo.drawAnnots(ideo.config.annotations);
+    }
+
+    if (ideo.config.armColors) {
+      var ac = ideo.config.armColors;
+      ideo.colorArms(ac[0], ac[1]);
     }
 
     var t1_a = new Date().getTime();

--- a/src/js/ideogram.js
+++ b/src/js/ideogram.js
@@ -282,6 +282,9 @@ Ideogram.prototype.getBands = function(content, taxid, chromosomes) {
 
 };
 
+/**
+* Fills cytogenetic arms -- p-arm and q-arm -- with specified colors
+*/
 Ideogram.prototype.colorArms = function(pArmColor, qArmColor) {
 
   var ideo = this;

--- a/src/js/ideogram.js
+++ b/src/js/ideogram.js
@@ -288,22 +288,31 @@ Ideogram.prototype.colorArms = function(pArmColor, qArmColor) {
 
   ideo.chromosomesArray.forEach(function(chr, chrIndex){
 
-    var pcen = chr.bands[chr.pcenIndex],
+    var bands = chr.bands,
+        pcen = bands[chr.pcenIndex],
+        qcen = bands[chr.pcenIndex + 1],
         chrID = chr.id,
-        rect = d3.select("#" + chrID + " path")[0][0].getBoundingClientRect(),
-        box = d3.select("#" + chrID + " path")[0][0].getBBox(),
         chrMargin = ideo.config.chrMargin * (chrIndex + 1),
         chrWidth = ideo.config.chrWidth;
 
     pcenStart = pcen.px.start;
+    qcenStop = qcen.px.stop;
 
     d3.select("#" + chrID)
       .append("line")
         .attr("x1", pcenStart)
-        .attr("y1", chrMargin)
+        .attr("y1", chrMargin + 0.2)
         .attr("x2", pcenStart)
-        .attr("y2", chrMargin + chrWidth)
+        .attr("y2", chrMargin + chrWidth - 0.2)
         .style("stroke", pArmColor)
+
+    d3.select("#" + chrID)
+      .append("line")
+        .attr("x1", qcenStop)
+        .attr("y1", chrMargin + 0.2)
+        .attr("x2", qcenStop)
+        .attr("y2", chrMargin + chrWidth - 0.2)
+        .style("stroke", qArmColor)
 
     d3.selectAll("#" + chrID + " .band")
       .data(chr.bands)

--- a/src/js/ideogram.js
+++ b/src/js/ideogram.js
@@ -282,6 +282,22 @@ Ideogram.prototype.getBands = function(content, taxid, chromosomes) {
 
 };
 
+Ideogram.prototype.colorArms = function(pArmColor, qArmColor) {
+  this.chromosomesArray.forEach(function(chr){
+    d3.selectAll("#" + chr.id + " .band")
+      .data(chr.bands)
+      .style("fill", function(d, i) {
+        if (i <= chr.pcenIndex) {
+          return pArmColor;
+        } else {
+          return qArmColor;
+        }
+      });
+  });
+  d3.selectAll(".p-ter.chromosomeBorder").style("fill", pArmColor);
+  d3.selectAll(".q-ter.chromosomeBorder").style("fill", qArmColor);
+};
+
 /**
 * Generates a model object for each chromosome
 * containing information on its name, DOM ID,

--- a/src/js/ideogram.js
+++ b/src/js/ideogram.js
@@ -283,8 +283,29 @@ Ideogram.prototype.getBands = function(content, taxid, chromosomes) {
 };
 
 Ideogram.prototype.colorArms = function(pArmColor, qArmColor) {
-  this.chromosomesArray.forEach(function(chr){
-    d3.selectAll("#" + chr.id + " .band")
+
+  var ideo = this;
+
+  ideo.chromosomesArray.forEach(function(chr, chrIndex){
+
+    var pcen = chr.bands[chr.pcenIndex],
+        chrID = chr.id,
+        rect = d3.select("#" + chrID + " path")[0][0].getBoundingClientRect(),
+        box = d3.select("#" + chrID + " path")[0][0].getBBox(),
+        chrMargin = ideo.config.chrMargin * (chrIndex + 1),
+        chrWidth = ideo.config.chrWidth;
+
+    pcenStart = pcen.px.start;
+
+    d3.select("#" + chrID)
+      .append("line")
+        .attr("x1", pcenStart)
+        .attr("y1", chrMargin)
+        .attr("x2", pcenStart)
+        .attr("y2", chrMargin + chrWidth)
+        .style("stroke", pArmColor)
+
+    d3.selectAll("#" + chrID + " .band")
       .data(chr.bands)
       .style("fill", function(d, i) {
         if (i <= chr.pcenIndex) {
@@ -296,20 +317,7 @@ Ideogram.prototype.colorArms = function(pArmColor, qArmColor) {
   });
   d3.selectAll(".p-ter.chromosomeBorder").style("fill", pArmColor);
   d3.selectAll(".q-ter.chromosomeBorder").style("fill", qArmColor);
-  d3.selectAll(".acen")[0].forEach(function(d){
-  console.log(d);
-  var chrID = d.id.split("-").slice(0,2).join("-");
-  console.log(chrID)
-  var r = d.getBoundingClientRect();
-  console.log(r);
-  d3.select("#" + chrID)
-    .append("line")
-      .attr("x1", r.top)
-      .attr("y1", r.left + r.width)
-      .attr("x2", r.top)
-      .attr("y2", r.left)
-      .style("stroke", "#0F0")
-  });
+
 };
 
 /**


### PR DESCRIPTION
This enables coloring cytogenetic arms -- the p-arm and q-arm.  Arms can be colored in multiple ways:

* As a parameter upon ideogram construction, e.g. `armColors: ["#D00", "#CCC"]`
* Using a method on an existing ideogram, e.g. `colorArms("#D00", "#CCC")`

This resolves #48.