### PR TITLE
Upgrade to version 4 of D3.js

### DIFF
--- a/cli/batch-render.js
+++ b/cli/batch-render.js
@@ -76,7 +76,7 @@ function getIndexHtml() {
   var html, css, d3, js, bands, path;
 
   css = dir + '/src/css/ideogram.css';
-  d3 = dir + '/node_modules/d3/d3.min.js';
+  d3 = dir + '/node_modules/d3/build/d3.min.js';
   js = dir + '/src/js/ideogram.js';
   bands = dir + '/data/bands/native/ideogram_9606_GCF_000001305.14_850_V1.js';
 
@@ -227,12 +227,12 @@ ideogramDrawer = function(config) {
     d3.selectAll(".annot").remove();
     ra = rearrangedAnnots[i];
     ideogram.drawProcessedAnnots(ra[1]);
-    svg = d3.select(ideogram.config.container)[0][0].innerHTML;
+    svg = d3.select(ideogram.config.container).nodes()[0].innerHTML;
     images.push([ra[0], svg, ra[2]]);
   }
 
   chrRects = {};
-  chrs = d3.selectAll(".chromosome")[0];
+  chrs = d3.selectAll(".chromosome").nodes()[0];
   for (i = 0; i < chrs.length; i++) {
     chr = chrs[i];
     chrID = chr["id"].split("-")[0].slice(3); // e.g. chr12-9606 -> 12

--- a/examples/ancestry.html
+++ b/examples/ancestry.html
@@ -4,7 +4,7 @@
   <title>Ancestry | Ideogram</title>
   <link type="text/css" rel="stylesheet" href="../src/css/ideogram.css"/>
   <script type="text/javascript" src="../src/js/d3.min.js"></script>
-  <script type="text/javascript" src="../src/js/ideogram.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.1.1/d3.min.js"></script>
   <script type="text/javascript" src="../src/js/crossfilter.min.js"></script>
   <script type="text/javascript" src="../src/js/ideogram.filter.js"></script>
   <style>

--- a/examples/ancestry_tracks.html
+++ b/examples/ancestry_tracks.html
@@ -3,7 +3,7 @@
 <head>
   <title>Annotations, tracks | Ideogram</title>
   <link type="text/css" rel="stylesheet" href="../src/css/ideogram.css"/>
-  <script type="text/javascript" src="../src/js/d3.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.1.1/d3.min.js"></script>
   <script type="text/javascript" src="../src/js/ideogram.js"></script>
 </head>
 <body>

--- a/examples/annotations_basic.html
+++ b/examples/annotations_basic.html
@@ -3,7 +3,7 @@
 <head>
   <title>Annotations, basic | Ideogram</title>
   <link type="text/css" rel="stylesheet" href="../src/css/ideogram.css"/>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.1.1/d3.min.js"></script>
   <script type="text/javascript" src="../src/js/ideogram.js"></script>
   <style>
     html, body {

--- a/examples/annotations_colored_arms.html
+++ b/examples/annotations_colored_arms.html
@@ -3,7 +3,7 @@
 <head>
   <title>Annotations, colored arms | Ideogram</title>
   <link type="text/css" rel="stylesheet" href="../src/css/ideogram.css"/>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.1.1/d3.min.js"></script>
   <script type="text/javascript" src="../src/js/ideogram.js"></script>
   <script type="text/javascript" src="../data/bands/native/ideogram_9606_GCF_000001305.14_850_V1.js"></script>
 </head>

--- a/examples/annotations_external_data.html
+++ b/examples/annotations_external_data.html
@@ -3,7 +3,7 @@
 <head>
   <title>Annotations, external data | Ideogram</title>
   <link type="text/css" rel="stylesheet" href="../src/css/ideogram.css"/>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.1.1/d3.min.js"></script>
   <script type="text/javascript" src="../src/js/ideogram.js"></script>
 </head>
 <body>

--- a/examples/annotations_histogram.html
+++ b/examples/annotations_histogram.html
@@ -3,7 +3,7 @@
 <head>
   <title>Annotations, histogram | Ideogram</title>
   <link type="text/css" rel="stylesheet" href="../src/css/ideogram.css"/>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.1.1/d3.min.js"></script>
   <script type="text/javascript" src="../src/js/ideogram.js"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/crossfilter/1.3.12/crossfilter.min.js"></script>
   <script type="text/javascript" src="../src/js/ideogram.filter.js"></script>

--- a/examples/annotations_overlaid.html
+++ b/examples/annotations_overlaid.html
@@ -3,7 +3,7 @@
 <head>
   <title>Annotations, overlays | Ideogram</title>
   <link type="text/css" rel="stylesheet" href="../src/css/ideogram.css"/>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.1.1/d3.min.js"></script>
   <script type="text/javascript" src="../src/js/ideogram.js"></script>
 </head>
 <body>

--- a/examples/annotations_tracks.html
+++ b/examples/annotations_tracks.html
@@ -3,7 +3,7 @@
 <head>
   <title>Annotations, tracks | Ideogram</title>
   <link type="text/css" rel="stylesheet" href="../src/css/ideogram.css"/>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.1.1/d3.min.js"></script>
   <script type="text/javascript" src="../src/js/ideogram.js"></script>
 </head>
 <body>

--- a/examples/brush.html
+++ b/examples/brush.html
@@ -3,7 +3,7 @@
 <head>
   <title>Brush | Ideogram</title>
   <link type="text/css" rel="stylesheet" href="../src/css/ideogram.css"/>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.1.1/d3.min.js"></script>
   <script type="text/javascript" src="../src/js/ideogram.js"></script>
 </head>
 <body>

--- a/examples/fly.html
+++ b/examples/fly.html
@@ -3,7 +3,7 @@
 <head>
   <title>Fly | Ideogram</title>
   <link type="text/css" rel="stylesheet" href="../src/css/ideogram.css"/>
-  <script type="text/javascript" src="../src/js/d3.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.1.1/d3.min.js"></script>
   <script type="text/javascript" src="../src/js/ideogram.js"></script>
 
 </head>

--- a/examples/homology_advanced.html
+++ b/examples/homology_advanced.html
@@ -3,7 +3,7 @@
 <head>
   <title>Homology, advanced | Ideogram</title>
   <link type="text/css" rel="stylesheet" href="../src/css/ideogram.css"/>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.1.1/d3.min.js"></script>
   <script type="text/javascript" src="../src/js/ideogram.js"></script>
 </head>
 <body>

--- a/examples/homology_basic.html
+++ b/examples/homology_basic.html
@@ -3,7 +3,7 @@
 <head>
   <title>Homology, basic | Ideogram</title>
   <link type="text/css" rel="stylesheet" href="../src/css/ideogram.css"/>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.1.1/d3.min.js"></script>
   <script type="text/javascript" src="../src/js/ideogram.js"></script>
 </head>
 <body>

--- a/examples/homology_interspecies.html
+++ b/examples/homology_interspecies.html
@@ -3,7 +3,7 @@
 <head>
   <title>Homology, interspecies | Ideogram</title>
   <link type="text/css" rel="stylesheet" href="../src/css/ideogram.css"/>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.1.1/d3.min.js"></script>
   <script type="text/javascript" src="../src/js/ideogram.js"></script>
 </head>
 <body>

--- a/examples/human.html
+++ b/examples/human.html
@@ -3,7 +3,7 @@
 <head>
   <title>Human | Ideogram</title>
   <link type="text/css" rel="stylesheet" href="../src/css/ideogram.css"/>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.1.1/d3.min.js"></script>
   <script type="text/javascript" src="../src/js/ideogram.js"></script>
 </head>
 <body>

--- a/examples/layout_small.html
+++ b/examples/layout_small.html
@@ -3,7 +3,7 @@
 <head>
   <title>Layout, small | Ideogram</title>
   <link type="text/css" rel="stylesheet" href="../src/css/ideogram.css"/>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.1.1/d3.min.js"></script>
   <script type="text/javascript" src="../src/js/ideogram.js"></script>
   <style>
 

--- a/examples/mouse.html
+++ b/examples/mouse.html
@@ -3,7 +3,7 @@
 <head>
   <title>Mouse | Ideogram</title>
   <link type="text/css" rel="stylesheet" href="../src/css/ideogram.css"/>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.1.1/d3.min.js"></script>
   <script type="text/javascript" src="../src/js/ideogram.js"></script>
 </head>
 <body>

--- a/examples/worm.html
+++ b/examples/worm.html
@@ -3,7 +3,7 @@
 <head>
   <title>Worm | Ideogram</title>
   <link type="text/css" rel="stylesheet" href="../src/css/ideogram.css"/>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.1.1/d3.min.js"></script>
   <script type="text/javascript" src="../src/js/ideogram.js"></script>
 </head>
 <body>

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/eweitz/ideogram#readme",
   "dependencies": {
-    "d3": "^3.5.6",
+    "d3": "4.1.1",
     "crossfilter": "^1.3.12",
     "async": "*",
     "commander": "*",

--- a/src/css/ideogram.css
+++ b/src/css/ideogram.css
@@ -61,7 +61,7 @@ text {
 	stroke-width:1;
 }
 
-.brush .extent {
+.brush .selection {
 	fill: #F00;
 	stroke: #F00;
   fill-opacity: .3;

--- a/src/js/ideogram.js
+++ b/src/js/ideogram.js
@@ -1235,7 +1235,7 @@ Ideogram.prototype.rotateAndToggleDisplay = function(chromosomeID) {
       .attr("data-orientation", "vertical")
       .transition()
       .attr("transform", verticalTransform)
-      .each("end", function() {
+      .on("end", function() {
 
         if (initOrientation == "vertical") {
           scale = "";
@@ -1267,7 +1267,7 @@ Ideogram.prototype.rotateAndToggleDisplay = function(chromosomeID) {
     chr
       .transition()
       .attr("transform", horizontalTransform)
-      .each("end", function() {
+      .on("end", function() {
 
         if (initOrientation == "horizontal") {
           if (currentOrientation == "vertical") {

--- a/src/js/ideogram.js
+++ b/src/js/ideogram.js
@@ -1152,13 +1152,13 @@ Ideogram.prototype.rotateAndToggleDisplay = function(chromosomeID) {
   chrMargin = this.config.chrMargin * chrIndex;
   chrWidth = this.config.chrWidth;
 
-  ideoBox = d3.select("#ideogram")[0][0].getBoundingClientRect();
+  ideoBox = d3.select("#ideogram").nodes()[0].getBoundingClientRect();
   ideoHeight = ideoBox.height;
   ideoWidth = ideoBox.width;
 
   if (initOrientation == "vertical") {
 
-    chrLength = chr[0][0].getBoundingClientRect().height;
+    chrLength = chr.nodes()[0].getBoundingClientRect().height;
 
     scaleX = (ideoWidth/chrLength)*0.97;
     scaleY = 1.5;
@@ -1189,7 +1189,7 @@ Ideogram.prototype.rotateAndToggleDisplay = function(chromosomeID) {
 
   } else {
 
-    chrLength = chr[0][0].getBoundingClientRect().width;
+    chrLength = chr.nodes()[0].getBoundingClientRect().width;
 
     scaleX = (ideoHeight/chrLength)*0.97;
     scaleY = 1.5;
@@ -1877,7 +1877,7 @@ Ideogram.prototype.putChromosomesInRows = function() {
     chrsPerRow = Math.floor(ideo.numChromosomes/rows);
 
     riCorrection = 0;
-    if (d3.select("svg > *")[0][0].tagName !== "g") {
+    if (d3.select("svg > *").nodes()[0].tagName !== "g") {
       // Accounts for cross-browser differences in handling of nth-child
       riCorrection = 2;
     }
@@ -1942,7 +1942,7 @@ Ideogram.prototype.createBrush = function(from, to) {
   }
 
   x = d3.scale.linear().domain(domain).range(range);
-  y = d3.select(".band")[0][0].getBBox().y - 3.25;
+  y = d3.select(".band").nodes()[0].getBBox().y - 3.25;
 
   if (typeof from === "undefined") {
     from = Math.floor(chrLengthBp/10);

--- a/src/js/ideogram.js
+++ b/src/js/ideogram.js
@@ -1941,7 +1941,7 @@ Ideogram.prototype.createBrush = function(from, to) {
     range.push(band.px.stop);
   }
 
-  x = d3.scale.linear().domain(domain).range(range);
+  x = d3.scaleLinear().domain(domain).range(range);
   y = d3.select(".band").nodes()[0].getBBox().y - 3.25;
 
   if (typeof from === "undefined") {
@@ -1952,28 +1952,27 @@ Ideogram.prototype.createBrush = function(from, to) {
     to = Math.ceil(from*2);
   }
 
-  x0 = from;
-  x1 = to;
+  x0 = ideo.convertBpToPx(chr, from);
+  x1 = ideo.convertBpToPx(chr, to);
 
   ideo.selectedRegion = {"from": from, "to": to, "extent": (to - from)};
 
-  ideo.brush = d3.svg.brush()
-    .x(x)
-    .extent([x0, x1])
+  ideo.brush = d3.brushX()
+    .extent([[0, 0], [length, width]])
     .on("brush", onBrushMove);
 
   var brushg = d3.select("#ideogram").append("g")
     .attr("class", "brush")
     .attr("transform", "translate(0, " + y + ")")
-    .call(ideo.brush);
-
-  brushg.selectAll("rect")
-      .attr("height", width);
+    .call(ideo.brush)
+    .call(ideo.brush.move, [x0, x1]);
 
   function onBrushMove() {
-    var extent = ideo.brush.extent(),
+
+    var extent = d3.event.selection.map(x.invert),
         from = Math.floor(extent[0]),
         to = Math.ceil(extent[1]);
+
     ideo.selectedRegion = {"from": from, "to": to, "extent": (to - from)};
 
     if (ideo.onBrushMove) {

--- a/src/js/ideogram.js
+++ b/src/js/ideogram.js
@@ -2070,14 +2070,15 @@ Ideogram.prototype.getBandColorGradients = function() {
   return gradients;
 };
 
+
 /*
   Returns an NCBI taxonomy identifier (taxid) for the given organism name
 
   Example:
-  * Input:
-  ideo.getTaxidFromEutils("Caenorhabditis elegans")
-  * Output:
-  "6239"
+    Input:
+      ideo.getTaxidFromEutils("Caenorhabditis elegans")
+    Output:
+      "6239"
 */
 Ideogram.prototype.getTaxidFromEutils = function(organism) {
 
@@ -2364,7 +2365,7 @@ Ideogram.prototype.init = function() {
 
     if (typeof chrBands === "undefined") {
 
-      d3.xhr(ideo.config.bandDir + bandDataFileNames[taxid])
+      d3.request(ideo.config.bandDir + bandDataFileNames[taxid])
         .on("beforesend", function(data) {
           // Ensures correct taxid is processed in response callback; using
           // simply 'taxid' variable gives the last *requested* taxid, which

--- a/test/cli-runner.html
+++ b/test/cli-runner.html
@@ -7,7 +7,7 @@
         <div id="mocha"></div>
         <script src="../node_modules/mocha/mocha.js"></script>
         <script src="../node_modules/chai/chai.js"></script>
-        <script src="../node_modules/d3/d3.min.js"></script>
+        <script src="../node_modules/d3/buid/d3.js"></script>
         <script src="../src/js/ideogram.js"></script>
         <script>
             mocha.ui('bdd');

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -6,7 +6,7 @@ describe("Ideogram CLI", function() {
 
   it("should run the built-in example", function(done) {
 
-    this.timeout(10000);
+    this.timeout(30000);
     var numImages = 100;
 
     var cmd =
@@ -20,6 +20,9 @@ describe("Ideogram CLI", function() {
       '--show-chromosome-labels true ' +
       '--orientation horizontal ' +
       '--local-annotations-path data/annotations/' + numImages + '_virtual_snvs.json';
+
+    console.log("Ideogram CLI test command:")
+    console.log(cmd)
 
     exec(cmd, function(error, stdout, stderr) {
       var images = fs.readdirSync('images');

--- a/test/web-runner.html
+++ b/test/web-runner.html
@@ -8,7 +8,7 @@
         <div id="mocha"></div>
         <script src="../node_modules/mocha/mocha.js"></script>
         <script src="../node_modules/chai/chai.js"></script>
-        <script src="../node_modules/d3/d3.min.js"></script>
+        <script src="../node_modules/d3/build/d3.js"></script>
         <script src="../src/js/ideogram.js"></script>
         <script>
             mocha.ui('bdd');
@@ -23,4 +23,3 @@
         </script>
     </body>
 </html>
-

--- a/test/web-test.js
+++ b/test/web-test.js
@@ -453,7 +453,7 @@ describe("Ideogram", function() {
       // edge of the p or q arm of chromosome 1
 
       var ter = d3.select("." + arm + "-ter"),
-          terBox = ter[0][0].getBBox(),
+          terBox = ter.nodes()[0].getBBox(),
           terX = terBox.x,
           terWidth = terBox.width,
           terEnd,
@@ -477,10 +477,10 @@ describe("Ideogram", function() {
     function onIdeogramLoadAnnots() {
 
       var pterEnd = getTerEnd("p"),
-          firstAnnotEnd = d3.selectAll("#chr1-9606 .annot")[0][0].getBBox().x,
+          firstAnnotEnd = d3.selectAll("#chr1-9606 .annot").nodes()[0].getBBox().x,
           qterEnd = getTerEnd("q"),
-          tmp = d3.selectAll("#chr1-9606 .annot"),
-          tmp = tmp[0][tmp[0].length - 1].getBBox(),
+          tmp = d3.selectAll("#chr1-9606 .annot").nodes(),
+          tmp = tmp[tmp.length - 1].getBBox(),
           lastAnnotEnd = tmp.x + tmp.width;
 
           console.log("pterEnd - firstAnnotEnd: " + (pterEnd - firstAnnotEnd));
@@ -559,7 +559,7 @@ describe("Ideogram", function() {
       // Tests use case from ../examples/human.html
 
       function callback() {
-        var numAnnots = d3.selectAll(".annot")[0].length;
+        var numAnnots = d3.selectAll(".annot").nodes().length;
         assert.equal(numAnnots, 1);
         done();
       }
@@ -576,14 +576,14 @@ describe("Ideogram", function() {
 
 
     it("should align chr. label with thick horizontal chromosome", function(done) {
-      // Tests use case from ../examples/human.html
+      // Tests use case from ../examples/annotations_basic.html
 
       function callback() {
         var band, bandMiddle,
             chrLabel, chrLabelMiddle;
 
-        band = d3.selectAll(".chromosome .band")[0][0].getBoundingClientRect();
-        chrLabel = d3.selectAll(".chromosome .chrLabel")[0][0].getBoundingClientRect();
+        band = d3.selectAll(".chromosome .band").nodes()[0].getBoundingClientRect();
+        chrLabel = d3.selectAll(".chromosome .chrLabel").nodes()[0].getBoundingClientRect();
 
         bandMiddle = band.top + band.height/2;
         chrLabelMiddle = chrLabel.top + chrLabel.height/2;
@@ -619,8 +619,8 @@ describe("Ideogram", function() {
         var band, bandMiddle,
             chrLabel, chrLabelMiddle;
 
-        band = d3.selectAll(".chromosome .band")[0][0].getBoundingClientRect();
-        chrLabel = d3.selectAll(".chromosome .chrLabel")[0][0].getBoundingClientRect();
+        band = d3.selectAll(".chromosome .band").nodes()[0].getBoundingClientRect();
+        chrLabel = d3.selectAll(".chromosome .chrLabel").nodes()[0].getBoundingClientRect();
 
         bandMiddle = band.left + band.width/2;
         chrLabelMiddle = chrLabel.left + chrLabel.width/2;
@@ -661,8 +661,8 @@ describe("Ideogram", function() {
         var band, bandMiddle,
             chrLabel, chrLabelMiddle;
 
-        band = d3.select(".chromosome .band")[0][0].getBoundingClientRect();
-        chrLabel = d3.select(".chromosome .chrLabel")[0][0].getBoundingClientRect();
+        band = d3.select(".chromosome .band").nodes()[0].getBoundingClientRect();
+        chrLabel = d3.select(".chromosome .chrLabel").nodes()[0].getBoundingClientRect();
 
         bandMiddle = band.left + band.width/2;
         chrLabelMiddle = chrLabel.left + chrLabel.width/2;


### PR DESCRIPTION
This upgrades Ideogram to [D3.js version 4](https://github.com/d3/d3/blob/master/CHANGES.md).  Ideogram depends on D3 for DOM data binding, HTTP requests, animations and essentially all DOM interaction.   

The new [queue](https://github.com/d3/d3-queue#d3-queue) module in D3 v4 is the primary motivation for this upgrade.  D3 queues should simplify handling of deferred asynchronous tasks, and avoid complicated nests of callbacks.   This pull request is part of the ongoing refinement of code (#51) needed to retrieve chromosome data for eukaryotes (#45).