### PR TITLE
Heatmap track filter

### DIFF
--- a/examples/vanilla/annotations-track-filters.html
+++ b/examples/vanilla/annotations-track-filters.html
@@ -7,7 +7,7 @@
         html, body { height: 100%; font: 12px Arial; line-height: 19.6px; }
         ul { float: left; padding-left: 5px}
         li { list-style: none; }
-        #ideogram-container { float: left;}
+        #filters-container ul { clear: both; margin-right: 20px; }
     </style>
 </head>
 <body>
@@ -19,23 +19,32 @@
     Select up to 3 of 9 tracks to display.  See also <a href="annotations-tracks">Annotations, tracks</a>.
 </p>
 
-<ul id="tracks-to-display">
-    Tracks to display
-    <li><label for="filter_1"><input type="checkbox" id="filter_1" checked/>A</label></li>
-    <li><label for="filter_2"><input type="checkbox" id="filter_2"/>B</label></li>
-    <li><label for="filter_3"><input type="checkbox" id="filter_3"/>C</label></li>
-    <li><label for="filter_4"><input type="checkbox" id="filter_4"/>D</label></li>
-    <li><label for="filter_5"><input type="checkbox" id="filter_5" checked/>E</label></li>
-    <li><label for="filter_6"><input type="checkbox" id="filter_6"/>F</label></li>
-    <li><label for="filter_7"><input type="checkbox" id="filter_7"/>G</label></li>
-    <li><label for="filter_8"><input type="checkbox" id="filter_8"/>H</label></li>
-    <li><label for="filter_9"><input type="checkbox" id="filter_9" checked/>I</label></li>
-</ul>
+<div id="filters-container">
+  <ul id="tracks-to-display">
+      Tracks to display
+      <li><label for="filter_1"><input type="checkbox" id="filter_1" checked/>A</label></li>
+      <li><label for="filter_2"><input type="checkbox" id="filter_2"/>B</label></li>
+      <li><label for="filter_3"><input type="checkbox" id="filter_3"/>C</label></li>
+      <li><label for="filter_4"><input type="checkbox" id="filter_4"/>D</label></li>
+      <li><label for="filter_5"><input type="checkbox" id="filter_5" checked/>E</label></li>
+      <li><label for="filter_6"><input type="checkbox" id="filter_6"/>F</label></li>
+      <li><label for="filter_7"><input type="checkbox" id="filter_7"/>G</label></li>
+      <li><label for="filter_8"><input type="checkbox" id="filter_8"/>H</label></li>
+      <li><label for="filter_9"><input type="checkbox" id="filter_9" checked/>I</label></li>
+  </ul>
+
+  <ul id="annotations-layout">
+    Annotations layout
+    <li><label for="shapes"><input type="radio" id="tracks" name="layout" checked/>Shapes</label></li>
+    <li><label for="heatmap"><input type="radio" id="heatmap" name="layout"/>Heatmap</label></li>
+  </ul>
+</div>
+
 <div id="ideogram-container"></div>
 
 <script type="text/javascript">
 
-  var config, ideogram, inputs;
+  var config, ideogram, checkboxes, annotsLayout;
 
   config = {
     organism: 'human',
@@ -43,31 +52,53 @@
     chrHeight: 400,
     annotationsPath: '../../data/annotations/9_tracks_virtual_snvs.json',
     annotationsNumTracks: 3,
+    chrMargin: 8,
     annotationsDisplayedTracks: [1, 5, 9]
   };
 
   ideogram = new Ideogram(config);
 
