### PR TITLE
Fix issue 115/116 - annotation position

### DIFF
--- a/src/js/init/write-container.js
+++ b/src/js/init/write-container.js
@@ -55,13 +55,14 @@ function writeTooltipContainer(ideo) {
     .attr('class', '_ideogramTooltip')
     .attr('id', '_ideogramTooltip')
     .style('opacity', 0)
-    .style('position', 'absolute')
+    .style('position', 'fixed')
     .style('text-align', 'center')
     .style('padding', '4px')
     .style('font', '12px sans-serif')
     .style('background', 'white')
     .style('border', '1px solid black')
-    .style('border-radius', '5px');
+    .style('border-radius', '5px')
+    .style('z-index', '100');
 }
 
 function writeContainerDom(taxid, ideo) {


### PR DESCRIPTION
In order to fix the above issues I just modified the `style` of  `_ideogramTooltip`. I added a `z-index:100` to address https://github.com/eweitz/ideogram/issues/116 and modified `position:fixed` to address https://github.com/eweitz/ideogram/issues/115. Below is a GIF, show casing the following changes working.

![ideogram-issue-115-116](https://user-images.githubusercontent.com/33464965/48880037-c986d180-edcb-11e8-9b9c-57c99a4189fc.gif)
