### PR TITLE
Improve maintainability by using smaller methods

### DIFF
--- a/src/js/annotations/annotations.js
+++ b/src/js/annotations/annotations.js
@@ -126,7 +126,6 @@ function validateAnnotsUrl(annotsUrl) {
   return extension;
 }
 
-
 function afterRawAnnots(ideo) {
   // Ensure annots are ordered by chromosome
   ideo.rawAnnots.annots = ideo.rawAnnots.annots.sort(function(a, b) {

--- a/src/js/annotations/annotations.js
+++ b/src/js/annotations/annotations.js
@@ -28,6 +28,63 @@ import {processAnnotData} from './process'
 
 var d3 = Object.assign({}, d3selection, d3fetch);
 
+function initNumTracksHeightAndBarWidth(ideo, config) {
+  var annotHeight;
+
+  if (!config.annotationHeight) {
+    annotHeight = Math.round(config.chrHeight / 100);
+    ideo.config.annotationHeight = annotHeight;
+  }
+
+  if (config.annotationTracks) {
+    ideo.config.numAnnotTracks = config.annotationTracks.length;
+  } else if (config.annotationsNumTracks) {
+    ideo.config.numAnnotTracks = config.annotationsNumTracks;
+  } else {
+    ideo.config.numAnnotTracks = 1;
+  }
+  ideo.config.annotTracksHeight =
+    config.annotationHeight * config.numAnnotTracks;
+
+  if (typeof config.barWidth === 'undefined') {
+    ideo.config.barWidth = 3;
+  }
+}
+
+function initHeatmap(ideo) {
+  if (ideo.config.annotationsLayout === 'heatmap') {
+    // window.onresize = function() { ideo.drawHeatmaps(ideo.annots); };
+
+    // ideo.isScrolling = null;
+
+    // Listen for scroll events
+    // window.addEventListener('scroll', function ( event ) {
+    //   // Clear our timeout throughout the scroll
+    //   window.clearTimeout( ideo.isScrolling );
+    //
+    //   // Set a timeout to run after scrolling ends
+    //   ideo.isScrolling = setTimeout(function() {
+    //     // Run the callback
+    //     console.log('Scrolling has stopped.');
+    //     ideo.drawHeatmaps(ideo.annots);
+    //   }, 300);
+    //
+    // // }, false);
+    //
+    // window.onscroll = function() { ideo.drawHeatmaps(ideo.annots); };
+  }
+}
+
+function initTooltip(ideo, config) {
+  if (config.showAnnotTooltip !== false) {
+    ideo.config.showAnnotTooltip = true;
+  }
+
+  if (config.onWillShowAnnotTooltip) {
+    ideo.onWillShowAnnotTooltipCallback = config.onWillShowAnnotTooltip;
+  }
+}
+
 /**
  * Initializes various annotation settings.  Constructor help function.
  */
@@ -39,106 +96,21 @@ function initAnnotSettings() {
     config.annotationsPath || config.localAnnotationsPath ||
     ideo.annots || config.annotations
   ) {
-    if (!config.annotationHeight) {
-      var annotHeight = Math.round(config.chrHeight / 100);
-      this.config.annotationHeight = annotHeight;
-    }
-
-    if (config.annotationTracks) {
-      this.config.numAnnotTracks = config.annotationTracks.length;
-    } else if (config.annotationsNumTracks) {
-      this.config.numAnnotTracks = config.annotationsNumTracks;
-    } else {
-      this.config.numAnnotTracks = 1;
-    }
-    this.config.annotTracksHeight =
-      config.annotationHeight * config.numAnnotTracks;
-
-    if (typeof config.barWidth === 'undefined') {
-      this.config.barWidth = 3;
-    }
+    initNumTracksHeightAndBarWidth(ideo, config);
   } else {
-    this.config.annotTracksHeight = 0;
+    ideo.config.annotTracksHeight = 0;
   }
 
   if (typeof config.annotationsColor === 'undefined') {
-    this.config.annotationsColor = '#F00';
+    ideo.config.annotationsColor = '#F00';
   }
 
-  if (config.showAnnotTooltip !== false) {
-    this.config.showAnnotTooltip = true;
-  }
-
-  if (config.onWillShowAnnotTooltip) {
-    this.onWillShowAnnotTooltipCallback = config.onWillShowAnnotTooltip;
-  }
-
-  if (config.annotationsLayout === 'heatmap') {
-    // window.onresize = function() {
-    //   ideo.drawHeatmaps(ideo.annots);
-    // };
-
-    // ideo.isScrolling = null;
-
-    // Listen for scroll events
-    // window.addEventListener('scroll', function ( event ) {
-    //
-    //   // Clear our timeout throughout the scroll
-    //   window.clearTimeout( ideo.isScrolling );
-    //
-    //   // Set a timeout to run after scrolling ends
-    //   ideo.isScrolling = setTimeout(function() {
-    //
-    //     // Run the callback
-    //     console.log('Scrolling has stopped.');
-    //     ideo.drawHeatmaps(ideo.annots);
-    //
-    //   }, 300);
-    //
-    // // }, false);
-    //
-    // window.onscroll = function() {
-    //   ideo.drawHeatmaps(ideo.annots);
-    //   // console.log('onscroll')
-    // };
-  }
-
+  initHeatmap(ideo);
+  initTooltip(ideo, config);
 }
 
-/**
- * Requests annotations URL via HTTP, sets ideo.rawAnnots for downstream
- * processing.
- *
- * @param annotsUrl Absolute or relative URL native or BED annotations file
- */
-function fetchAnnots(annotsUrl) {
-
-  var tmp, extension,
-    ideo = this;
-
-  function afterRawAnnots(rawAnnots) {
-
-    // Ensure annots are ordered by chromosome
-    ideo.rawAnnots.annots = rawAnnots.annots.sort(function(a, b) {
-      return Ideogram.naturalSort(a.chr, b.chr);
-    });
-
-    if (ideo.config.heatmaps) {
-      ideo.deserializeAnnotsForHeatmap(rawAnnots);
-    }
-    if (ideo.onLoadAnnotsCallback) {
-      ideo.onLoadAnnotsCallback();
-    }
-  }
-
-  if (annotsUrl.slice(0, 4) !== 'http') {
-    d3.json(ideo.config.annotationsPath)
-      .then(function(data) {
-        ideo.rawAnnots = data;
-        afterRawAnnots(ideo.rawAnnots);
-      });
-    return;
-  }
+function validateAnnotsUrl(annotsUrl) {
+  var tmp, extension;
 
   tmp = annotsUrl.split('?')[0].split('.');
   extension = tmp[tmp.length - 1];
@@ -151,6 +123,44 @@ function fetchAnnots(annotsUrl) {
     );
     return;
   }
+  return extension;
+}
+
+
+function afterRawAnnots(ideo) {
+  // Ensure annots are ordered by chromosome
+  ideo.rawAnnots.annots = ideo.rawAnnots.annots.sort(function(a, b) {
+    return Ideogram.naturalSort(a.chr, b.chr);
+  });
+
+  if (ideo.config.heatmaps) {
+    ideo.deserializeAnnotsForHeatmap(ideo.rawAnnots);
+  }
+  if (ideo.onLoadAnnotsCallback) {
+    ideo.onLoadAnnotsCallback();
+  }
+}
+
+/**
+ * Requests annotations URL via HTTP, sets ideo.rawAnnots for downstream
+ * processing.
+ *
+ * @param annotsUrl Absolute or relative URL native or BED annotations file
+ */
+function fetchAnnots(annotsUrl) {
+  var extension,
+    ideo = this;
+
+  if (annotsUrl.slice(0, 4) !== 'http') {
+    d3.json(ideo.config.annotationsPath)
+      .then(function(data) {
+        ideo.rawAnnots = data;
+        afterRawAnnots(ideo);
+      });
+    return;
+  }
+
+  extension = validateAnnotsUrl(annotsUrl);
 
   d3.text(annotsUrl).then(function(text) {
     if (extension === 'bed') {
@@ -158,9 +168,8 @@ function fetchAnnots(annotsUrl) {
     } else {
       ideo.rawAnnots = JSON.parse(text);
     }
-    afterRawAnnots(ideo.rawAnnots);
+    afterRawAnnots(ideo);
   });
-
 }
 
 /**

--- a/src/js/annotations/draw.js
+++ b/src/js/annotations/draw.js
@@ -1,12 +1,48 @@
 import * as d3selection from 'd3-selection';
+import {writeHistogramAnnots} from './histogram';
 
 var d3 = Object.assign({}, d3selection);
+
+function parseFriendlyAnnots(friendlyAnnots, rawAnnots) {
+  var i, j, annot, rawAnnot;
+
+  for (i = 0; i < friendlyAnnots.length; i++) {
+    annot = friendlyAnnots[i];
+
+    for (j = 0; j < rawAnnots.length; j++) {
+      if (annot.chr === rawAnnots[j].chr) {
+        rawAnnot = [
+          annot.name,
+          annot.start,
+          annot.stop - annot.start
+        ];
+        if ('color' in annot) rawAnnot.push(annot.color);
+        if ('shape' in annot) rawAnnot.push(annot.shape);
+        rawAnnots[j].annots.push(rawAnnot);
+        break;
+      }
+    }
+  }
+
+  return rawAnnots;
+}
+
+function parseFriendlyKeys(friendlyAnnots) {
+  var keys = ['name', 'start', 'length'];
+  if ('color' in friendlyAnnots[0]) {
+    keys.push('color');
+  }
+  if ('shape' in friendlyAnnots[0]) {
+    keys.push('shape');
+  }
+  return keys;
+}
 
 /**
  * Draws annotations defined by user
  */
 function drawAnnots(friendlyAnnots) {
-  var i, j, annot, rawAnnot, keys, chr,
+  var keys, chr,
     rawAnnots = [],
     ideo = this,
     chrs = ideo.chromosomes[ideo.config.taxid]; // TODO: multiorganism
@@ -19,99 +55,21 @@ function drawAnnots(friendlyAnnots) {
   for (chr in chrs) {
     rawAnnots.push({chr: chr, annots: []});
   }
+  rawAnnots = parseFriendlyAnnots(friendlyAnnots, rawAnnots)
 
-  for (i = 0; i < friendlyAnnots.length; i++) {
-    annot = friendlyAnnots[i];
+  keys = parseFriendlyKeys(friendlyAnnots);
 
-    for (j = 0; j < rawAnnots.length; j++) {
-      if (annot.chr === rawAnnots[j].chr) {
-        rawAnnot = [
-          annot.name,
-          annot.start,
-          annot.stop - annot.start
-        ];
-        if ('color' in annot) {
-          rawAnnot.push(annot.color);
-        }
-        if ('shape' in annot) {
-          rawAnnot.push(annot.shape);
-        }
-        rawAnnots[j].annots.push(rawAnnot);
-        break;
-      }
-    }
-  }
-
-  keys = ['name', 'start', 'length'];
-  if ('color' in friendlyAnnots[0]) {
-    keys.push('color');
-  }
-  if ('shape' in friendlyAnnots[0]) {
-    keys.push('shape');
-  }
   ideo.rawAnnots = {keys: keys, annots: rawAnnots};
-
   ideo.annots = ideo.processAnnotData(ideo.rawAnnots);
 
   ideo.drawProcessedAnnots(ideo.annots);
 }
 
-/**
- * Draws genome annotations on chromosomes.
- * Annotations can be rendered as either overlaid directly
- * on a chromosome, or along one or more "tracks"
- * running parallel to each chromosome.
- */
-function drawProcessedAnnots(annots) {
-  var chrWidth, chrWidths, layout, annotHeight, triangle, circle, rectangle,
-    chr, chrs, r, chrAnnot, i, numAnnots, x1, x2, y1, y2, filledAnnots,
-    ideo = this;
-
-  d3.selectAll(ideo.selector + ' .annot').remove();
-
-  chrWidth = this.config.chrWidth;
-
-  chrWidths = {};
-  chrs = ideo.chromosomes[ideo.config.taxid];
-  for (chr in chrs) {
-    chrWidths[chr] = chrs[chr].width;
-  }
-
-  layout = 'tracks';
-  if (this.config.annotationsLayout) {
-    layout = this.config.annotationsLayout;
-  }
-
-  if (layout === 'histogram') {
-    annots = ideo.getHistogramBars(annots);
-  }
-
-  if (layout === 'heatmap') {
-    ideo.drawHeatmaps(annots);
-    return;
-  }
-
-  if (
-    layout !== 'heatmap' && layout !== 'histogram'
-  ) {
-    numAnnots = 0;
-    for (i = 0; i < annots.length; i++) {
-      numAnnots += annots[i].annots.length;
-    }
-    if (numAnnots > 2000) {
-      console.warn(
-        'Rendering more than 2000 annotations in Ideogram?\n' +
-        'Try setting "annotationsLayout" to "heatmap" or "histogram" in your ' +
-        'Ideogram configuration object for better layout and performance.'
-      );
-    }
-  }
-
-  annotHeight = ideo.config.annotationHeight;
+function getShapes(annotHeight) {
+  var triangle, circle, rectangle, r;
 
   triangle =
-    'm0,0 l -' + annotHeight + ' ' +
-    (2 * annotHeight) +
+    'm0,0 l -' + annotHeight + ' ' + (2 * annotHeight) +
     ' l ' + (2 * annotHeight) + ' 0 z';
 
   // From http://stackoverflow.com/a/10477334, with a minor change ("m -r, r")
@@ -129,107 +87,140 @@ function drawProcessedAnnots(annots) {
     'l ' + annotHeight + ' 0' +
     'l 0 -' + (2 * annotHeight) + 'z';
 
-  filledAnnots = ideo.fillAnnots(annots);
+  return {triangle: triangle, circle: circle, rectangle: rectangle};
+}
 
-  chrAnnot = d3.selectAll(ideo.selector + ' .chromosome')
+function getChrAnnotNodes(filledAnnots, ideo) {
+  return d3.selectAll(ideo.selector + ' .chromosome')
     .data(filledAnnots)
     .selectAll('path.annot')
     .data(function(d) {
       return d.annots;
     })
     .enter();
+}
+
+function determineShape(d, shapes) {
+  if (!d.shape || d.shape === 'triangle') {
+    return shapes.triangle;
+  } else if (d.shape === 'circle') {
+    return shapes.circle;
+  } else if (d.shape === 'rectangle') {
+    return shapes.rectangle;
+  } else {
+    return d.shape;
+  }
+}
+
+function writeTrackAnnots(chrAnnot, ideo) {
+  var shapes,
+    annotHeight = ideo.config.annotationHeight;
+
+  shapes = getShapes(annotHeight);
+
+  chrAnnot.append('g')
+    .attr('id', function(d) { return d.id; })
+    .attr('class', 'annot')
+    .attr('transform', function(d) {
+      var y = ideo.config.chrWidth + (d.trackIndex * annotHeight * 2);
+      return 'translate(' + d.px + ',' + y + ')';
+    })
+    .append('path')
+    .attr('d', function(d) { return determineShape(d, shapes); })
+    .attr('fill', function(d) { return d.color; })
+    .on('mouseover', function(d) { ideo.showAnnotTooltip(d, this); })
+    .on('mouseout', function() { ideo.startHideAnnotTooltipTimeout(); });
+}
+
+/**
+ * Overlaid annotations appear directly on chromosomes
+ */
+function writeOverlayAnnots(chrAnnot, ideo) {
+  chrAnnot.append('polygon')
+    .attr('id', function(d) { return d.id; })
+    .attr('class', 'annot')
+    .attr('points', function(d) {
+      var x1, x2,
+        chrWidth = ideo.config.chrWidth;
+
+      if (d.stopPx - d.startPx > 1) {
+        x1 = d.startPx;
+        x2 = d.stopPx;
+      } else {
+        x1 = d.px - 0.5;
+        x2 = d.px + 0.5;
+      }
+
+      return (
+        x1 + ',' + chrWidth + ' ' + x2 + ',' + chrWidth + ' ' +
+        x2 + ',0 ' + x1 + ',0'
+      );
+    })
+    .attr('fill', function(d) { return d.color; })
+    .on('mouseover', function(d) { ideo.showAnnotTooltip(d, this); })
+    .on('mouseout', function() { ideo.startHideAnnotTooltipTimeout(); });
+}
+
+function warnIfTooManyAnnots(layout, annots) {
+  var i, numAnnots;
+
+  if (layout !== 'heatmap' && layout !== 'histogram') {
+    numAnnots = 0;
+    for (i = 0; i < annots.length; i++) {
+      numAnnots += annots[i].annots.length;
+    }
+    if (numAnnots > 2000) {
+      console.warn(
+        'Rendering more than 2000 annotations in Ideogram?\n' +
+        'Try setting "annotationsLayout" to "heatmap" or "histogram" in your ' +
+        'Ideogram configuration object for better layout and performance.'
+      );
+    }
+  }
+}
+
+function drawAnnotsByLayoutType(layout, annots, ideo) {
+  var filledAnnots, chrAnnot;
+
+  warnIfTooManyAnnots(layout, annots);
+
+  if (layout === 'histogram') annots = ideo.getHistogramBars(annots);
+
+  filledAnnots = ideo.fillAnnots(annots);
+
+  chrAnnot = getChrAnnotNodes(filledAnnots, ideo);
 
   if (layout === 'tracks') {
-    chrAnnot
-      .append('g')
-      .attr('id', function(d) {
-        return d.id;
-      })
-      .attr('class', 'annot')
-      .attr('transform', function(d) {
-        var y = ideo.config.chrWidth + (d.trackIndex * annotHeight * 2);
-        return 'translate(' + d.px + ',' + y + ')';
-      })
-      .append('path')
-      .attr('d', function(d) {
-        if (!d.shape || d.shape === 'triangle') {
-          return triangle;
-        } else if (d.shape === 'circle') {
-          return circle;
-        } else if (d.shape === 'rectangle') {
-          return rectangle;
-        } else {
-          return d.shape;
-        }
-      })
-      .attr('fill', function(d) {
-        return d.color;
-      })
-      .on('mouseover', function(d) { ideo.showAnnotTooltip(d, this); })
-      .on('mouseout', function() { ideo.startHideAnnotTooltipTimeout(); });
-
+    writeTrackAnnots(chrAnnot, ideo);
   } else if (layout === 'overlay') {
-    // Overlaid annotations appear directly on chromosomes
-
-    chrAnnot.append('polygon')
-      .attr('id', function(d) {
-        return d.id;
-      })
-      .attr('class', 'annot')
-      .attr('points', function(d) {
-        if (d.stopPx - d.startPx > 1) {
-          x1 = d.startPx;
-          x2 = d.stopPx;
-        } else {
-          x1 = d.px - 0.5;
-          x2 = d.px + 0.5;
-        }
-        y1 = chrWidth;
-        y2 = 0;
-
-        return (
-          x1 + ',' + y1 + ' ' +
-          x2 + ',' + y1 + ' ' +
-          x2 + ',' + y2 + ' ' +
-          x1 + ',' + y2
-        );
-      })
-      .attr('fill', function(d) {
-        return d.color;
-      })
-      .on('mouseover', function(d) { ideo.showAnnotTooltip(d, this); })
-      .on('mouseout', function() { ideo.startHideAnnotTooltipTimeout(); });
+    writeOverlayAnnots(chrAnnot, ideo);
   } else if (layout === 'histogram') {
-    chrAnnot.append('polygon')
-    // .attr('id', function(d, i) { return d.id; })
-      .attr('class', 'annot')
-      .attr('points', function(d) {
-        x1 = d.px + ideo.bump;
-        x2 = d.px + ideo.config.barWidth + ideo.bump;
-        y1 = chrWidth;
-        y2 = chrWidth + d.height;
+    writeHistogramAnnots(chrAnnot, ideo);
+  }
+}
 
-        var thisChrWidth = chrWidths[d.chrName].width;
+/**
+ * Draws genome annotations on chromosomes.
+ * Annotations can be rendered as either overlaid directly
+ * on a chromosome, or along one or more "tracks"
+ * running parallel to each chromosome.
+ */
+function drawProcessedAnnots(annots) {
+  var layout,
+    ideo = this;
 
-        if (x2 > thisChrWidth) {
-          x2 = thisChrWidth;
-        }
+  d3.selectAll(ideo.selector + ' .annot').remove();
 
-        return (
-          x1 + ',' + y1 + ' ' +
-          x2 + ',' + y1 + ' ' +
-          x2 + ',' + y2 + ' ' +
-          x1 + ',' + y2
-        );
-      })
-      .attr('fill', function(d) {
-        return d.color;
-      });
+  layout = 'tracks';
+  if (ideo.config.annotationsLayout) layout = ideo.config.annotationsLayout;
+
+  if (layout === 'heatmap') {
+    ideo.drawHeatmaps(annots);
+    return;
   }
 
-  if (ideo.onDrawAnnotsCallback) {
-    ideo.onDrawAnnotsCallback();
-  }
+  drawAnnotsByLayoutType(layout, annots, ideo);
+  if (ideo.onDrawAnnotsCallback) ideo.onDrawAnnotsCallback();
 }
 
 export {drawAnnots, drawProcessedAnnots}

--- a/src/js/annotations/events.js
+++ b/src/js/annotations/events.js
@@ -39,6 +39,40 @@ function startHideAnnotTooltipTimeout() {
   }, 250);
 }
 
+function writeTooltip(tooltip, content, matrix, yOffset, ideo) {
+  tooltip.html(content)
+    .style('opacity', 1) // Make tooltip visible
+    .style('left', (window.pageXOffset + matrix.e) + 'px')
+    .style('top', (window.pageYOffset + matrix.f - yOffset) + 'px')
+    .style('pointer-events', null) // Prevent bug in clicking chromosome
+    .on('mouseover', function () {
+      clearTimeout(ideo.hideAnnotTooltipTimeout);
+    })
+    .on('mouseout', function () {
+      ideo.startHideAnnotTooltipTimeout();
+    });
+}
+
+function getContentAndYOffset(annot) {
+  var content, yOffset, range, displayName;
+
+  range = 'chr' + annot.chr + ':' + annot.start.toLocaleString();
+  if (annot.length > 0) {
+    // Only show range if stop differs from start
+    range += '-' + annot.stop.toLocaleString();
+  }
+  content = range;
+  yOffset = 24;
+
+  if (annot.name) {
+    displayName = annot.displayName ? annot.displayName : annot.name;
+    content = displayName + '<br/>' + content;
+    yOffset += 8;
+  }
+
+  return [content, yOffset];
+}
+
 /**
  * Optional callback, invoked before showing annotation tooltip
  */
@@ -55,12 +89,10 @@ function onWillShowAnnotTooltip(annot) {
  * @param context {Object} "This" of the caller -- an SVG path DOM object
  */
 function showAnnotTooltip(annot, context) {
-  var matrix, range, content, yOffset, displayName, tooltip,
+  var matrix, content, yOffset, tooltip,
     ideo = this;
 
-  if (ideo.config.showAnnotTooltip === false) {
-    return;
-  }
+  if (ideo.config.showAnnotTooltip === false) return;
 
   clearTimeout(ideo.hideAnnotTooltipTimeout);
 
@@ -74,32 +106,9 @@ function showAnnotTooltip(annot, context) {
   matrix = context.getScreenCTM()
     .translate(+context.getAttribute('cx'), +context.getAttribute('cy'));
 
-  range = 'chr' + annot.chr + ':' + annot.start.toLocaleString();
-  if (annot.length > 0) {
-    // Only show range if stop differs from start
-    range += '-' + annot.stop.toLocaleString();
-  }
-  content = range;
-  yOffset = 24;
+  [content, yOffset] = getContentAndYOffset(annot)
 
-  if (annot.name) {
-    displayName = annot.displayName ? annot.displayName : annot.name;
-    content = displayName + '<br/>' + content;
-    yOffset += 8;
-  }
-
-  tooltip
-    .html(content)
-    .style('opacity', 1) // Make tooltip visible
-    .style('left', (window.pageXOffset + matrix.e) + 'px')
-    .style('top', (window.pageYOffset + matrix.f - yOffset) + 'px')
-    .style('pointer-events', null) // Prevent bug in clicking chromosome
-    .on('mouseover', function () {
-      clearTimeout(ideo.hideAnnotTooltipTimeout);
-    })
-    .on('mouseout', function () {
-      ideo.startHideAnnotTooltipTimeout();
-    });
+  writeTooltip(tooltip, content, matrix, yOffset, ideo)
 }
 
 export {

--- a/src/js/annotations/filter.js
+++ b/src/js/annotations/filter.js
@@ -14,21 +14,11 @@ function restoreDefaultTracks() {
   ideo.drawAnnots(ideo.processAnnotData(ideo.rawAnnots));
 }
 
-/**
- * Adds or removes tracks from the displayed list of tracks.
- * Only works when raw annotations are dense.
- *
- * @param trackIndexes Array of indexes of tracks to display
- */
-function updateDisplayedTracks(trackIndexes) {
-  var displayedRawAnnotsByChr, displayedAnnots, i, j, rawAnnots, annots, annot,
-    trackIndex,
-    ideo = this,
-    annotsByChr = ideo.rawAnnots.annots;
+function getDisplayedRawAnnotsByChr(annotsByChr, trackIndexes) {
+  var annot, displayedRawAnnotsByChr, annots, i, displayedAnnots, j,
+    trackIndex;
 
   displayedRawAnnotsByChr = [];
-
-  ideo.config.numAnnotTracks = trackIndexes.length;
 
   // Filter displayed tracks by selected track indexes
   for (i = 0; i < annotsByChr.length; i++) {
@@ -45,6 +35,25 @@ function updateDisplayedTracks(trackIndexes) {
     displayedRawAnnotsByChr.push({chr: annots.chr, annots: displayedAnnots});
   }
 
+  return displayedRawAnnotsByChr;
+}
+
+/**
+ * Adds or removes tracks from the displayed list of tracks.
+ * Only works when raw annotations are dense.
+ *
+ * @param trackIndexes Array of indexes of tracks to display
+ */
+function updateDisplayedTracks(trackIndexes) {
+  var displayedRawAnnotsByChr, displayedAnnots, rawAnnots, trackIndex,
+    ideo = this,
+    annotsByChr = ideo.rawAnnots.annots;
+
+  ideo.config.numAnnotTracks = trackIndexes.length;
+
+  displayedRawAnnotsByChr =
+    getDisplayedRawAnnotsByChr(annotsByChr, trackIndexes);
+
   rawAnnots = {keys: ideo.rawAnnots.keys, annots: displayedRawAnnotsByChr};
 
   displayedAnnots = ideo.processAnnotData(rawAnnots);
@@ -57,25 +66,11 @@ function updateDisplayedTracks(trackIndexes) {
   return displayedAnnots;
 }
 
-function setOriginalTrackIndexes(rawAnnots) {
-  var keys, annotsByChr, annots, annot, i, j, trackIndexOriginal,
-    setAnnotsByChr, setAnnots, numAvailTracks;
-
-  keys = rawAnnots.keys;
-
-  // If this method is unnecessary, pass through
-  if (
-    keys.length < 4 ||
-    keys[3] !== 'trackIndex' ||
-    keys[4] === 'trackIndexOriginal'
-  ) {
-    return rawAnnots;
-  }
+function getSetAnnotsByChr(annotsByChr, ideo) {
+  var i, j, annots, annot, setAnnots, trackIndexOriginal, numAvailTracks,
+    setAnnotsByChr = [];
 
   numAvailTracks = 1;
-
-  annotsByChr = rawAnnots.annots;
-  setAnnotsByChr = [];
 
   for (i = 0; i < annotsByChr.length; i++) {
     annots = annotsByChr[i];
@@ -92,10 +87,31 @@ function setOriginalTrackIndexes(rawAnnots) {
     setAnnotsByChr.push({chr: annots.chr, annots: setAnnots});
   }
 
+  ideo.numAvailTracks = numAvailTracks;
+
+  return setAnnotsByChr;
+}
+
+function setOriginalTrackIndexes(rawAnnots) {
+  var keys, annotsByChr, setAnnotsByChr,
+    ideo = this;
+
+  keys = rawAnnots.keys;
+
+  // If this method is unnecessary, pass through
+  if (
+    keys.length < 4 ||
+    keys[3] !== 'trackIndex' ||
+    keys[4] === 'trackIndexOriginal'
+  ) {
+    return rawAnnots;
+  }
+
+  annotsByChr = rawAnnots.annots;
+  setAnnotsByChr = getSetAnnotsByChr(annotsByChr, ideo);
+
   keys.splice(4, 0, 'trackIndexOriginal');
   rawAnnots = {keys: keys, annots: setAnnotsByChr};
-
-  this.numAvailTracks = numAvailTracks;
 
   return rawAnnots;
 }

--- a/src/js/annotations/heatmap.js
+++ b/src/js/annotations/heatmap.js
@@ -2,6 +2,42 @@ import * as d3selection from 'd3-selection';
 
 var d3 = Object.assign({}, d3selection);
 
+function writeCanvases(chr, chrLeft, chrWidth, ideoHeight, ideo) {
+  var j, trackLeft, trackWidth, canvas, context,
+    contextArray = [],
+    numAnnotTracks = ideo.config.numAnnotTracks;
+
+  // Create a canvas for each annotation track on this chromosome
+  for (j = 0; j < numAnnotTracks; j++) {
+    trackWidth = chrWidth - 1;
+    trackLeft = chrLeft + j * chrWidth - (trackWidth * numAnnotTracks);
+    canvas = d3.select(ideo.config.container + ' #_ideogramOuterWrap')
+      .append('canvas')
+      .attr('id', chr.id + '-canvas-' + j)
+      .attr('width', chrWidth - 1)
+      .attr('height', ideoHeight)
+      .style('position', 'absolute')
+      .style('left', trackLeft + 'px');
+    context = canvas.nodes()[0].getContext('2d');
+    contextArray.push(context);
+  }
+
+  return contextArray;
+}
+
+function fillCanvasAnnots(annots, contextArray, chrWidth, ideoMarginTop) {
+  var j, annot, context, x;
+
+  // Fill in the canvas(es) with annotation colors to draw a heatmap
+  for (j = 0; j < annots.length; j++) {
+    annot = annots[j];
+    context = contextArray[annot.trackIndex];
+    context.fillStyle = annot.color;
+    x = annot.trackIndex - 1;
+    context.fillRect(x, annot.startPx + ideoMarginTop, chrWidth, 0.5);
+  }
+}
+
 /**
  * Draws a 1D heatmap of annotations along each chromosome.
  * Ideal for representing very dense annotation sets in a granular manner
@@ -14,13 +50,10 @@ var d3 = Object.assign({}, d3selection);
  * @param annots {Array} Processed annotation objects
  */
 function drawHeatmaps(annotContainers) {
-
-  var ideo = this,
+  var annots, chrLeft, contextArray, chrWidth, i, chr,
+    ideo = this,
     ideoMarginTop = ideo._layout.margin.top,
-    ideoHeight = ideo.config.chrHeight + ideoMarginTop,
-    numAnnotTracks = ideo.config.numAnnotTracks,
-    annots, chr, chrLeft, trackLeft, trackWidth, canvas, contextArray,
-    chrWidth, context, annot, x, i, j;
+    ideoHeight = ideo.config.chrHeight + ideoMarginTop;
 
   d3.selectAll(ideo.config.container + ' canvas').remove();
 
@@ -30,37 +63,113 @@ function drawHeatmaps(annotContainers) {
     annots = annotContainers[i].annots;
     chr = ideo.chromosomesArray[i];
     chrWidth = ideo.config.chrWidth;
-    chrLeft = ideo._layout.getChromosomeSetYTranslate(i)
+    chrLeft = ideo._layout.getChromosomeSetYTranslate(i);
 
-    contextArray = [];
-
-    // Create a canvas for each annotation track on this chromosome
-    for (j = 0; j < numAnnotTracks; j++) {
-      trackWidth = chrWidth - 1;
-      trackLeft = chrLeft + j * chrWidth - (trackWidth * numAnnotTracks);
-      canvas = d3.select(ideo.config.container + ' #_ideogramOuterWrap')
-        .append('canvas')
-        .attr('id', chr.id + '-canvas-' + j)
-        .attr('width', chrWidth - 1)
-        .attr('height', ideoHeight)
-        .style('position', 'absolute')
-        .style('left', trackLeft + 'px');
-      context = canvas.nodes()[0].getContext('2d');
-      contextArray.push(context);
-    }
-
-    // Fill in the canvas(es) with annotation colors to draw a heatmap
-    for (j = 0; j < annots.length; j++) {
-      annot = annots[j];
-      context = contextArray[annot.trackIndex];
-      context.fillStyle = annot.color;
-      x = annot.trackIndex - 1;
-      context.fillRect(x, annot.startPx + ideoMarginTop, chrWidth, 0.5);
-    }
+    contextArray = writeCanvases(chr, chrLeft, chrWidth, ideoHeight, ideo)
+    fillCanvasAnnots(annots, contextArray, chrWidth, ideoMarginTop);
   }
 
   if (ideo.onDrawAnnotsCallback) {
     ideo.onDrawAnnotsCallback();
+  }
+}
+
+function shouldUseThresholdColor(m, numThresholds, value, prevThreshold,
+  threshold) {
+
+  return (
+    // If this is the last threshold, and
+    // its value is "+" and the value is above the previous threshold...
+    m === numThresholds && (
+      threshold === '+' && value > prevThreshold
+    ) ||
+
+    // ... or if the value matches the threshold...
+    value === threshold ||
+
+    // ... or if this isn't the first or last threshold, and
+    // the value is between this threshold and the previous one...
+    m !== 0 && m !== numThresholds && (
+      value <= threshold &&
+      value > prevThreshold
+    ) ||
+
+    // ... or if this is the first threshold and the value is
+    // at or below the threshold
+    m === 0 && value <= threshold
+  );
+}
+
+function getHeatmapAnnotColor(thresholds, value) {
+  var m, numThresholds, thresholdList, threshold, tvInt, thresholdColor,
+    prevThreshold, useThresholdColor, color;
+
+  for (m = 0; m < thresholds.length; m++) {
+    numThresholds = thresholds.length - 1;
+    thresholdList = thresholds[m];
+    threshold = thresholdList[0];
+
+    // The threshold value is usually an integer,
+    // but can also be a "+" character indicating that
+    // this threshold is anything greater than the previous threshold.
+    tvInt = parseInt(threshold);
+    if (isNaN(tvInt) === false) threshold = tvInt;
+    if (m !== 0) prevThreshold = parseInt(thresholds[m - 1][0]);
+    thresholdColor = thresholdList[1];
+
+    useThresholdColor = shouldUseThresholdColor(m, numThresholds, value,
+      prevThreshold, threshold);
+
+    if (useThresholdColor) {
+      color = thresholdColor;
+    }
+  }
+
+  return color;
+}
+
+function getNewRawAnnots(heatmapKeyIndexes, rawAnnots, ideo) {
+  var j, k, ra, newRa, value, thresholds, color, trackIndex,
+    newRas = [];
+
+  for (j = 0; j < rawAnnots.length; j++) {
+    ra = rawAnnots[j];
+    for (k = 0; k < heatmapKeyIndexes.length; k++) {
+      newRa = ra.slice(0, 3); // name, start, length
+
+      value = ra[heatmapKeyIndexes[k]];
+      thresholds = ideo.config.heatmaps[k].thresholds;
+      color = getHeatmapAnnotColor(thresholds, value);
+
+      trackIndex = k;
+      newRa.push(trackIndex, color, value);
+      newRas.push(newRa);
+    }
+  }
+
+  return newRas;
+}
+
+function getNewRawAnnotContainers(heatmapKeyIndexes, rawAnnotBoxes, ideo) {
+  var raContainer, chr, rawAnnots, newRas, i,
+    newRaContainers = [];
+
+  for (i = 0; i < rawAnnotBoxes.length; i++) {
+    raContainer = rawAnnotBoxes[i];
+    chr = raContainer.chr;
+
+    rawAnnots = raContainer.annots;
+    newRas = getNewRawAnnots(heatmapKeyIndexes, rawAnnots, ideo);
+
+    newRaContainers.push({chr: chr, annots: newRas});
+  }
+  return newRaContainers;
+}
+
+function reportPerformance(t0, ideo) {
+  var t1 = new Date().getTime();
+  if (ideo.config.debug) {
+    console.log('Time in deserializeAnnotsForHeatmap: ' + (t1 - t0) + ' ms');
   }
 }
 
@@ -77,19 +186,11 @@ function drawHeatmaps(annotContainers) {
  * @param rawAnnotsContainer {Object} Raw annotations as passed from server
  */
 function deserializeAnnotsForHeatmap(rawAnnotsContainer) {
-
-  var t0 = new Date().getTime();
-
-  var raContainer, chr, ra, i, j, k, m, trackIndex, rawAnnots,
-    newRaContainers, newRa, newRas, color,
-    heatmapKey, heatmapKeyIndexes, value,
-    thresholds, thresholdList, thresholdColor, threshold, prevThreshold,
-    tvInt, numThresholds,
+  var newRaContainers, heatmapKey, heatmapKeyIndexes, i,
+    t0 = new Date().getTime(),
     keys = rawAnnotsContainer.keys,
     rawAnnotBoxes = rawAnnotsContainer.annots,
     ideo = this;
-
-  newRaContainers = [];
 
   heatmapKeyIndexes = [];
   for (i = 0; i < ideo.config.heatmaps.length; i++) {
@@ -97,74 +198,8 @@ function deserializeAnnotsForHeatmap(rawAnnotsContainer) {
     heatmapKeyIndexes.push(keys.indexOf(heatmapKey));
   }
 
-  for (i = 0; i < rawAnnotBoxes.length; i++) {
-
-    raContainer = rawAnnotBoxes[i];
-    chr = raContainer.chr;
-    rawAnnots = raContainer.annots;
-    newRas = [];
-
-    for (j = 0; j < rawAnnots.length; j++) {
-
-      ra = rawAnnots[j];
-
-      for (k = 0; k < heatmapKeyIndexes.length; k++) {
-
-        newRa = ra.slice(0, 3); // name, start, length
-
-        value = ra[heatmapKeyIndexes[k]];
-        thresholds = ideo.config.heatmaps[k].thresholds;
-
-        for (m = 0; m < thresholds.length; m++) {
-          numThresholds = thresholds.length - 1;
-          thresholdList = thresholds[m];
-          threshold = thresholdList[0];
-
-          // The threshold value is usually an integer,
-          // but can also be a "+" character indicating that
-          // this threshold is anything greater than the previous threshold.
-          tvInt = parseInt(threshold);
-          if (isNaN(tvInt) === false) {
-            threshold = tvInt;
-          }
-          if (m !== 0) {
-            prevThreshold = parseInt(thresholds[m - 1][0]);
-          }
-          thresholdColor = thresholdList[1];
-
-          if (
-
-            // If this is the last threshold, and
-          // its value is "+" and the value is above the previous threshold...
-          m === numThresholds && (
-            threshold === '+' && value > prevThreshold
-          ) ||
-
-          // ... or if the value matches the threshold...
-          value === threshold ||
-
-          // ... or if this isn't the first or last threshold, and
-          // the value is between this threshold and the previous one...
-          m !== 0 && m !== numThresholds && (
-            value <= threshold &&
-            value > prevThreshold
-          ) ||
-
-          // ... or if this is the first threshold and the value is
-          // at or below the threshold
-          m === 0 && value <= threshold
-          ) {
-            color = thresholdColor;
-          }
-        }
-
-        trackIndex = k;
-        newRa.push(trackIndex, color, value);
-        newRas.push(newRa);
-      }
-    }
-    newRaContainers.push({chr: chr, annots: newRas});
-  }
+  newRaContainers =
+    getNewRawAnnotContainers(heatmapKeyIndexes, rawAnnotBoxes, ideo);
 
   keys.splice(3, 0, 'trackIndex');
   keys.splice(4, 0, 'color');
@@ -172,10 +207,7 @@ function deserializeAnnotsForHeatmap(rawAnnotsContainer) {
   ideo.rawAnnots.keys = keys;
   ideo.rawAnnots.annots = newRaContainers;
 
-  var t1 = new Date().getTime();
-  if (ideogram.config.debug) {
-    console.log('Time in deserializeAnnotsForHeatmap: ' + (t1 - t0) + ' ms');
-  }
+  reportPerformance(t0, ideo);
 }
 
 export {drawHeatmaps, deserializeAnnotsForHeatmap}

--- a/src/js/annotations/heatmap.js
+++ b/src/js/annotations/heatmap.js
@@ -120,9 +120,7 @@ function getHeatmapAnnotColor(thresholds, value) {
     useThresholdColor = shouldUseThresholdColor(m, numThresholds, value,
       prevThreshold, threshold);
 
-    if (useThresholdColor) {
-      color = thresholdColor;
-    }
+    if (useThresholdColor) color = thresholdColor;
   }
 
   return color;

--- a/src/js/annotations/histogram.js
+++ b/src/js/annotations/histogram.js
@@ -137,4 +137,46 @@ function getHistogramBars(annots) {
   return bars;
 }
 
-export {getHistogramBars}
+
+function getHistogramPoints(d, chrWidth, chrWidths, ideo) {
+  var x1, x2, y1, y2;
+
+  x1 = d.px + ideo.bump;
+  x2 = d.px + ideo.config.barWidth + ideo.bump;
+  y1 = chrWidth;
+  y2 = chrWidth + d.height;
+
+  var thisChrWidth = chrWidths[d.chr];
+
+  if (x2 > thisChrWidth) {
+    x2 = thisChrWidth;
+  }
+
+  return (
+    x1 + ',' + y1 + ' ' +
+    x2 + ',' + y1 + ' ' +
+    x2 + ',' + y2 + ' ' +
+    x1 + ',' + y2
+  );
+}
+
+function writeHistogramAnnots(chrAnnot, ideo) {
+  var chrs, chr,
+    chrWidths = {},
+    chrWidth = ideo.config.chrWidth;
+
+  chrs = ideo.chromosomes[ideo.config.taxid];
+  for (chr in chrs) {
+    chrWidths[chr] = chrs[chr];
+  }
+
+  chrAnnot.append('polygon')
+    // .attr('id', function(d, i) { return d.id; })
+    .attr('class', 'annot')
+    .attr('points', function(d) {
+      return getHistogramPoints(d, chrWidth, chrWidths, ideo);
+    })
+    .attr('fill', function(d) { return d.color; });
+}
+
+export {getHistogramBars, writeHistogramAnnots}

--- a/src/js/annotations/process.js
+++ b/src/js/annotations/process.js
@@ -187,7 +187,6 @@ function addAnnots(rawAnnots, keys, ideo) {
       addAnnotsForChr(annots, omittedAnnots, annotsByChr, chrModel,
         m, keys, ideo);
   }
-
   return [annots, omittedAnnots];
 }
 

--- a/src/js/annotations/process.js
+++ b/src/js/annotations/process.js
@@ -1,49 +1,174 @@
+// Default colors for tracks of annotations
+var colorMap = [
+  ['F00'], // If there is 1 track, then color it red.
+  ['F00', '88F'], // If 2 tracks, color one red and one light blue.
+  ['F00', 'CCC', '88F'], // If 3, color one red, one grey, one light blue.
+  ['F00', 'FA0', '0AF', '88F'], // And so on.
+  ['F00', 'FA0', 'CCC', '0AF', '88F'],
+  ['F00', 'FA0', '875', '578', '0AF', '88F'],
+  ['F00', 'FA0', '875', 'CCC', '578', '0AF', '88F'],
+  ['F00', 'FA0', '7A0', '875', '0A7', '578', '0AF', '88F'],
+  ['F00', 'FA0', '7A0', '875', 'CCC', '0A7', '578', '0AF', '88F'],
+  ['F00', 'FA0', '7A0', '875', '552', '255', '0A7', '578', '0AF', '88F']
+];
+
 /**
- * Proccesses genome annotation data.
- *
- * This method converts raw annotation data from server, which is structured as
- * an array of arrays, into a more verbose data structure consisting of an
- * array of objects.  It also adds pixel offset information.
+ * Ensure annotation containers are ordered by chromosome.
  */
-function processAnnotData(rawAnnots) {
-  var keys, numTracks, i, j, k, m, n, annot, annots, thisAnnot, annotsByChr,
-    chr, chrs, chrModel, ra, startPx, stopPx, px, annotTrack,
-    unorderedAnnots, colorMap, colors, omittedAnnots, numOmittedTracks, numAvailTracks,
-    ideo = this,
-    config = ideo.config;
+function orderAnnotContainers(annots, ideo) {
+  var unorderedAnnots, i, j, annot, chr, chrs;
 
-  omittedAnnots = {};
-
-  colorMap = [
-    ['F00'],
-    ['F00', '88F'],
-    ['F00', 'CCC', '88F'],
-    ['F00', 'FA0', '0AF', '88F'],
-    ['F00', 'FA0', 'CCC', '0AF', '88F'],
-    ['F00', 'FA0', '875', '578', '0AF', '88F'],
-    ['F00', 'FA0', '875', 'CCC', '578', '0AF', '88F'],
-    ['F00', 'FA0', '7A0', '875', '0A7', '578', '0AF', '88F'],
-    ['F00', 'FA0', '7A0', '875', 'CCC', '0A7', '578', '0AF', '88F'],
-    ['F00', 'FA0', '7A0', '875', '552', '255', '0A7', '578', '0AF', '88F']
-  ];
-
-  keys = rawAnnots.keys;
-  rawAnnots = rawAnnots.annots;
-
-  numTracks = config.numAnnotTracks;
-  numAvailTracks = ideo.numAvailTracks;
-
-  colors = colorMap[numAvailTracks - 1];
-
-  if (numTracks > 10) {
-    console.error(
-      'Ideogram only displays up to 10 tracks at a time.  ' +
-      'You specified ' + numTracks + ' tracks.  ' +
-      'Perhaps consider a different way to visualize your data.'
-    );
+  unorderedAnnots = annots;
+  annots = [];
+  chrs = ideo.chromosomesArray;
+  for (i = 0; i < chrs.length; i++) {
+    chr = chrs[i].name;
+    for (j = 0; j < unorderedAnnots.length; j++) {
+      annot = unorderedAnnots[j];
+      if (annot.chr === chr) {
+        annots.push(annot);
+      }
+    }
   }
 
+  return annots;
+}
+
+/**
+ * Add client annotations, as in annotations-tracks.html
+ */
+function addClientAnnot(annots, annot, config, ra, m) {
+  var annotTrack;
+
+  annot.trackIndex = ra[3];
+  annotTrack = config.annotationTracks[annot.trackIndex];
+  if (annotTrack.color) {
+    annot.color = annotTrack.color;
+  }
+  if (annotTrack.shape) {
+    annot.shape = annotTrack.shape;
+  }
+
+  annots[m].annots.push(annot);
+
+  return annots;
+}
+
+/**
+ * Add sparse server annotations, as in annotations-track-filters.html
+ */
+function addSparseServertAnnot(annot, ra, colors, omittedAnnots, annots, numTracks, m) {
+  annot.trackIndex = ra[3];
+  annot.trackIndexOriginal = ra[4];
+  annot.color = '#' + colors[annot.trackIndexOriginal];
+
+  // Catch annots that will be omitted from display
+  if (annot.trackIndex > numTracks - 1) {
+    if (annot.trackIndex in omittedAnnots) {
+      omittedAnnots[annot.trackIndex].push(annot);
+    } else {
+      omittedAnnots[annot.trackIndex] = [annot];
+    }
+    return [annots, omittedAnnots];
+  }
+  annots[m].annots.push(annot);
+
+  return [annots, omittedAnnots];
+}
+
+function addDenseServerAnnot(keys, annots, annot, m) {
+  var n, thisAnnot;
+
+  // Dense server annotations
+  for (n = 4; n < keys.length; n++) {
+    thisAnnot = Object.assign({}, annot); // copy by value
+    thisAnnot.trackIndex = n - 4;
+    thisAnnot.trackIndexOriginal = n - 3;
+    thisAnnot.color = '#' + colors[thisAnnot.trackIndexOriginal];
+    annots[m].annots.push(thisAnnot);
+  }
+
+  return annots;
+}
+
+/**
+ * Basic client annotations, as in annotations-basic.html
+ * and annotations-external.html
+ */
+function addBasicClientAnnot(annots, annot, config, m) {
+  annot.trackIndex = 0;
+  if (!annot.color) {
+    annot.color = config.annotationsColor;
+  }
+  if (!annot.shape) {
+    annot.shape = 'triangle';
+  }
+  annots[m].annots.push(annot);
+
+  return annots;
+}
+
+function addAnnot(annot, keys, ra, config, omittedAnnots, annots, m,
+  numAvailTracks, numTracks, colors) {
+
+  if (config.annotationTracks) {
+    annots = addClientAnnot(annots, annot, config, ra, m);
+  } else if (keys[3] === 'trackIndex' && numAvailTracks !== 1) {
+    [annots, omittedAnnots] = 
+      addSparseServertAnnot(annot, ra, colors, omittedAnnots, annots, numTracks, m);
+  } else if (
+    keys.length > 3 &&
+    keys[3] in {trackIndex: 1, color: 1, shape: 1} === false &&
+    keys[4] === 'trackIndexOriginal'
+  ) {
+    annots = addDenseServerAnnot(keys, annots, annot, m);
+  } else {
+    annots = addBasicClientAnnot(annots, annot, config, m);
+  }
+
+  return [annots, omittedAnnots];
+}
+
+function addAnnotsForChr(annots, omittedAnnots, annotsByChr, chr, chrModel,
+  colors, m, keys, numTracks, ideo, i, numAvailTracks) {
+  var j, k, annot, startPx, stopPx, px, ra,
+    config = ideo.config;
+
+  for (j = 0; j < annotsByChr.annots.length; j++) {
+    ra = annotsByChr.annots[j];
+    annot = {};
+
+    for (k = 0; k < keys.length; k++) {
+      annot[keys[k]] = ra[k];
+    }
+
+    annot.stop = annot.start + annot.length;
+
+    startPx = ideo.convertBpToPx(chrModel, annot.start);
+    stopPx = ideo.convertBpToPx(chrModel, annot.stop);
+    px = Math.round((startPx + stopPx) / 2);
+
+    annot.chr = chr;
+    annot.chrIndex = i;
+    annot.px = px;
+    annot.startPx = startPx;
+    annot.stopPx = stopPx;  
+
+    [annots, omittedAnnots] = 
+      addAnnot(annot, keys, ra, config, omittedAnnots, annots, m, numAvailTracks, numTracks, colors);
+  }
+
+  return [annots, omittedAnnots];
+}
+
+function addAnnots(rawAnnots, keys, numTracks, numAvailTracks, ideo) {
+  var annots, omittedAnnots, m, i, annotsByChr, chr, chrModel, colors,
+    config = ideo.config;
+
   annots = [];
+  omittedAnnots = {};
+
+  colors = colorMap[numAvailTracks - 1];
 
   m = -1;
   for (i = 0; i < rawAnnots.length; i++) {
@@ -64,79 +189,23 @@ function processAnnotData(rawAnnots) {
     m++;
     annots.push({chr: annotsByChr.chr, annots: []});
 
-    for (j = 0; j < annotsByChr.annots.length; j++) {
-      ra = annotsByChr.annots[j];
-      annot = {};
+    [annots, omittedAnnots] =
+      addAnnotsForChr(annots, omittedAnnots, annotsByChr, chr, chrModel,
+        colors, m, keys, numTracks, ideo, i, numAvailTracks);
+  }
 
-      for (k = 0; k < keys.length; k++) {
-        annot[keys[k]] = ra[k];
-      }
+  return [annots, omittedAnnots]
+}
 
-      annot.stop = annot.start + annot.length;
+function sendTrackAndAnnotWarnings(numTracks, omittedAnnots) {
+  var numOmittedTracks;
 
-      startPx = ideo.convertBpToPx(chrModel, annot.start);
-      stopPx = ideo.convertBpToPx(chrModel, annot.stop);
-      px = Math.round((startPx + stopPx) / 2);
-
-      annot.chr = chr;
-      annot.chrIndex = i;
-      annot.px = px;
-      annot.startPx = startPx;
-      annot.stopPx = stopPx;
-
-      if (config.annotationTracks) {
-        // Client annotations, as in annotations-tracks.html
-        annot.trackIndex = ra[3];
-        annotTrack = config.annotationTracks[annot.trackIndex];
-        if (annotTrack.color) {
-          annot.color = annotTrack.color;
-        }
-        if (annotTrack.shape) {
-          annot.shape = annotTrack.shape;
-        }
-        annots[m].annots.push(annot);
-      } else if (keys[3] === 'trackIndex' && numAvailTracks !== 1) {
-        // Sparse server annotations, as in annotations-track-filters.html
-        annot.trackIndex = ra[3];
-        annot.trackIndexOriginal = ra[4];
-        annot.color = '#' + colors[annot.trackIndexOriginal];
-
-        // Catch annots that will be omitted from display
-        if (annot.trackIndex > numTracks - 1) {
-          if (annot.trackIndex in omittedAnnots) {
-            omittedAnnots[annot.trackIndex].push(annot);
-          } else {
-            omittedAnnots[annot.trackIndex] = [annot];
-          }
-          continue;
-        }
-        annots[m].annots.push(annot);
-      } else if (
-        keys.length > 3 &&
-        keys[3] in {trackIndex: 1, color: 1, shape: 1} === false &&
-        keys[4] === 'trackIndexOriginal'
-      ) {
-        // Dense server annotations
-        for (n = 4; n < keys.length; n++) {
-          thisAnnot = Object.assign({}, annot); // copy by value
-          thisAnnot.trackIndex = n - 4;
-          thisAnnot.trackIndexOriginal = n - 3;
-          thisAnnot.color = '#' + colors[thisAnnot.trackIndexOriginal];
-          annots[m].annots.push(thisAnnot);
-        }
-      } else {
-        // Basic client annotations, as in annotations-basic.html
-        // and annotations-external.html
-        annot.trackIndex = 0;
-        if (!annot.color) {
-          annot.color = config.annotationsColor;
-        }
-        if (!annot.shape) {
-          annot.shape = 'triangle';
-        }
-        annots[m].annots.push(annot);
-      }
-    }
+  if (numTracks > 10) {
+    console.error(
+      'Ideogram only displays up to 10 tracks at a time.  ' +
+      'You specified ' + numTracks + ' tracks.  ' +
+      'Perhaps consider a different way to visualize your data.'
+    );
   }
 
   numOmittedTracks = Object.keys(omittedAnnots).length;
@@ -147,20 +216,31 @@ function processAnnotData(rawAnnots) {
       'extra tracks.'
     );
   }
+}
 
-  // Ensure annotation containers are ordered by chromosome
-  unorderedAnnots = annots;
-  annots = [];
-  chrs = ideo.chromosomesArray;
-  for (i = 0; i < chrs.length; i++) {
-    chr = chrs[i].name;
-    for (j = 0; j < unorderedAnnots.length; j++) {
-      annot = unorderedAnnots[j];
-      if (annot.chr === chr) {
-        annots.push(annot);
-      }
-    }
-  }
+/**
+ * Proccesses genome annotation data.
+ *
+ * This method converts raw annotation data from server, which is structured as
+ * an array of arrays, into a more verbose data structure consisting of an
+ * array of objects.  It also adds pixel offset information.
+ */
+function processAnnotData(rawAnnots) {
+  var numTracks, keys, annots, omittedAnnots, numAvailTracks, 
+    ideo = this;
+
+  keys = rawAnnots.keys;
+  rawAnnots = rawAnnots.annots;
+
+  numTracks = ideo.config.numAnnotTracks;
+  numAvailTracks = ideo.numAvailTracks;
+
+  [annots, omittedAnnots] = 
+    addAnnots(rawAnnots, keys, numTracks, numAvailTracks, ideo);
+
+  sendTrackAndAnnotWarnings(numTracks, omittedAnnots)
+
+  annots = orderAnnotContainers(annots, ideo);
 
   return annots;
 }

--- a/src/js/annotations/process.js
+++ b/src/js/annotations/process.js
@@ -78,20 +78,21 @@ function addSparseServertAnnot(annot, ra, omittedAnnots, annots, m, ideo) {
   return [annots, omittedAnnots];
 }
 
-function addDenseServerAnnot(keys, annots, annot, m) {
-  var n, thisAnnot;
+// TODO: This needs a working test case.
+// function addDenseServerAnnot(keys, annots, annot, m) {
+//   var n, thisAnnot;
 
-  // Dense server annotations
-  for (n = 4; n < keys.length; n++) {
-    thisAnnot = Object.assign({}, annot); // copy by value
-    thisAnnot.trackIndex = n - 4;
-    thisAnnot.trackIndexOriginal = n - 3;
-    thisAnnot.color = '#' + colors[thisAnnot.trackIndexOriginal];
-    annots[m].annots.push(thisAnnot);
-  }
+//   // Dense server annotations
+//   for (n = 4; n < keys.length; n++) {
+//     thisAnnot = Object.assign({}, annot); // copy by value
+//     thisAnnot.trackIndex = n - 4;
+//     thisAnnot.trackIndexOriginal = n - 3;
+//     thisAnnot.color = '#' + colors[thisAnnot.trackIndexOriginal];
+//     annots[m].annots.push(thisAnnot);
+//   }
 
-  return annots;
-}
+//   return annots;
+// }
 
 /**
  * Basic client annotations, as in annotations-basic.html
@@ -117,12 +118,12 @@ function addAnnot(annot, keys, ra, omittedAnnots, annots, m, ideo) {
   } else if (keys[3] === 'trackIndex' && ideo.numAvailTracks !== 1) {
     [annots, omittedAnnots] = 
       addSparseServertAnnot(annot, ra, omittedAnnots, annots, m, ideo);
-  } else if (
-    keys.length > 3 &&
-    keys[3] in {trackIndex: 1, color: 1, shape: 1} === false &&
-    keys[4] === 'trackIndexOriginal'
-  ) {
-    annots = addDenseServerAnnot(keys, annots, annot, m);
+  // } else if (
+  //   keys.length > 3 &&
+  //   keys[3] in {trackIndex: 1, color: 1, shape: 1} === false &&
+  //   keys[4] === 'trackIndexOriginal'
+  // ) {
+  //   annots = addDenseServerAnnot(keys, annots, annot, m);
   } else {
     annots = addBasicClientAnnot(annots, annot, m, ideo);
   }

--- a/src/js/annotations/synteny.js
+++ b/src/js/annotations/synteny.js
@@ -2,18 +2,117 @@ import * as d3selection from 'd3-selection';
 
 var d3 = Object.assign({}, d3selection);
 
+function writeSyntenicRegion(syntenies, regionID, ideo) {
+  return syntenies.append('g')
+    .attr('class', 'syntenicRegion')
+    .attr('id', regionID)
+    .on('click', function() {
+      var activeRegion = this;
+      var others = d3.selectAll(ideo.selector + ' .syntenicRegion')
+        .filter(function() {
+          return (this !== activeRegion);
+        });
+
+      others.classed('hidden', !others.classed('hidden'));
+    })
+    .on('mouseover', function() {
+      var activeRegion = this;
+      d3.selectAll(ideo.selector + ' .syntenicRegion')
+        .filter(function() { return (this !== activeRegion); })
+        .classed('ghost', true);
+    })
+    .on('mouseout', function() {
+      d3.selectAll(ideo.selector + ' .syntenicRegion')
+        .classed('ghost', false);
+    });
+}
+
+function getRegionsR1AndR2(regions, xOffset, ideo) {
+  var r1, r2;
+
+  r1 = regions.r1;
+  r2 = regions.r2;
+
+  r1.startPx = ideo.convertBpToPx(r1.chr, r1.start) + xOffset;
+  r1.stopPx = ideo.convertBpToPx(r1.chr, r1.stop) + xOffset;
+  r2.startPx = ideo.convertBpToPx(r2.chr, r2.start) + xOffset;
+  r2.stopPx = ideo.convertBpToPx(r2.chr, r2.stop) + xOffset;
+
+  return [r1, r2];
+}
+
+function writeSyntenicRegionPolygons(syntenicRegion, x1, x2, r1, r2, regions) {
+  var color, opacity;
+
+  color = ('color' in regions) ? regions.color : '#CFC';
+  opacity = ('opacity' in regions) ? regions.opacity : 1;
+
+  syntenicRegion.append('polygon')
+    .attr('points',
+      x1 + ', ' + r1.startPx + ' ' +
+      x1 + ', ' + r1.stopPx + ' ' +
+      x2 + ', ' + r2.stopPx + ' ' +
+      x2 + ', ' + r2.startPx
+    )
+    .attr('style', 'fill: ' + color + '; fill-opacity: ' + opacity);
+}
+
+function writeSyntenicRegionLines(syntenicRegion, x1, x2, r1, r2) {
+  syntenicRegion.append('line')
+    .attr('class', 'syntenyBorder')
+    .attr('x1', x1)
+    .attr('x2', x2)
+    .attr('y1', r1.startPx)
+    .attr('y2', r2.startPx);
+
+  syntenicRegion.append('line')
+    .attr('class', 'syntenyBorder')
+    .attr('x1', x1)
+    .attr('x2', x2)
+    .attr('y1', r1.stopPx)
+    .attr('y2', r2.stopPx);
+}
+
+function writeSyntenicRegions(syntenicRegions, syntenies, xOffset, ideo) {
+  var i, regions, r1, r2, regionID, syntenicRegion, chrWidth, x1, x2;
+
+  for (i = 0; i < syntenicRegions.length; i++) {
+    regions = syntenicRegions[i];
+
+    [r1, r2] = getRegionsR1AndR2(regions, xOffset, ideo)
+
+    regionID = (
+      r1.chr.id + '_' + r1.start + '_' + r1.stop + '_' +
+      '__' +
+      r2.chr.id + '_' + r2.start + '_' + r2.stop
+    );
+
+    syntenicRegion = writeSyntenicRegion(syntenies, regionID, ideo);
+
+    chrWidth = ideo.config.chrWidth;
+    x1 = ideo._layout.getChromosomeSetYTranslate(0);
+    x2 = ideo._layout.getChromosomeSetYTranslate(1) - chrWidth;
+
+    writeSyntenicRegionPolygons(syntenicRegion, x1, x2, r1, r2, regions);
+    writeSyntenicRegionLines(syntenicRegion, x1, x2, r1, r2);
+  }
+}
+
+function reportPerformance(t0, ideo) {
+  var t1 = new Date().getTime();
+  if (ideo.config.debug) {
+    console.log('Time in drawSyntenicRegions: ' + (t1 - t0) + ' ms');
+  }
+}
+
 /**
  * Draws a trapezoid connecting a genomic range on
  * one chromosome to a genomic range on another chromosome;
  * a syntenic region.
  */
 function drawSynteny(syntenicRegions) {
-  var t0 = new Date().getTime();
-
-  var r1, r2,
-    syntenies,
-    i, color, opacity, xOffset,
-    regionID, regions, syntenicRegion,
+  var syntenies, xOffset, 
+    t0 = new Date().getTime(),
     ideo = this;
 
   syntenies = d3.select(ideo.selector)
@@ -22,90 +121,9 @@ function drawSynteny(syntenicRegions) {
 
   xOffset = ideo._layout.margin.left;
 
-  for (i = 0; i < syntenicRegions.length; i++) {
-    regions = syntenicRegions[i];
+  writeSyntenicRegions(syntenicRegions, syntenies, xOffset, ideo);
 
-    r1 = regions.r1;
-    r2 = regions.r2;
-
-    color = '#CFC';
-    if ('color' in regions) {
-      color = regions.color;
-    }
-
-    opacity = 1;
-    if ('opacity' in regions) {
-      opacity = regions.opacity;
-    }
-
-    r1.startPx = this.convertBpToPx(r1.chr, r1.start) + xOffset;
-    r1.stopPx = this.convertBpToPx(r1.chr, r1.stop) + xOffset;
-    r2.startPx = this.convertBpToPx(r2.chr, r2.start) + xOffset;
-    r2.stopPx = this.convertBpToPx(r2.chr, r2.stop) + xOffset;
-
-    regionID = (
-      r1.chr.id + '_' + r1.start + '_' + r1.stop + '_' +
-      '__' +
-      r2.chr.id + '_' + r2.start + '_' + r2.stop
-    );
-
-    syntenicRegion = syntenies.append('g')
-      .attr('class', 'syntenicRegion')
-      .attr('id', regionID)
-      .on('click', function() {
-        var activeRegion = this;
-        var others = d3.selectAll(ideo.selector + ' .syntenicRegion')
-          .filter(function() {
-            return (this !== activeRegion);
-          });
-
-        others.classed('hidden', !others.classed('hidden'));
-      })
-      .on('mouseover', function() {
-        var activeRegion = this;
-        d3.selectAll(ideo.selector + ' .syntenicRegion')
-          .filter(function() {
-            return (this !== activeRegion);
-          })
-          .classed('ghost', true);
-      })
-      .on('mouseout', function() {
-        d3.selectAll(ideo.selector + ' .syntenicRegion')
-          .classed('ghost', false);
-      });
-
-    var chrWidth = ideo.config.chrWidth;
-    var x1 = this._layout.getChromosomeSetYTranslate(0);
-    var x2 = this._layout.getChromosomeSetYTranslate(1) - chrWidth;
-
-    syntenicRegion.append('polygon')
-      .attr('points',
-        x1 + ', ' + r1.startPx + ' ' +
-        x1 + ', ' + r1.stopPx + ' ' +
-        x2 + ', ' + r2.stopPx + ' ' +
-        x2 + ', ' + r2.startPx
-      )
-      .attr('style', 'fill: ' + color + '; fill-opacity: ' + opacity);
-
-    syntenicRegion.append('line')
-      .attr('class', 'syntenyBorder')
-      .attr('x1', x1)
-      .attr('x2', x2)
-      .attr('y1', r1.startPx)
-      .attr('y2', r2.startPx);
-
-    syntenicRegion.append('line')
-      .attr('class', 'syntenyBorder')
-      .attr('x1', x1)
-      .attr('x2', x2)
-      .attr('y1', r1.stopPx)
-      .attr('y2', r2.stopPx);
-  }
-
-  var t1 = new Date().getTime();
-  if (ideo.config.debug) {
-    console.log('Time in drawSyntenicRegions: ' + (t1 - t0) + ' ms');
-  }
+  reportPerformance(t0, ideo);
 }
 
 export {drawSynteny}

--- a/src/js/bands/draw.js
+++ b/src/js/bands/draw.js
@@ -5,7 +5,8 @@
 
 import * as d3selection from 'd3-selection';
 import {Object} from '../lib.js';
-import {hideUnshownBandLabels, setBandsToShow} from './show.js';
+import {hideUnshownBandLabels, setBandsToShow} from './show';
+import {staticColors, staticCss, staticGradients} from './styles';
 
 var d3 = Object.assign({}, d3selection);
 
@@ -74,6 +75,19 @@ function drawBandLabelStalk(chr, bandsToLabel, chrModel, textOffsets) {
     .attr('y2', ideo._layout.getChromosomeBandTickY2(chrModel.chrIndex));
 }
 
+function getChrModels(chromosomes) {
+  var taxid, chr,
+    chrModels = [];
+
+  for (taxid in chromosomes) {
+    for (chr in chromosomes[taxid]) {
+      chrModels.push(chromosomes[taxid][chr]);
+    }
+  }
+
+  return chrModels;
+}
+
 /**
  * Draws text and stalks for cytogenetic band labels.
  *
@@ -81,19 +95,14 @@ function drawBandLabelStalk(chr, bandsToLabel, chrModel, textOffsets) {
  * Stalks are small lines that visually connect labels to their bands.
  */
 function drawBandLabels(chromosomes) {
-  var i, chr, taxid, chrModel, textOffsets, bandsToLabel,
+  var i, chr, chrModel, chrModels, textOffsets, bandsToLabel,
     ideo = this,
-    textOffsets = {},
-    chrs = [];
+    textOffsets = {};
 
-  for (taxid in chromosomes) {
-    for (chr in chromosomes[taxid]) {
-      chrs.push(chromosomes[taxid][chr]);
-    }
-  }
+  chrModels = getChrModels(chromosomes);
 
-  for (i = 0; i < chrs.length; i++) {
-    chrModel = chrs[i];
+  for (i = 0; i < chrModels.length; i++) {
+    chrModel = chrModels[i];
     chr = d3.select(ideo.selector + ' #' + chrModel.id);
     textOffsets[chrModel.id] = [];
 
@@ -106,33 +115,26 @@ function drawBandLabels(chromosomes) {
     ideo.drawBandLabelStalk(chr, bandsToLabel, chrModel, textOffsets);
   }
 
-  ideo.setBandsToShow(chrs, textOffsets);
+  ideo.setBandsToShow(chrModels, textOffsets);
 }
 
-/**
- * Returns SVG gradients that give chromosomes a polished look
- */
-function getBandColorGradients() {
-  var colors, stain, color1, color2, color3, css, i,
+function getStainAndColors(i, colors) {
+  var stain, color1, color2, color3;
+
+  stain = colors[i][0];
+  color1 = colors[i][1];
+  color2 = colors[i][2];
+  color3 = colors[i][3];
+
+  return [stain, color1, color2, color3];
+}
+
+function getGradients(colors) {
+  var i, stain, color1, color2, color3,
     gradients = '';
 
-  colors = [
-    ['gneg', '#FFF', '#FFF', '#DDD'],
-    ['gpos25', '#C8C8C8', '#DDD', '#BBB'],
-    ['gpos33', '#BBB', '#BBB', '#AAA'],
-    ['gpos50', '#999', '#AAA', '#888'],
-    ['gpos66', '#888', '#888', '#666'],
-    ['gpos75', '#777', '#777', '#444'],
-    ['gpos100', '#444', '#666', '#000'],
-    ['acen', '#FEE', '#FEE', '#FDD'],
-    ['noBands', '#BBB', '#BBB', '#AAA']
-  ];
-
   for (i = 0; i < colors.length; i++) {
-    stain = colors[i][0];
-    color1 = colors[i][1];
-    color2 = colors[i][2];
-    color3 = colors[i][3];
+    [stain, color1, color2, color3] = getStainAndColors(i, colors);
     gradients +=
       '<linearGradient id="' + stain + '" x1="0%" y1="0%" x2="0%" y2="100%">';
     if (stain === "gneg") {
@@ -150,79 +152,21 @@ function getBandColorGradients() {
       '</linearGradient>';
   }
 
-  css = '<style>' +
-    'svg#_ideogram  {padding-left: 5px;} ' +
-    'svg#_ideogram .labeled {padding-left: 15px;} ' +
-    'svg#_ideogram.labeledLeft {padding-left: 15px; padding-top: 15px;} ' +
-    // Tahoma has great readability and space utilization at small sizes
-    // More: http://ux.stackexchange.com/a/3334
-    '#_ideogram text {font: 9px Tahoma; fill: #000;} ' +
-    '#_ideogram .italic {font-style: italic;} ' +
-    '#_ideogram .chromosome {cursor: pointer; fill: #AAA;}' +
-    '#_ideogram .chrSetLabel {font-weight: bolder;}' +
-    '#_ideogram .ghost {opacity: 0.2;}' +
-    '#_ideogram .hidden {display: none;}' +
-    '#_ideogram .bandLabelStalk line {stroke: #AAA; stroke-width: 1;}' +
-    '#_ideogram .syntenyBorder {stroke:#AAA;stroke-width:1;}' +
-    '#_ideogram .brush .selection {' +
-    '  fill: #F00;' +
-    '  stroke: #F00;' +
-    '  fill-opacity: .3;' +
-    '  shape-rendering: crispEdges;' +
-    '}' +
-    '#_ideogram .noBands {fill: #AAA;}' +
-    // NCBI stain density colors
-    '#_ideogram .gneg {fill: #FFF}' +
-    '#_ideogram .gpos25 {fill: #BBB}' +
-    '#_ideogram .gpos33 {fill: #AAA}' +
-    '#_ideogram .gpos50 {fill: #888}' +
-    '#_ideogram .gpos66 {fill: #666}' +
-    '#_ideogram .gpos75 {fill: #444}' +
-    '#_ideogram .gpos100 {fill: #000}' +
-    '#_ideogram .gpos {fill: #000}' +
-    '#_ideogram .acen {fill: #FDD}' +
-    '#_ideogram .stalk {fill: #CCE;}' +
-    '#_ideogram .gvar {fill: #DDF}' +
-    // Used when overlaid with annotations
-    '#_ideogram.faint .gneg {fill: #FFF}' +
-    '#_ideogram.faint .gpos25 {fill: #EEE}' +
-    '#_ideogram.faint .gpos33 {fill: #EEE}' +
-    '#_ideogram.faint .gpos50 {fill: #EEE}' +
-    '#_ideogram.faint .gpos66 {fill: #EEE}' +
-    '#_ideogram.faint .gpos75 {fill: #EEE}' +
-    '#_ideogram.faint .gpos100 {fill: #DDD}' +
-    '#_ideogram.faint .gpos {fill: #DDD}' +
-    '#_ideogram.faint .acen {fill: #FEE}' +
-    '#_ideogram.faint .stalk {fill: #EEF;}' +
-    '#_ideogram.faint .gvar {fill: #EEF}' +
-    '#_ideogram .gneg {fill: url("#gneg")} ' +
-    '#_ideogram .gpos25 {fill: url("#gpos25")} ' +
-    '#_ideogram .gpos33 {fill: url("#gpos33")} ' +
-    '#_ideogram .gpos50 {fill: url("#gpos50")} ' +
-    '#_ideogram .gpos66 {fill: url("#gpos66")} ' +
-    '#_ideogram .gpos75 {fill: url("#gpos75")} ' +
-    '#_ideogram .gpos100 {fill: url("#gpos100")} ' +
-    '#_ideogram .gpos {fill: url("#gpos100")} ' +
-    '#_ideogram .acen {fill: url("#acen")} ' +
-    '#_ideogram .stalk {fill: url("#stalk")} ' +
-    '#_ideogram .gvar {fill: url("#gvar")} ' +
-    '#_ideogram .noBands {fill: url("#noBands")} ' +
-    '#_ideogram .chromosome {fill: url("#noBands")} ' +
-    '</style>';
+  return gradients;
+}
 
-  gradients +=
-    '<pattern id="stalk" width="2" height="1" patternUnits="userSpaceOnUse" ' +
-    'patternTransform="rotate(30 0 0)">' +
-    '<rect x="0" y="0" width="10" height="2" fill="#CCE" /> ' +
-    '<line x1="0" y1="0" x2="0" y2="100%" style="stroke:#88B; ' +
-    'stroke-width:0.7;" />' +
-    '</pattern>' +
-    '<pattern id="gvar" width="2" height="1" patternUnits="userSpaceOnUse" ' +
-    'patternTransform="rotate(-30 0 0)">' +
-    '<rect x="0" y="0" width="10" height="2" fill="#DDF" /> ' +
-    '<line x1="0" y1="0" x2="0" y2="100%" style="stroke:#99C; ' +
-    'stroke-width:0.7;" />' +
-    '</pattern>';
+/**
+ * Returns SVG gradients that give chromosomes a polished look
+ */
+function getBandColorGradients() {
+  var css,
+    gradients = '';
+
+  gradients = getGradients(staticColors);
+
+  css = staticCss;
+
+  gradients += staticGradients;
   gradients = "<defs>" + gradients + "</defs>";
   gradients = css + gradients;
 

--- a/src/js/bands/fetch.js
+++ b/src/js/bands/fetch.js
@@ -1,0 +1,42 @@
+function setBandData(url, fileNames, chrBands, ideo) {
+  var taxid, fetchedTaxid, fileName;
+
+  // Ensures correct taxid is processed in response callback;
+  // using simply upstream 'taxid' variable gives the last
+  // *requested* taxid, which fails when dealing with multiple taxa.
+  for (taxid in fileNames) {
+    fileName = fileNames[taxid];
+    if (url.includes(fileName) && fileName !== '') {
+      fetchedTaxid = taxid;
+    }
+  }
+
+  ideo.bandData[fetchedTaxid] = chrBands;
+}
+
+function fetchBands(bandDataFileNames, taxid, t0, ideo) {
+  var bandDataUrl = ideo.config.dataDir + bandDataFileNames[taxid];
+
+  if (!ideo.numBandDataResponses) ideo.numBandDataResponses = 0;
+
+  fetch(bandDataUrl)
+    .then(function(response) {
+      return response.text().then(function(rawBands) {
+
+        // Fetched data is a JavaScript variable, so assign it
+        eval(rawBands);
+
+        setBandData(response.url, bandDataFileNames, chrBands, ideo);
+
+        ideo.numBandDataResponses += 1;
+
+        if (ideo.numBandDataResponses === ideo.config.taxids.length) {
+          var bandsArray = ideo.processBandData();
+          ideo.writeContainer(bandsArray, taxid, t0);
+          delete ideo.numBandDataResponses;
+        }
+      });
+    });
+}
+
+export {fetchBands}

--- a/src/js/bands/show.js
+++ b/src/js/bands/show.js
@@ -18,7 +18,6 @@ function hideUnshownBandLabels() {
   // Most bands are hidden, so we can optimize by
   // Hiding all bands, then QSA'ing and displaying the
   // relatively few bands that are shown.
-  var t0C = new Date().getTime();
   d3.selectAll(ideo.selector + ' .bandLabel, .bandLabelStalk')
     .style('display', 'none');
   d3.selectAll(bandsToShow).style('display', '');

--- a/src/js/bands/styles.js
+++ b/src/js/bands/styles.js
@@ -1,0 +1,90 @@
+var staticColors, staticCss, staticGradients;
+
+staticColors = [
+  ['gneg', '#FFF', '#FFF', '#DDD'],
+  ['gpos25', '#C8C8C8', '#DDD', '#BBB'],
+  ['gpos33', '#BBB', '#BBB', '#AAA'],
+  ['gpos50', '#999', '#AAA', '#888'],
+  ['gpos66', '#888', '#888', '#666'],
+  ['gpos75', '#777', '#777', '#444'],
+  ['gpos100', '#444', '#666', '#000'],
+  ['acen', '#FEE', '#FEE', '#FDD'],
+  ['noBands', '#BBB', '#BBB', '#AAA']
+];
+
+staticCss =
+  '<style>' +
+  'svg#_ideogram  {padding-left: 5px;} ' +
+  'svg#_ideogram .labeled {padding-left: 15px;} ' +
+  'svg#_ideogram.labeledLeft {padding-left: 15px; padding-top: 15px;} ' +
+  // Tahoma has great readability and space utilization at small sizes
+  // More: http://ux.stackexchange.com/a/3334
+  '#_ideogram text {font: 9px Tahoma; fill: #000;} ' +
+  '#_ideogram .italic {font-style: italic;} ' +
+  '#_ideogram .chromosome {cursor: pointer; fill: #AAA;}' +
+  '#_ideogram .chrSetLabel {font-weight: bolder;}' +
+  '#_ideogram .ghost {opacity: 0.2;}' +
+  '#_ideogram .hidden {display: none;}' +
+  '#_ideogram .bandLabelStalk line {stroke: #AAA; stroke-width: 1;}' +
+  '#_ideogram .syntenyBorder {stroke:#AAA;stroke-width:1;}' +
+  '#_ideogram .brush .selection {' +
+  '  fill: #F00;' +
+  '  stroke: #F00;' +
+  '  fill-opacity: .3;' +
+  '  shape-rendering: crispEdges;' +
+  '}' +
+  '#_ideogram .noBands {fill: #AAA;}' +
+  // NCBI stain density colors
+  '#_ideogram .gneg {fill: #FFF}' +
+  '#_ideogram .gpos25 {fill: #BBB}' +
+  '#_ideogram .gpos33 {fill: #AAA}' +
+  '#_ideogram .gpos50 {fill: #888}' +
+  '#_ideogram .gpos66 {fill: #666}' +
+  '#_ideogram .gpos75 {fill: #444}' +
+  '#_ideogram .gpos100 {fill: #000}' +
+  '#_ideogram .gpos {fill: #000}' +
+  '#_ideogram .acen {fill: #FDD}' +
+  '#_ideogram .stalk {fill: #CCE;}' +
+  '#_ideogram .gvar {fill: #DDF}' +
+  // Used when overlaid with annotations
+  '#_ideogram.faint .gneg {fill: #FFF}' +
+  '#_ideogram.faint .gpos25 {fill: #EEE}' +
+  '#_ideogram.faint .gpos33 {fill: #EEE}' +
+  '#_ideogram.faint .gpos50 {fill: #EEE}' +
+  '#_ideogram.faint .gpos66 {fill: #EEE}' +
+  '#_ideogram.faint .gpos75 {fill: #EEE}' +
+  '#_ideogram.faint .gpos100 {fill: #DDD}' +
+  '#_ideogram.faint .gpos {fill: #DDD}' +
+  '#_ideogram.faint .acen {fill: #FEE}' +
+  '#_ideogram.faint .stalk {fill: #EEF;}' +
+  '#_ideogram.faint .gvar {fill: #EEF}' +
+  '#_ideogram .gneg {fill: url("#gneg")} ' +
+  '#_ideogram .gpos25 {fill: url("#gpos25")} ' +
+  '#_ideogram .gpos33 {fill: url("#gpos33")} ' +
+  '#_ideogram .gpos50 {fill: url("#gpos50")} ' +
+  '#_ideogram .gpos66 {fill: url("#gpos66")} ' +
+  '#_ideogram .gpos75 {fill: url("#gpos75")} ' +
+  '#_ideogram .gpos100 {fill: url("#gpos100")} ' +
+  '#_ideogram .gpos {fill: url("#gpos100")} ' +
+  '#_ideogram .acen {fill: url("#acen")} ' +
+  '#_ideogram .stalk {fill: url("#stalk")} ' +
+  '#_ideogram .gvar {fill: url("#gvar")} ' +
+  '#_ideogram .noBands {fill: url("#noBands")} ' +
+  '#_ideogram .chromosome {fill: url("#noBands")} ' +
+  '</style>';
+
+staticGradients =
+  '<pattern id="stalk" width="2" height="1" patternUnits="userSpaceOnUse" ' +
+  'patternTransform="rotate(30 0 0)">' +
+  '<rect x="0" y="0" width="10" height="2" fill="#CCE" /> ' +
+  '<line x1="0" y1="0" x2="0" y2="100%" style="stroke:#88B; ' +
+  'stroke-width:0.7;" />' +
+  '</pattern>' +
+  '<pattern id="gvar" width="2" height="1" patternUnits="userSpaceOnUse" ' +
+  'patternTransform="rotate(-30 0 0)">' +
+  '<rect x="0" y="0" width="10" height="2" fill="#DDF" /> ' +
+  '<line x1="0" y1="0" x2="0" y2="100%" style="stroke:#99C; ' +
+  'stroke-width:0.7;" />' +
+  '</pattern>';
+
+export {staticColors, staticCss, staticGradients};

--- a/src/js/init/configure.js
+++ b/src/js/init/configure.js
@@ -1,70 +1,34 @@
-/**
- * High-level helper method for Ideogram constructor.
- *
- * @param config Configuration object.  Enables setting Ideogram properties.
- */
-function configure(config) {
+function configurePloidy(ideo) {
 
-  var orientation,
-    chrWidth, chrHeight,
-    container, rect;
-
-  // Clone the config object, to allow multiple instantiations
-  // without picking up prior ideogram's settings
-  this.config = JSON.parse(JSON.stringify(config));
-
-  if (!this.config.debug) {
-    this.config.debug = false;
+  if (!ideo.config.ploidy) {
+    ideo.config.ploidy = 1;
   }
 
-  if (!this.config.dataDir) {
-    this.config.dataDir = this.getDataDir();
-  }
-
-  if (!this.config.ploidy) {
-    this.config.ploidy = 1;
-  }
-
-  if (this.config.ploidy > 1) {
-    this.sexChromosomes = {};
-    if (!this.config.sex) {
+  if (ideo.config.ploidy > 1) {
+    ideo.sexChromosomes = {};
+    if (!ideo.config.sex) {
       // Default to 'male' per human, mouse reference genomes.
       // TODO: The default sex value should probably be the heterogametic sex,
       // i.e. whichever sex has allosomes that differ in morphology.
       // In mammals and most insects that is the male.
       // However, in birds and reptiles, that is female.
-      this.config.sex = 'male';
+      ideo.config.sex = 'male';
     }
-    if (this.config.ploidy === 2 && !this.config.ancestors) {
-      this.config.ancestors = {M: '#ffb6c1', P: '#add8e6'};
-      this.config.ploidyDesc = 'MP';
+    if (ideo.config.ploidy === 2 && !ideo.config.ancestors) {
+      ideo.config.ancestors = {M: '#ffb6c1', P: '#add8e6'};
+      ideo.config.ploidyDesc = 'MP';
     }
   }
+}
 
-  if (!this.config.container) {
-    this.config.container = 'body';
-  }
+function configureHeight(ideo) {
+  var container, rect, chrHeight;
 
-  this.selector = this.config.container + ' #_ideogram';
-
-  if (!this.config.resolution) {
-    this.config.resolution = '';
-  }
-
-  if ('showChromosomeLabels' in this.config === false) {
-    this.config.showChromosomeLabels = true;
-  }
-
-  if (!this.config.orientation) {
-    orientation = 'vertical';
-    this.config.orientation = orientation;
-  }
-
-  if (!this.config.chrHeight) {
-    container = this.config.container;
+  if (!ideo.config.chrHeight) {
+    container = ideo.config.container;
     rect = document.querySelector(container).getBoundingClientRect();
 
-    if (orientation === 'vertical') {
+    if (ideo.config.orientation === 'vertical') {
       chrHeight = rect.height;
     } else {
       chrHeight = rect.width;
@@ -73,113 +37,40 @@ function configure(config) {
     if (container === 'body') {
       chrHeight = 400;
     }
-    this.config.chrHeight = chrHeight;
+    ideo.config.chrHeight = chrHeight;
   }
+}
 
-  if (!this.config.chrWidth) {
+function configureWidth(ideo) {
+  var chrWidth, chrHeight;
+
+  if (!ideo.config.chrWidth) {
     chrWidth = 10;
-    chrHeight = this.config.chrHeight;
+    chrHeight = ideo.config.chrHeight;
 
     if (chrHeight < 900 && chrHeight > 500) {
       chrWidth = Math.round(chrHeight / 40);
     } else if (chrHeight >= 900) {
       chrWidth = Math.round(chrHeight / 45);
     }
-    this.config.chrWidth = chrWidth;
+    ideo.config.chrWidth = chrWidth;
   }
+}
 
-  if (!this.config.chrMargin) {
-    if (this.config.ploidy === 1) {
-      this.config.chrMargin = 10;
+function configureMargin(ideo) {
+  if (!ideo.config.chrMargin) {
+    if (ideo.config.ploidy === 1) {
+      ideo.config.chrMargin = 10;
     } else {
       // Defaults polyploid chromosomes to relatively small interchromatid gap
-      this.config.chrMargin = Math.round(this.config.chrWidth / 4);
+      ideo.config.chrMargin = Math.round(ideo.config.chrWidth / 4);
     }
   }
+}
 
-  if (!this.config.showBandLabels) {
-    this.config.showBandLabels = false;
-  }
 
-  if ('showFullyBanded' in this.config) {
-    this.config.showFullyBanded = config.showFullyBanded;
-  } else {
-    this.config.showFullyBanded = true;
-  }
-
-  if (!this.config.brush) {
-    this.config.brush = null;
-  }
-
-  if (!this.config.rows) {
-    this.config.rows = 1;
-  }
-
-  this.bump = Math.round(this.config.chrHeight / 125);
-  this.adjustedBump = false;
-  if (this.config.chrHeight < 200) {
-    this.adjustedBump = true;
-    this.bump = 4;
-  }
-
-  if (config.showBandLabels) {
-    this.config.chrMargin += 20;
-  }
-
-  if (config.chromosome) {
-    this.config.chromosomes = [config.chromosome];
-    if ('showBandLabels' in config === false) {
-      this.config.showBandLabels = true;
-    }
-    if ('rotatable' in config === false) {
-      this.config.rotatable = false;
-    }
-  }
-
-  if (!this.config.showNonNuclearChromosomes) {
-    this.config.showNonNuclearChromosomes = false;
-  }
-
-  this.initAnnotSettings();
-
-  this.config.chrMargin = (
-    this.config.chrMargin +
-    this.config.chrWidth +
-    this.config.annotTracksHeight * 2
-  );
-
-  if (config.onLoad) {
-    this.onLoadCallback = config.onLoad;
-  }
-
-  if (config.onLoadAnnots) {
-    this.onLoadAnnotsCallback = config.onLoadAnnots;
-  }
-
-  if (config.onDrawAnnots) {
-    this.onDrawAnnotsCallback = config.onDrawAnnots;
-  }
-
-  if (config.onBrushMove) {
-    this.onBrushMoveCallback = config.onBrushMove;
-  }
-
-  if (config.onWillShowAnnotTooltip) {
-    this.onWillShowAnnotTooltipCallback = config.onWillShowAnnotTooltip;
-  }
-
-  if (config.onDidRotate) {
-    this.onDidRotateCallback = config.onDidRotate;
-  }
-
-  this.coordinateSystem = 'iscn';
-
-  this.maxLength = {
-    bp: 0,
-    iscn: 0
-  };
-
-  this.organisms = {
+function configureOrganisms(ideo) {
+  ideo.organisms = {
     9606: {
       commonName: 'Human',
       scientificName: 'Homo sapiens',
@@ -206,7 +97,133 @@ function configure(config) {
         default: 'mock'
       }
     }
+  }
+}
+
+function configureCallbacks(config, ideo) {
+  if (config.onLoad) {
+    ideo.onLoadCallback = config.onLoad;
+  }
+  if (config.onLoadAnnots) {
+    ideo.onLoadAnnotsCallback = config.onLoadAnnots;
+  }
+  if (config.onDrawAnnots) {
+    ideo.onDrawAnnotsCallback = config.onDrawAnnots;
+  }
+  if (config.onBrushMove) {
+    ideo.onBrushMoveCallback = config.onBrushMove;
+  }
+  if (config.onWillShowAnnotTooltip) {
+    ideo.onWillShowAnnotTooltipCallback = config.onWillShowAnnotTooltip;
+  }
+  if (config.onDidRotate) {
+    ideo.onDidRotateCallback = config.onDidRotate;
+  }
+}
+
+/**
+ * High-level helper method for Ideogram constructor.
+ *
+ * @param config Configuration object.  Enables setting Ideogram properties.
+ */
+function configure(config) {
+
+  var orientation;
+
+  // Clone the config object, to allow multiple instantiations
+  // without picking up prior ideogram's settings
+  this.config = JSON.parse(JSON.stringify(config));
+
+  if (!this.config.debug) {
+    this.config.debug = false;
+  }
+
+  if (!this.config.dataDir) {
+    this.config.dataDir = this.getDataDir();
+  }
+
+  configurePloidy(this);
+
+  if (!this.config.container) {
+    this.config.container = 'body';
+  }
+
+  this.selector = this.config.container + ' #_ideogram';
+
+  if (!this.config.resolution) {
+    this.config.resolution = '';
+  }
+
+  if ('showChromosomeLabels' in this.config === false) {
+    this.config.showChromosomeLabels = true;
+  }
+
+  if (!this.config.orientation) {
+    orientation = 'vertical';
+    this.config.orientation = orientation;
+  }
+
+  if (!this.config.showBandLabels) {
+    this.config.showBandLabels = false;
+  }
+
+  configureHeight(this);
+  configureWidth(this);
+  configureMargin(this);
+
+  if ('showFullyBanded' in this.config) {
+    this.config.showFullyBanded = config.showFullyBanded;
+  } else {
+    this.config.showFullyBanded = true;
+  }
+
+  if (!this.config.brush) {
+    this.config.brush = null;
+  }
+
+  if (!this.config.rows) {
+    this.config.rows = 1;
+  }
+
+  this.bump = Math.round(this.config.chrHeight / 125);
+  this.adjustedBump = false;
+  if (this.config.chrHeight < 200) {
+    this.adjustedBump = true;
+    this.bump = 4;
+  }
+
+  if (config.chromosome) {
+    this.config.chromosomes = [config.chromosome];
+    if ('showBandLabels' in config === false) {
+      this.config.showBandLabels = true;
+    }
+    if ('rotatable' in config === false) {
+      this.config.rotatable = false;
+    }
+  }
+
+  if (!this.config.showNonNuclearChromosomes) {
+    this.config.showNonNuclearChromosomes = false;
+  }
+
+  this.initAnnotSettings();
+
+  this.config.chrMargin = (
+    this.config.chrMargin +
+    this.config.chrWidth +
+    this.config.annotTracksHeight * 2
+  );
+
+  configureCallbacks(config, this);
+
+  this.coordinateSystem = 'iscn';
+
+  this.maxLength = {
+    bp: 0,
+    iscn: 0
   };
+
+  configureOrganisms(this);
 
   // A flat array of chromosomes
   // (this.chromosomes is an object of

--- a/src/js/init/configure.js
+++ b/src/js/init/configure.js
@@ -1,5 +1,4 @@
 function configurePloidy(ideo) {
-
   if (!ideo.config.ploidy) ideo.config.ploidy = 1;
 
   if (ideo.config.ploidy > 1) {
@@ -127,16 +126,37 @@ function configureCallbacks(config, ideo) {
 }
 
 function configureMiscellaneous(ideo) {
-  // A flat array of chromosomes
-  // (ideo.chromosomes is an object of
-  // arrays of chromosomes, keyed by organism)
   ideo.chromosomesArray = [];
-
   ideo.coordinateSystem = 'iscn';
   ideo.maxLength = {bp: 0, iscn: 0};
-  ideo.bandsToShow = [];
   ideo.chromosomes = {};
   ideo.numChromosomes = 0;
+  if (!ideo.config.debug) ideo.config.debug = false;
+  if (!ideo.config.dataDir) ideo.config.dataDir = ideo.getDataDir();
+  if (!ideo.config.container) ideo.config.container = 'body';
+  ideo.selector = ideo.config.container + ' #_ideogram';
+  if (!ideo.config.resolution) ideo.config.resolution = '';
+  if (!ideo.config.orientation) ideo.config.orientation = 'vertical';
+  if (!ideo.config.brush) ideo.config.brush = null;
+  if (!ideo.config.rows) ideo.config.rows = 1;
+  if ('showChromosomeLabels' in ideo.config === false) {
+    ideo.config.showChromosomeLabels = true;
+  }
+  if (!ideo.config.showNonNuclearChromosomes) {
+    ideo.config.showNonNuclearChromosomes = false;
+  }
+}
+
+function configureBands(ideo) {
+  if (!ideo.config.showBandLabels) ideo.config.showBandLabels = false;
+
+  if ('showFullyBanded' in ideo.config) {
+    ideo.config.showFullyBanded = ideo.config.showFullyBanded;
+  } else {
+    ideo.config.showFullyBanded = true;
+  }
+
+  ideo.bandsToShow = [];
   ideo.bandData = {};
 }
 
@@ -146,64 +166,26 @@ function configureMiscellaneous(ideo) {
  * @param config Configuration object.  Enables setting Ideogram properties.
  */
 function configure(config) {
-
+  
   // Clone the config object, to allow multiple instantiations
   // without picking up prior ideogram's settings
   this.config = JSON.parse(JSON.stringify(config));
 
-  if (!this.config.debug) this.config.debug = false;
-
-  if (!this.config.dataDir) this.config.dataDir = this.getDataDir();
-
+  configureMiscellaneous(this);
   configurePloidy(this);
-
-  if (!this.config.container) this.config.container = 'body';
-
-  this.selector = this.config.container + ' #_ideogram';
-
-  if (!this.config.resolution) this.config.resolution = '';
-
-  if ('showChromosomeLabels' in this.config === false) {
-    this.config.showChromosomeLabels = true;
-  }
-
-  if (!this.config.orientation) this.config.orientation = 'vertical';
-
-  if (!this.config.showBandLabels) this.config.showBandLabels = false;
-
+  configureBands(this);
   configureHeight(this);
   configureWidth(this);
   configureMargin(this);
-
-  if ('showFullyBanded' in this.config) {
-    this.config.showFullyBanded = config.showFullyBanded;
-  } else {
-    this.config.showFullyBanded = true;
-  }
-
-  if (!this.config.brush) this.config.brush = null;
-
-  if (!this.config.rows) this.config.rows = 1;
-
+  configureCallbacks(config, this);
+  configureOrganisms(this);
   configureBump(this);
   configureSingleChromosome(config, this);
-
-  if (!this.config.showNonNuclearChromosomes) {
-    this.config.showNonNuclearChromosomes = false;
-  }
-
   this.initAnnotSettings();
-
   this.config.chrMargin += (
     this.config.chrWidth +
     this.config.annotTracksHeight * 2
   );
-
-  configureCallbacks(config, this);
-
-  configureOrganisms(this);
-  configureMiscellaneous(this);
-
   this.init();
 }
 

--- a/src/js/init/finish-init.js
+++ b/src/js/init/finish-init.js
@@ -3,6 +3,78 @@ import {Object} from '../lib';
 
 var d3 = Object.assign({}, d3selection);
 
+function processLabels(config, ideo) {
+  var i, chrID, t0C, t1C;
+
+  if (config.showBandLabels === true) {
+    t0C = new Date().getTime();
+    ideo.hideUnshownBandLabels();
+    t1C = new Date().getTime();
+    if (config.debug) {
+      console.log('Time in showing bands: ' + (t1C - t0C) + ' ms');
+    }
+
+    if (config.orientation === 'vertical') {
+      for (i = 0; i < ideo.chromosomesArray.length; i++) {
+        chrID = '#' + ideo.chromosomesArray[i].id;
+        ideo.rotateChromosomeLabels(d3.select(chrID), i);
+      }
+    }
+  }
+
+  if (config.showChromosomeLabels === true) {
+    ideo.drawChromosomeLabels(ideo.chromosomes);
+  }
+}
+
+function processAnnots(ideo) {
+  if (typeof ideo.timeout !== 'undefined') window.clearTimeout(ideo.timeout);
+
+  ideo.rawAnnots = ideo.setOriginalTrackIndexes(ideo.rawAnnots);
+
+  if (ideo.config.annotationsDisplayedTracks) {
+    ideo.annots =
+      ideo.updateDisplayedTracks(ideo.config.annotationsDisplayedTracks);
+  } else {
+    ideo.annots = ideo.processAnnotData(ideo.rawAnnots);
+    if (ideo.config.filterable) ideo.initCrossFilter();
+    ideo.drawProcessedAnnots(ideo.annots);
+  }
+}
+
+/**
+ * Waits for potentially large annotation dataset
+ * to be received by the client, then triggers annotation processing.
+ */
+function waitForAndProcessAnnots(ideo) {
+  if (ideo.rawAnnots) {
+    processAnnots(ideo);
+  } else {
+    (function checkAnnotData() {
+      ideo.timeout = setTimeout(function() {
+        if (!ideo.rawAnnots) {
+          checkAnnotData();
+        } else {
+          processAnnots(ideo);
+        }
+      }, 50);
+    })();
+  }
+}
+
+function reportDebugTimings(config, t0, t0A) {
+
+  var t1A = new Date().getTime();
+  if (config.debug) {
+    console.log('Time in drawChromosome: ' + (t1A - t0A) + ' ms');
+  }
+
+  var t1 = new Date().getTime();
+  if (config.debug) {
+    console.log('Time constructing ideogram: ' + (t1 - t0) + ' ms');
+  }
+}
+
 /**
  * Completes high-level initialization.
  * Draws chromosomes and band labels, rotating as needed;
@@ -10,102 +82,24 @@ var d3 = Object.assign({}, d3selection);
  * creates brush, emits notification of load completion, etc.
  */
 function finishInit(bandsArray, t0) {
-  var i, 
-    t0A = new Date().getTime(),
+  var t0A = new Date().getTime(),
     ideo = this,
     config = ideo.config;
 
-  try {
+  ideo.initDrawChromosomes(bandsArray);
 
-    ideo.initDrawChromosomes(bandsArray);
+  if (config.annotationsPath) waitForAndProcessAnnots(ideo);
 
-    // Waits for potentially large annotation dataset
-    // to be received by the client, then triggers annotation processing
-    if (config.annotationsPath) {
-      function pa() {
-        if (typeof ideo.timeout !== 'undefined') {
-          window.clearTimeout(ideo.timeout);
-        }
+  processLabels(config, ideo);
 
-        ideo.rawAnnots = ideo.setOriginalTrackIndexes(ideo.rawAnnots);
+  if (config.brush) ideo.createBrush(config.brush);
+  if (config.annotations) ideo.drawAnnots(config.annotations);
 
-        if (config.annotationsDisplayedTracks) {
-          ideo.annots = ideo.updateDisplayedTracks(config.annotationsDisplayedTracks);
-        } else {
-          ideo.annots = ideo.processAnnotData(ideo.rawAnnots);
+  reportDebugTimings(config, t0, t0A);
 
-          if (config.filterable) {
-            ideo.initCrossFilter();
-          }
+  ideo.setOverflowScroll();
 
-          ideo.drawProcessedAnnots(ideo.annots);
-        }
-      }
-
-      if (ideo.rawAnnots) {
-        pa();
-      } else {
-        (function checkAnnotData() {
-          ideo.timeout = setTimeout(function() {
-              if (!ideo.rawAnnots) {
-                checkAnnotData();
-              } else {
-                pa();
-              }
-            },
-            50
-          );
-        })();
-      }
-    }
-
-    if (config.showBandLabels === true) {
-      ideo.hideUnshownBandLabels();
-      var t1C = new Date().getTime();
-      if (config.debug) {
-        console.log('Time in showing bands: ' + (t1C - t0C) + ' ms');
-      }
-
-      if (config.orientation === 'vertical') {
-        var chrID;
-        for (i = 0; i < ideo.chromosomesArray.length; i++) {
-          chrID = '#' + ideo.chromosomesArray[i].id;
-          ideo.rotateChromosomeLabels(d3.select(chrID), i);
-        }
-      }
-    }
-
-    if (config.showChromosomeLabels === true) {
-      ideo.drawChromosomeLabels(ideo.chromosomes);
-    }
-
-    if (config.brush) {
-      ideo.createBrush(config.brush);
-    }
-
-    if (config.annotations) {
-      ideo.drawAnnots(config.annotations);
-    }
-
-    var t1A = new Date().getTime();
-    if (config.debug) {
-      console.log('Time in drawChromosome: ' + (t1A - t0A) + ' ms');
-    }
-
-    var t1 = new Date().getTime();
-    if (config.debug) {
-      console.log('Time constructing ideogram: ' + (t1 - t0) + ' ms');
-    }
-
-    ideo.setOverflowScroll();
-
-    if (ideo.onLoadCallback) {
-      ideo.onLoadCallback();
-    }
-  } catch (e) {
-    // console.log(e);
-    throw e;
-  }
+  if (ideo.onLoadCallback) ideo.onLoadCallback();
 }
 
 export {finishInit}

--- a/src/js/init/init.js
+++ b/src/js/init/init.js
@@ -48,7 +48,7 @@ function prepareChromosomes(bandsArray, chrs, taxid, chrIndex, ideo) {
   return chrIndex;
 }
 
-function setCoordinateSystem(chrBands, chrs, ideo) {
+function setCoordinateSystem(chrs, ideo) {
   if (
     typeof chrBands !== 'undefined' &&
     chrs.length >= chrBands.length / 2
@@ -72,7 +72,7 @@ function initDrawChromosomes(bandsArray) {
     taxid = taxids[i];
     chrs = ideo.config.chromosomes[taxid];
 
-    setCoordinateSystem(chrBands, chrs, ideo);
+    setCoordinateSystem(chrs, ideo);
 
     ideo.chromosomes[taxid] = {};
     ideo.setSexChromosomes(chrs);

--- a/src/js/init/init.js
+++ b/src/js/init/init.js
@@ -5,10 +5,11 @@
 import * as d3fetch from 'd3-fetch';
 import * as d3selection from 'd3-selection';
 
-import {Object} from '../lib';
+import {Object, hasNonGenBankAssembly} from '../lib';
 import {configure} from './configure';
 import {finishInit} from './finish-init';
 import {writeContainer} from './write-container';
+import {fetchBands} from '../bands/fetch';
 
 var d3 = Object.assign({}, d3fetch, d3selection);
 
@@ -54,7 +55,6 @@ function initDrawChromosomes(bandsArray) {
       chrModel = ideo.getChromosomeModel(bands, chromosome, taxid, chrIndex);
 
       chrIndex += 1;
-
 
       if (typeof chromosome !== 'string') {
         chromosome = chromosome.name;
@@ -103,7 +103,6 @@ function handleRotateOnClick() {
   }
 }
 
-
 /**
  * Called when Ideogram has finished initializing.
  * Accounts for certain ideogram properties not being set until
@@ -113,23 +112,74 @@ function onLoad() {
   call(this.onLoadCallback);
 }
 
-/**
- * Initializes an ideogram.
- * Sets some high-level properties based on instance configuration,
- * fetches band and annotation data if needed, and
- * writes an SVG element to the document to contain the ideogram
- */
-function init() {
-  var taxid, i, svgClass, accession, promise,
-    t0 = new Date().getTime(),
-    ideo = this,
-    config = ideo.config,
-    bandsArray = [],
-    numBandDataResponses = 0,
-    resolution = config.resolution;
+function getBandFileName(taxid, accession, ideo) {
+  var organism = ideo.organisms[taxid];
+  var bandFileName = [Ideogram.slugify(organism.scientificName)];
+  var assemblies = organism.assemblies;
+  var resolution = ideo.config.resolution;
 
-  promise = new Promise(function(resolve) {
-    if (typeof config.organism === 'number') {
+  if (accession !== assemblies.default) {
+    bandFileName.push(accession);
+  }
+  if (
+    taxid === '9606' &&
+    (accession in assemblies === 'false' &&
+      Object.values(assemblies).includes(config.assembly) ||
+      (resolution !== '' && resolution !== 850))
+  ) {
+    bandFileName.push(resolution);
+  }
+  bandFileName = bandFileName.join('-') + '.js';
+
+  return bandFileName;
+}
+
+function getBandFileNames(taxid, bandFileNames, ideo) {
+  var organism, assemblies, accession, bandFileName,
+    config = ideo.config;
+
+  organism = ideo.organisms[taxid];
+
+  if (!config.assembly) ideo.config.assembly = 'default';
+
+  assemblies = organism.assemblies;
+
+  if (ideo.assemblyIsAccession()) {
+    accession = config.assembly;
+  } else {
+    accession = assemblies[config.assembly];
+  }
+
+  bandFileName = getBandFileName(taxid, accession, ideo);
+
+  if (taxid === '9606' || taxid === '10090') {
+    bandFileNames[taxid] = bandFileName;
+  }
+  return bandFileNames;
+}
+
+function prepareContainer(taxid, bandFileNames, t0, ideo) {
+  var bandsArray;
+
+  if (
+    hasNonGenBankAssembly(ideo) &&
+    typeof chrBands === 'undefined' && taxid in bandFileNames
+  ) {
+    fetchBands(bandFileNames, taxid, t0, ideo);
+  } else {
+    if (typeof chrBands !== 'undefined') {
+      // If bands already available,
+      // e.g. via <script> tag in initial page load
+      ideo.bandData[taxid] = chrBands;
+    }
+    bandsArray = ideo.processBandData();
+    ideo.writeContainer(bandsArray, taxid, t0);
+  }
+}
+
+function initializeTaxids(ideo) {
+  return new Promise(function(resolve) {
+    if (typeof ideo.config.organism === 'number') {
       // 'organism' is a taxid, e.g. 9606
       ideo.getOrganismFromEutils(function() {
         ideo.getTaxids(resolve);
@@ -138,104 +188,39 @@ function init() {
       ideo.getTaxids(resolve);
     }
   });
+}
 
-  promise.then(function(taxids) {
-    var organism;
+function getBandsAndPrepareContainer(taxids, t0, ideo) {
+  var bandFileNames, i, taxid;
 
-    taxid = taxids[0];
-    ideo.config.taxid = taxid;
-    ideo.config.taxids = taxids;
+  taxid = taxids[0];
+  ideo.config.taxid = taxid;
+  ideo.config.taxids = taxids;
 
-    var assemblies,
-      bandFileName;
+  bandFileNames = {
+    9606: '',
+    10090: ''
+  };
 
-    var bandDataFileNames = {
-      9606: '',
-      10090: ''
-    };
+  for (i = 0; i < taxids.length; i++) {
+    taxid = String(taxids[i]);
+    bandFileNames = getBandFileNames(taxid, bandFileNames, ideo);
+    prepareContainer(taxid, bandFileNames, t0, ideo);
+  }
+}
 
-    for (i = 0; i < taxids.length; i++) {
-      taxid = String(taxids[i]);
-      organism = ideo.organisms[taxid];
+/**
+ * Initializes an ideogram.
+ * Sets some high-level properties based on instance configuration,
+ * fetches band and annotation data if needed, and
+ * writes an SVG element to the document to contain the ideogram
+ */
+function init() {
+  var t0 = new Date().getTime(),
+    ideo = this;
 
-      if (!config.assembly) {
-        ideo.config.assembly = 'default';
-      }
-      assemblies = organism.assemblies;
-
-      if (ideo.assemblyIsAccession()) {
-        accession = config.assembly;
-      } else {
-        accession = assemblies[config.assembly];
-      }
-
-      bandFileName = [Ideogram.slugify(organism.scientificName)];
-      if (accession !== assemblies.default) {
-        bandFileName.push(accession);
-      }
-      if (
-        taxid === '9606' &&
-        (accession in assemblies === 'false' &&
-          Object.values(assemblies).includes(config.assembly) ||
-          (resolution !== '' && resolution !== 850))
-      ) {
-        bandFileName.push(resolution);
-      }
-      bandFileName = bandFileName.join('-') + '.js';
-
-      if (taxid === '9606' || taxid === '10090') {
-        bandDataFileNames[taxid] = bandFileName;
-      }
-
-      if (
-        typeof accession !== 'undefined' &&
-        /GCA_/.test(config.assembly) === false &&
-        typeof chrBands === 'undefined' && taxid in bandDataFileNames
-      ) {
-
-        var bandDataUrl = config.dataDir + bandDataFileNames[taxid];
-
-        fetch(bandDataUrl)
-          .then(function(response) {
-            return response.text().then(function(text) {
-
-              // Fetched data is a JavaScript variable, so assign it
-              eval(text);
-
-              // Ensures correct taxid is processed
-              // in response callback; using simply upstream 'taxid' variable
-              // gives the last *requested* taxid, which fails when dealing
-              // with multiple taxa.
-              var fetchedTaxid, tid, bandDataFileName;
-              for (tid in bandDataFileNames) {
-                bandDataFileName = bandDataFileNames[tid];
-                if (
-                  response.url.includes(bandDataFileName) &&
-                  bandDataFileName !== ''
-                ) {
-                  fetchedTaxid = tid;
-                }
-              }
-
-              ideo.bandData[fetchedTaxid] = chrBands;
-              numBandDataResponses += 1;
-
-              if (numBandDataResponses === taxids.length) {
-                bandsArray = ideo.processBandData();
-                ideo.writeContainer(bandsArray, taxid, t0);
-              }
-            });
-          });
-      } else {
-        if (typeof chrBands !== 'undefined') {
-          // If bands already available,
-          // e.g. via <script> tag in initial page load
-          ideo.bandData[taxid] = chrBands;
-        }
-        bandsArray = ideo.processBandData();
-        ideo.writeContainer(bandsArray, taxid, t0);
-      }
-    }
+  initializeTaxids(ideo).then(function(taxids) {
+    getBandsAndPrepareContainer(taxids, t0, ideo);
   });
 }
 

--- a/src/js/init/write-container.js
+++ b/src/js/init/write-container.js
@@ -7,20 +7,12 @@ import {Layout} from '../layouts/layout';
 var d3 = Object.assign({}, d3selection);
 
 /**
- * Writes the HTML elements that contain this ideogram instance.
+ * If ploidy description is a string, then convert it to the canonical
+ * array format.  String ploidyDesc is used when depicting e.g. parental
+ * origin each member of chromosome pair in a human genome.
+ * See ploidy-basic.html for usage example.
  */
-function writeContainer(bandsArray, taxid, t0) {
-  var svgClass,
-    ideo = this;
-
-  if (ideo.config.annotationsPath) {
-    ideo.fetchAnnots(ideo.config.annotationsPath);
-  }
-
-  // If ploidy description is a string, then convert it to the canonical
-  // array format.  String ploidyDesc is used when depicting e.g. parental
-  // origin each member of chromosome pair in a human genome.
-  // See ploidy-basic.html for usage example.
+function setPloidy(ideo) {
   if (
     'ploidyDesc' in ideo.config &&
     typeof ideo.config.ploidyDesc === 'string'
@@ -33,11 +25,10 @@ function writeContainer(bandsArray, taxid, t0) {
   }
   // Organism ploidy description
   ideo._ploidy = new Ploidy(ideo.config);
+}
 
-  // Chromosome's layout
-  ideo._layout = Layout.getInstance(ideo.config, ideo);
-
-  svgClass = '';
+function getContainerSvgClass(ideo) {
+  var svgClass = '';
   if (ideo.config.showChromosomeLabels) {
     if (ideo.config.orientation === 'horizontal') {
       svgClass += 'labeledLeft ';
@@ -53,25 +44,13 @@ function writeContainer(bandsArray, taxid, t0) {
     svgClass += 'faint';
   }
 
-  var gradients = ideo.getBandColorGradients();
-  var svgWidth = ideo._layout.getWidth(taxid);
-  var svgHeight = ideo._layout.getHeight(taxid);
+  return svgClass
+}
 
-  d3.select(ideo.config.container)
-    .append('div')
-    .attr('id', '_ideogramOuterWrap')
-    .append('div')
-    .attr('id', '_ideogramInnerWrap')
-    .append('svg')
-    .attr('id', '_ideogram')
-    .attr('class', svgClass)
-    .attr('width', svgWidth)
-    .attr('height', svgHeight)
-    .html(gradients);
-
-  ideo.isOnlyIdeogram = document.querySelectorAll('#_ideogram').length === 1;
-
-  // Tooltip div setup w/ default styling.
+/**
+ * Write tooltip div setup with default styling.
+ */
+function writeTooltipContainer(ideo) {
   d3.select(ideo.config.container + ' #_ideogramOuterWrap').append("div")
     .attr('class', 'tooltip')
     .attr('id', 'tooltip')
@@ -83,7 +62,39 @@ function writeContainer(bandsArray, taxid, t0) {
     .style('background', 'white')
     .style('border', '1px solid black')
     .style('border-radius', '5px');
+}
 
+function writeContainerDom(taxid, ideo) {
+  d3.select(ideo.config.container)
+    .append('div')
+    .attr('id', '_ideogramOuterWrap')
+    .append('div')
+    .attr('id', '_ideogramInnerWrap')
+    .append('svg')
+    .attr('id', '_ideogram')
+    .attr('class', getContainerSvgClass(ideo))
+    .attr('width', ideo.getBandColorGradients())
+    .attr('height', ideo._layout.getHeight(taxid))
+    .html(ideo.getBandColorGradients());
+}
+
+/**
+ * Writes the HTML elements that contain this ideogram instance.
+ */
+function writeContainer(bandsArray, taxid, t0) {
+  var ideo = this;
+
+  if (ideo.config.annotationsPath) {
+    ideo.fetchAnnots(ideo.config.annotationsPath);
+  }
+
+  setPloidy(ideo);
+  ideo._layout = Layout.getInstance(ideo.config, ideo);
+
+  writeContainerDom(taxid, ideo);
+
+  ideo.isOnlyIdeogram = document.querySelectorAll('#_ideogram').length === 1;
+  writeTooltipContainer(ideo);
   ideo.finishInit(bandsArray, t0);
 }
 

--- a/src/js/init/write-container.js
+++ b/src/js/init/write-container.js
@@ -73,7 +73,7 @@ function writeContainerDom(taxid, ideo) {
     .append('svg')
     .attr('id', '_ideogram')
     .attr('class', getContainerSvgClass(ideo))
-    .attr('width', ideo.getBandColorGradients())
+    .attr('width', ideo._layout.getWidth(taxid))
     .attr('height', ideo._layout.getHeight(taxid))
     .html(ideo.getBandColorGradients());
 }

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -19,6 +19,18 @@ function assemblyIsAccession() {
 }
 
 /**
+ * Is the assembly in this.config an NCBI Assembly accession?
+ *
+ * @returns {boolean}
+ */
+function hasNonGenBankAssembly(ideo) {
+  return (
+    'assembly' in ideo.config &&
+    /(GCA_)/.test(ideo.config.assembly) === false
+  );
+}
+
+/**
  * Returns directory used to fetch data for bands and annotations
  *
  * This simplifies ideogram configuration.  By default, the dataDir is
@@ -79,7 +91,8 @@ function getSvg() {
 }
 
 export {
-  assemblyIsAccession, getDataDir, drawChromosomeLabels, rotateChromosomeLabels,
-  round, appendHomolog, drawChromosome, rotateAndToggleDisplay, onDidRotate,
-  getSvg, setOverflowScroll, Object
+  assemblyIsAccession, hasNonGenBankAssembly, getDataDir,
+  drawChromosomeLabels, rotateChromosomeLabels, round, appendHomolog,
+  drawChromosome, rotateAndToggleDisplay, onDidRotate, getSvg,
+  setOverflowScroll, Object
 };

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -19,7 +19,7 @@ function assemblyIsAccession() {
 }
 
 /**
- * Is the assembly in this.config an NCBI Assembly accession?
+ * Is the assembly in this.config not from GenBank?
  *
  * @returns {boolean}
  */
@@ -27,6 +27,18 @@ function hasNonGenBankAssembly(ideo) {
   return (
     'assembly' in ideo.config &&
     /(GCA_)/.test(ideo.config.assembly) === false
+  );
+}
+
+/**
+ * Is the assembly in this.config from GenBank?
+ *
+ * @returns {boolean}
+ */
+function hasGenBankAssembly(ideo) {
+  return (
+    'assembly' in ideo.config &&
+    /(GCA_)/.test(ideo.config.assembly)
   );
 }
 
@@ -91,7 +103,7 @@ function getSvg() {
 }
 
 export {
-  assemblyIsAccession, hasNonGenBankAssembly, getDataDir,
+  assemblyIsAccession, hasNonGenBankAssembly, hasGenBankAssembly, getDataDir,
   drawChromosomeLabels, rotateChromosomeLabels, round, appendHomolog,
   drawChromosome, rotateAndToggleDisplay, onDidRotate, getSvg,
   setOverflowScroll, Object

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -53,10 +53,10 @@ function hasGenBankAssembly(ideo) {
  * @returns {String}
  */
 function getDataDir() {
-  var scripts = document.scripts,
+  var script, tmp, protocol, dataDir, ideogramInLeaf,
+    scripts = document.scripts,
     host = location.host.split(':')[0],
-    version = Ideogram.version,
-    script, tmp, protocol, dataDir;
+    version = Ideogram.version;
 
   if (host !== 'localhost' && host !== '127.0.0.1') {
     return (
@@ -66,10 +66,8 @@ function getDataDir() {
 
   for (var i = 0; i < scripts.length; i++) {
     script = scripts[i];
-    if (
-      'src' in script &&
-      /ideogram/.test(script.src.split('/').slice(-1))
-    ) {
+    ideogramInLeaf = /ideogram/.test(script.src.split('/').slice(-1));
+    if ('src' in script && ideogramInLeaf) {
       tmp = script.src.split('//');
       protocol = tmp[0];
       tmp = '/' + tmp[1].split('/').slice(0,-2).join('/');

--- a/src/js/ploidy.js
+++ b/src/js/ploidy.js
@@ -21,15 +21,10 @@ export class Ploidy {
 
   // Normalize use defined description
   _normalize(description) {
-    var normalized, key, descValue;
+    var key, descValue,
+      normalized = [];
 
-    // Return the same if no description provided
-    if (!description) {
-      return description;
-    }
-
-    // Array of normalized description objects
-    normalized = [];
+    if (!description) return description;
 
     // Loop through description and normalize
     for (key in description) {

--- a/src/js/services/eutils-config.js
+++ b/src/js/services/eutils-config.js
@@ -5,4 +5,28 @@ var esearch = eutils + 'esearch.fcgi?retmode=json';
 var esummary = eutils + 'esummary.fcgi?retmode=json';
 var elink = eutils + 'elink.fcgi?retmode=json';
 
-export {esearch, esummary, elink}
+function getAssemblySearchUrl(ideo) {
+  var organism, termStem, asmSearchUrl;
+
+  organism = ideo.config.organism;
+
+  if (ideo.assemblyIsAccession()) {
+    termStem = ideo.config.assembly + '%22[Assembly%20Accession]';
+  } else {
+    termStem = (
+      organism + '%22[organism]' +
+      'AND%20(%22latest%20refseq%22[filter])%20'
+    );
+  }
+
+  asmSearchUrl =
+    ideo.esearch +
+    '&db=assembly' +
+    '&term=%22' + termStem +
+    'AND%20(%22chromosome%20level%22[filter]%20' +
+    'OR%20%22complete%20genome%22[filter])';
+
+  return asmSearchUrl;
+}
+
+export {esearch, esummary, elink, getAssemblySearchUrl}

--- a/src/js/services/organisms.js
+++ b/src/js/services/organisms.js
@@ -120,74 +120,91 @@ function setTaxidAndAssemblyAndChromosomes(callback) {
   });
 }
 
+function prepareTmpChrsAndTaxids(ideo) {
+  var orgs, taxids, tmpChrs, i, org, taxid,
+    config = ideo.config;
+
+  taxids = [];
+  tmpChrs = {};
+  orgs = (config.multiorganism) ? config.organism : [config.organism];
+
+  for (i = 0; i < orgs.length; i++) {
+    // Gets a list of taxids from common organism names
+    org = orgs[i];
+    for (taxid in ideo.organisms) {
+      if (ideo.organisms[taxid].commonName.toLowerCase() === org) {
+        taxids.push(taxid);
+        if (config.multiorganism) {
+          // Adjusts 'chromosomes' configuration parameter to make object
+          // keys use taxid instead of common organism name
+          tmpChrs[taxid] = config.chromosomes[org];
+        }
+      }
+    }
+  }
+
+  return [tmpChrs, taxids];
+}
+
+function getTaxidsForOrganismInConfig(taxids, callback, ideo) {
+
+  var tmpChrs;
+
+  [tmpChrs, taxids] = prepareTmpChrsAndTaxids(ideo);
+
+  if (
+    taxids.length === 0 ||
+    ideo.assemblyIsAccession() && /GCA_/.test(ideo.config.assembly)
+  ) {
+    ideo.setTaxidAndAssemblyAndChromosomes(callback);
+  } else {
+    ideo.config.taxids = taxids;
+    if (ideo.config.multiorganism) {
+      ideo.config.chromosomes = tmpChrs;
+    }
+    callback(taxids);
+  }
+}
+
+function getIsMultiorganism(taxidInit, ideo) {
+  return (
+    ('organism' in ideo.config && ideo.config.organism instanceof Array) ||
+    (taxidInit && ideo.config.taxid instanceof Array)
+  );
+}
+
+function getTaxidsForOrganismNotInConfig(taxids, taxidInit, callback, ideo) {
+  if (ideo.config.multiorganism) {
+    ideo.coordinateSystem = 'bp';
+    if (taxidInit) {
+      taxids = ideo.config.taxid;
+    }
+  } else {
+    if (taxidInit) {
+      taxids = [ideo.config.taxid];
+    }
+    ideo.config.taxids = taxids;
+  }
+  callback(taxids);
+}
+
 /**
  * Returns an array of taxids for the current ideogram
  * Also sets configuration parameters related to taxid(s), whether ideogram is
  * multiorganism, and adjusts chromosomes parameters as needed
  **/
 function getTaxids(callback) {
-  var taxid, taxids, org, orgs, i, taxidInit, tmpChrs, multiorganism,
+  var taxids, taxidInit,
     ideo = this;
 
   taxidInit = 'taxid' in ideo.config;
 
-  ideo.config.multiorganism = (
-      ('organism' in ideo.config && ideo.config.organism instanceof Array) ||
-      (taxidInit && ideo.config.taxid instanceof Array)
-  );
-
-  multiorganism = ideo.config.multiorganism;
+  ideo.config.multiorganism = getIsMultiorganism(taxidInit, ideo);
 
   if ('organism' in ideo.config) {
-    // Ideogram instance was constructed using common organism name(s)
-    if (multiorganism) {
-      orgs = ideo.config.organism;
-    } else {
-      orgs = [ideo.config.organism];
-    }
-
-    taxids = [];
-    tmpChrs = {};
-    for (i = 0; i < orgs.length; i++) {
-      // Gets a list of taxids from common organism names
-      org = orgs[i];
-      for (taxid in ideo.organisms) {
-        if (ideo.organisms[taxid].commonName.toLowerCase() === org) {
-          taxids.push(taxid);
-          if (multiorganism) {
-            // Adjusts 'chromosomes' configuration parameter to make object
-            // keys use taxid instead of common organism name
-            tmpChrs[taxid] = ideo.config.chromosomes[org];
-          }
-        }
-      }
-    }
-
-    if (
-        taxids.length === 0 ||
-        ideo.assemblyIsAccession() && /GCA_/.test(ideo.config.assembly)
-    ) {
-      ideo.setTaxidAndAssemblyAndChromosomes(callback);
-    } else {
-      ideo.config.taxids = taxids;
-      if (multiorganism) {
-        ideo.config.chromosomes = tmpChrs;
-      }
-      callback(taxids);
-    }
+    getTaxidsForOrganismInConfig(taxids, callback, ideo)
   } else {
-    if (multiorganism) {
-      ideo.coordinateSystem = 'bp';
-      if (taxidInit) {
-        taxids = ideo.config.taxid;
-      }
-    } else {
-      if (taxidInit) {
-        taxids = [ideo.config.taxid];
-      }
-      ideo.config.taxids = taxids;
-    }
-    callback(taxids);
+    getTaxidsForOrganismNotInConfig(taxids, taxidInit, callback, ideo);
   }
 }
 

--- a/src/js/services/organisms.js
+++ b/src/js/services/organisms.js
@@ -208,7 +208,28 @@ function getTaxids(callback) {
   }
 }
 
+/**
+ * Searches NCBI EUtils for the common organism name for this ideogram
+ * instance's taxid (i.e. NCBI Taxonomy ID)
+ *
+ * @param callback Function to call upon completing ESearch request
+ */
+function getOrganismFromEutils(callback) {
+  var organism, taxonomySearch, taxid,
+    ideo = this;
+
+  taxid = ideo.config.organism;
+
+  taxonomySearch = ideo.esummary + '&db=taxonomy&id=' + taxid;
+
+  d3.json(taxonomySearch).then(function(data) {
+    organism = data.result[String(taxid)].commonname;
+    ideo.config.organism = organism;
+    return callback(organism);
+  });
+}
+
 export {
   getTaxidFromEutils, setTaxidAndAssemblyAndChromosomes, getTaxids,
-  setTaxidData
+  setTaxidData, getOrganismFromEutils
 }

--- a/src/js/sex-chromosomes.js
+++ b/src/js/sex-chromosomes.js
@@ -54,19 +54,16 @@ function drawSexChromosomes(container, chrIndex) {
  *  https://en.wikipedia.org/wiki/Category:Sex_chromosome_aneuploidies
  */
 function setSexChromosomes(chrs) {
-  if (this.config.ploidy !== 2 || !this.config.sex) {
-    return;
-  }
+  var chr, i,
+    ideo = this,
+    sexChrs = {X: 1, Y: 1};
 
-  var ideo = this,
-    sexChrs = {X: 1, Y: 1},
-    chr, i;
+  if (this.config.ploidy !== 2 || !this.config.sex) return;
 
   ideo.sexChromosomes.list = [];
 
   for (i = 0; i < chrs.length; i++) {
     chr = chrs[i];
-
     if (ideo.config.sex === 'male' && chr in sexChrs) {
       ideo.sexChromosomes.list.push(chr);
       if (!ideo.sexChromosomes.index) {

--- a/test/web-test.js
+++ b/test/web-test.js
@@ -386,12 +386,12 @@ describe('Ideogram', function() {
     var ideogram = new Ideogram(config);
   });
 
-  it('should have 48 annotations in overlaid annotations example', function(done) {
+  it('should have 1000 annotations in overlaid annotations example', function(done) {
     // Tests use case from old ../examples/vanilla/annotations-overlaid.html
 
     function callback() {
       var numAnnots = document.getElementsByClassName('annot').length;
-      assert.equal(numAnnots, 48);
+      assert.equal(numAnnots, 1000);
       done();
     }
 


### PR DESCRIPTION
This refactors almost all of Ideogram's large, monolithic methods into smaller, more modular methods that are 25 lines or smaller.  It continues the campaign for better maintainability begun in #103.

In its functional-style runtime code, Ideogram had 88 large methods before this change, and has 183 small methods now.  Entire methods now almost always fit in one screen, and significant blocks of code that were often uncommented are more understandable at a glance through methods names.