-  inputs = document.querySelectorAll('input');
-
-  inputs.forEach(function(input) {
-    input.addEventListener('click', function() {
+  checkboxes = document.querySelectorAll('input[type=checkbox]');
+  checkboxes.forEach(function(checkbox) {
+    checkbox.addEventListener('click', function() {
       updateTracks();
     });
   });
 
-  function updateTracks() {
+  radioButtons = document.querySelectorAll('input[type=radio]');
+  radioButtons.forEach(function(radioButton) {
+    radioButton.addEventListener('click', function() {
+      updateIdeogram();
+    });
+  });
 
-    // Get selected tracks
+  function getSelectedTracks() {
     var selectedTracks = [];
-    inputs.forEach(function(input) {
-      var trackIndex = parseInt(input.getAttribute('id').split('_')[1]);
-      if (input.checked) {
+    
+    checkboxes.forEach(function(checkbox) {
+      var trackIndex = parseInt(checkbox.getAttribute('id').split('_')[1]);
+      if (checkbox.checked) {
         selectedTracks.push(trackIndex);
       }
     });
+    
+    return selectedTracks;
+  }
 
+  function updateTracks() {
+    var selectedTracks = getSelectedTracks();
     ideogram.updateDisplayedTracks(selectedTracks);
+  }
+
+  function updateIdeogram() {
+    
+    var tracks = getSelectedTracks();
+    var layout = document.querySelector('input[name=layout]:checked').id;
+    
+    config.annotationsDisplayedTracks = tracks;
+    config.annotationsLayout = layout;
+
+    ideogram = new Ideogram(config);
   }
 
 </script>

--- a/examples/vanilla/annotations-track-filters.html
+++ b/examples/vanilla/annotations-track-filters.html
@@ -35,8 +35,8 @@
 
   <ul id="annotations-layout">
     Annotations layout
-    <li><label for="shapes"><input type="radio" id="tracks" name="layout" checked/>Shapes</label></li>
-    <li><label for="heatmap"><input type="radio" id="heatmap" name="layout"/>Heatmap</label></li>
+    <li><label for="heatmap"><input type="radio" id="heatmap" name="layout" checked/>Heatmap</label></li>
+    <li><label for="tracks"><input type="radio" id="tracks" name="layout"/>Shapes</label></li>
   </ul>
 </div>
 
@@ -53,7 +53,8 @@
     annotationsPath: '../../data/annotations/9_tracks_virtual_snvs.json',
     annotationsNumTracks: 3,
     chrMargin: 8,
-    annotationsDisplayedTracks: [1, 5, 9]
+    annotationsDisplayedTracks: [1, 5, 9],
+    annotationsLayout: 'heatmap'
   };
 
   ideogram = new Ideogram(config);

--- a/src/js/annotations/filter.js
+++ b/src/js/annotations/filter.js
@@ -45,7 +45,7 @@ function getDisplayedRawAnnotsByChr(annotsByChr, trackIndexes) {
  * @param trackIndexes Array of indexes of tracks to display
  */
 function updateDisplayedTracks(trackIndexes) {
-  var displayedRawAnnotsByChr, displayedAnnots, rawAnnots, trackIndex,
+  var displayedRawAnnotsByChr, displayedAnnots, rawAnnots,
     ideo = this,
     annotsByChr = ideo.rawAnnots.annots;
 
@@ -53,14 +53,12 @@ function updateDisplayedTracks(trackIndexes) {
 
   displayedRawAnnotsByChr =
     getDisplayedRawAnnotsByChr(annotsByChr, trackIndexes);
-
   rawAnnots = {keys: ideo.rawAnnots.keys, annots: displayedRawAnnotsByChr};
 
   displayedAnnots = ideo.processAnnotData(rawAnnots);
 
   d3.selectAll(ideo.selector + ' .annot').remove();
   ideo.drawAnnots(displayedAnnots);
-
   ideogram.displayedTrackIndexes = trackIndexes;
 
   return displayedAnnots;

--- a/src/js/annotations/heatmap.js
+++ b/src/js/annotations/heatmap.js
@@ -13,12 +13,12 @@ function writeCanvases(chr, chrLeft, chrWidth, ideoHeight, ideo) {
   // Create a canvas for each annotation track on this chromosome
   for (j = 0; j < numAnnotTracks; j++) {
     trackWidth = chrWidth - 1;
-    trackLeft = chrLeft + j * chrWidth - (trackWidth * numAnnotTracks);
+    trackLeft = chrLeft - trackWidth * (numAnnotTracks - j);
     trackLeft -= marginHack;
     canvas = d3.select(ideo.config.container + ' #_ideogramInnerWrap')
       .append('canvas')
       .attr('id', chr.id + '-canvas-' + j)
-      .attr('width', chrWidth - 1)
+      .attr('width', trackWidth)
       .attr('height', ideoHeight)
       .style('position', 'absolute')
       .style('left', trackLeft + 'px');
@@ -69,7 +69,7 @@ function drawHeatmaps(annotContainers) {
     chrWidth = ideo.config.chrWidth;
     chrLeft = ideo._layout.getChromosomeSetYTranslate(i);
 
-    contextArray = writeCanvases(chr, chrLeft, chrWidth, ideoHeight, ideo)
+    contextArray = writeCanvases(chr, chrLeft, chrWidth, ideoHeight, ideo);
     fillCanvasAnnots(annots, contextArray, chrWidth, ideoMarginTop);
   }
 

--- a/src/js/init/write-container.js
+++ b/src/js/init/write-container.js
@@ -65,6 +65,10 @@ function writeTooltipContainer(ideo) {
 }
 
 function writeContainerDom(taxid, ideo) {
+
+  // Remove any previous container content
+  d3.selectAll(ideo.config.container + ' #_ideogramOuterWrap').remove();
+
   d3.select(ideo.config.container)
     .append('div')
     .attr('id', '_ideogramOuterWrap') // contains tooltip + all else

--- a/src/js/layouts/layout.js
+++ b/src/js/layouts/layout.js
@@ -234,7 +234,7 @@ export class Layout {
 
   _getAdditionalOffset() {
     return (
-      (this._config.annotationHeight || 0) * (this._config.numAnnotTracks || 1)
+      (this._config.annotationHeight || 0) * (this._config.annotationsNumTracks || 1)
     );
   }
 

--- a/test/web-test.js
+++ b/test/web-test.js
@@ -712,7 +712,7 @@ describe('Ideogram', function() {
     ideogram = new Ideogram(config);
   });
 
-  it('should have filterable tracks in track-filters example', function(done) {
+  it('should have filterable tracks in track filters example', function(done) {
     // Tests use case from ../examples/vanilla/annotations-track-filters.html
 
     var firstRun = true;
@@ -728,7 +728,7 @@ describe('Ideogram', function() {
       var numAnnots = document.getElementsByClassName('annot').length;
       assert.equal(numAnnots, 696);
 
-      // Filters tracks to show only 4th and 5th track (of 20)
+      // Filters tracks to show only 4th and 5th track (of 9)
       ideogram.updateDisplayedTracks([4, 5]);
       numAnnots = document.getElementsByClassName('annot').length;
       assert.equal(numAnnots, 620);
@@ -743,6 +743,54 @@ describe('Ideogram', function() {
       annotationsNumTracks: 3,
       annotationsDisplayedTracks: [1, 5, 9],
       onDrawAnnots: callback
+    };
+
+    ideogram = new Ideogram(config);
+  });
+
+  it('should filter heatmap tracks', function(done) {
+    // Tests use case from ../examples/vanilla/annotations-track-filters.html
+
+    var firstRun = true;
+
+    function callback() {
+
+      var track1, track2, track3;
+
+      if (firstRun) {
+        firstRun = false;
+      } else {
+        return;
+      }
+
+      track1 = document.querySelector('#chr2-9606-canvas-0').getBoundingClientRect();
+      track2 = document.querySelector('#chr2-9606-canvas-1').getBoundingClientRect();
+      track3 = document.querySelector('#chr2-9606-canvas-2').getBoundingClientRect();
+
+      assert.equal(track1.x, 62);
+      assert.equal(track2.x, 71);
+      assert.equal(track3.x, 80);
+
+      // Filters tracks to show only 4th and 5th track (of 9)
+      ideogram.updateDisplayedTracks([4, 5]);
+
+      track1 = document.querySelector('#chr2-9606-canvas-0').getBoundingClientRect();
+      track2 = document.querySelector('#chr2-9606-canvas-1').getBoundingClientRect();
+
+      assert.equal(track1.x, 71);
+      assert.equal(track2.x, 80);
+
+      done();
+    }
+
+    var config = {
+      organism: 'human',
+      annotationsPath: '../dist/data/annotations/9_tracks_virtual_snvs.json',
+      dataDir: '/dist/data/bands/native/',
+      annotationsNumTracks: 3,
+      annotationsDisplayedTracks: [1, 5, 9],
+      onDrawAnnots: callback,
+      annotationsLayout: 'heatmap'
     };
 
     ideogram = new Ideogram(config);


### PR DESCRIPTION
This enables filtering tracks when annotations have a heatmap layout.  

It extends "[Filtering annotations by track](https://github.com/eweitz/ideogram/pull/100)" with support for heatmaps, which requires special handling as heatmaps render via canvas instead of SVG.