### PR TITLE
Legend for annotations

### DIFF
--- a/api.md
+++ b/api.md
@@ -43,6 +43,7 @@ var ideogram = new Ideogram({
 * [heatmaps](#heatmaps)
 * [filterable](#filterable)
 * [fullChromosomeLabels](#fullchromosomelabels)
+* [legend](#legend)
 * [onBrushMove](#onbrushmove)
 * [onDidRotate](#ondidrotate)
 * [onDrawAnnots](#ondrawannots)
@@ -143,6 +144,9 @@ Boolean.  Optional.  Whether annotations should be filterable.  Example in [Anno
 
 ## fullChromosomeLabels
 Boolean.  Optional.  Whether to include abbreviation species name in chromosome label.  Example in [Homology, interspecies](https://eweitz.github.io/ideogram/homology-interspecies).
+
+## legend
+Array.  Optional.  List of objects describing annotations.  Example in [Annotations, tracks](https://eweitz.github.io/ideogram/annotations-tracks).
 
 ## onBrushMove
 Function.  Optional.  Callback function to invoke when brush moves.  Example in [Brush](https://eweitz.github.io/ideogram/brush).

--- a/examples/vanilla/annotations-heatmap.html
+++ b/examples/vanilla/annotations-heatmap.html
@@ -44,24 +44,43 @@
     {id: 'geneTypeTrack', displayName: 'Gene type'},
   ];
 
+  var legend = [
+    {
+      name: 'Expression level',
+      rows: [
+        {color: '#88F', name: 'Low'},
+        {color: '#CCC', name: 'Medium'},
+        {color: '#F33', name: 'High'}
+      ]
+    },
+    {
+      name: 'Gene type',
+      rows: [
+        {color: '#00F', name: 'mRNA'},
+        {color: '#0AF', name: 'misc_RNA'},
+        {color: '#AAA', name: 'miRNA'},
+        {color: '#FA0', name: 'tRNA'},
+        {color: '#F00', name: 'lncRNA'}
+      ]
+    }
+  ]
+
   var heatmaps = [
       {
         key: 'expression-level',
-        displayName: 'Expression level',
         thresholds: [
-          ['2', '#88F', 'Low'],
-          ['4', '#CCC', 'Medium'],
-          ['+', '#F33', 'High']]
+          ['2', '#88F'],
+          ['4', '#CCC'],
+          ['+', '#F33']]
       },
       {
         key: 'gene-type',
-        displayName: 'Gene type',
         thresholds: [
-          ['0', '#00F', 'mRNA'],
-          ['1', '#0AF', 'misc_RNA'],
-          ['2', '#AAA', 'miRNA'],
-          ['3', '#FA0', 'tRNA'],
-          ['4', '#F00', 'lncRNA']
+          ['0', '#00F'],
+          ['1', '#0AF'],
+          ['2', '#AAA'],
+          ['3', '#FA0'],
+          ['4', '#F00']
         ]
       }
     ]
@@ -73,6 +92,7 @@
     chrHeight: 275,
     annotationsPath: '../../data/annotations/SRR562646.json',
     annotationsLayout: 'heatmap',
+    legend: legend,
     heatmaps: heatmaps,
     annotationTracks: annotationTracks,
     rotatable: false // Support for rotatable heatmaps is planned

--- a/examples/vanilla/annotations-heatmap.html
+++ b/examples/vanilla/annotations-heatmap.html
@@ -44,6 +44,26 @@
     {id: 'geneTypeTrack', displayName: 'Gene type'},
   ];
 
+  var heatmaps = [
+      {
+        key: 'expression-level',
+        thresholds: [
+          ['2', '#88F', 'Low'],
+          ['4', '#CCC', 'Medium'],
+          ['+', '#F33', 'High']]
+      },
+      {
+        key: 'gene-type',
+        thresholds: [
+          ['0', '#00F', 'mRNA'],
+          ['1', '#0AF', 'misc_RNA'],
+          ['2', '#AAA', 'miRNA'],
+          ['3', '#FA0', 'tRNA'],
+          ['4', '#F00', 'lncRNA']
+        ]
+      }
+    ]
+
   var config = {
     container: '#container',
     organism: 'human',
@@ -51,16 +71,7 @@
     chrHeight: 275,
     annotationsPath: '../../data/annotations/SRR562646.json',
     annotationsLayout: 'heatmap',
-    heatmaps: [
-      {
-        key: 'expression-level',
-        thresholds: [['2', '#88F'], ['4', '#CCC'], ['+', '#F33']]
-      },
-      {
-        key: 'gene-type',
-        thresholds: [['0', '#00F'], ['1', '#0AF'], ['2', '#AAA'], ['3', '#FA0'], ['4', '#F00']]
-      }
-    ],
+    heatmaps: heatmaps,
     annotationTracks: annotationTracks,
     rotatable: false // Support for rotatable heatmaps is planned
   };

--- a/examples/vanilla/annotations-heatmap.html
+++ b/examples/vanilla/annotations-heatmap.html
@@ -47,6 +47,7 @@
   var heatmaps = [
       {
         key: 'expression-level',
+        displayName: 'Expression level',
         thresholds: [
           ['2', '#88F', 'Low'],
           ['4', '#CCC', 'Medium'],
@@ -54,6 +55,7 @@
       },
       {
         key: 'gene-type',
+        displayName: 'Gene type',
         thresholds: [
           ['0', '#00F', 'mRNA'],
           ['1', '#0AF', 'misc_RNA'],

--- a/examples/vanilla/annotations-tracks.html
+++ b/examples/vanilla/annotations-tracks.html
@@ -13,8 +13,7 @@
 <a href="annotations-external-data">Next</a>
 <p>
   1000 <a href="https://github.com/eweitz/ideogram/blob/ca64a3c51e1b5ecaae89d2422ffc408565743644/scripts/create_annots.py#L68">
-  randomly generated</a> SNVs across the human genome, artificially categorized
-  as "pathogenic" (red), "uncertain significance" (grey) or "benign" (green).
+  randomly generated</a> SNVs across the human genome. 
   See also <a href="annotations-track-filters">Annotations, track filters</a>.
   <br/>
   <br/>
@@ -56,13 +55,23 @@
       {id: 'benignTrack',  displayName: 'Benign', color: '#8D4', shape: shape}
     ];
 
+    var legend = [{
+      name: 'Clinical significance (simulated)',
+      rows: [
+        {name: 'Pathogenic', color: '#F00'},
+        {name: 'Uncertain significance', color: '#CCC'},
+        {name: 'Benign', color: '#8D4'}
+      ]
+    }];
+
     var config = {
       organism: 'human',
       orientation: 'vertical',
       chrWidth: 8,
       annotationsPath: '../../data/annotations/1000_virtual_snvs.json',
       annotationTracks: annotationTracks,
-      annotationHeight: annotHeight
+      annotationHeight: annotHeight,
+      legend: legend
     };
 
     if (typeof ideogram !== 'undefined') {

--- a/examples/vanilla/annotations-tracks.html
+++ b/examples/vanilla/annotations-tracks.html
@@ -58,9 +58,9 @@
     var legend = [{
       name: 'Clinical significance (simulated)',
       rows: [
-        {name: 'Pathogenic', color: '#F00'},
-        {name: 'Uncertain significance', color: '#CCC'},
-        {name: 'Benign', color: '#8D4'}
+        {name: 'Pathogenic', color: '#F00', shape: shape},
+        {name: 'Uncertain significance', color: '#CCC', shape: shape},
+        {name: 'Benign', color: '#8D4', shape: shape}
       ]
     }];
 

--- a/src/js/annotations/draw.js
+++ b/src/js/annotations/draw.js
@@ -1,5 +1,7 @@
 import * as d3selection from 'd3-selection';
+
 import {writeHistogramAnnots} from './histogram';
+import { writeLegend } from './legend'
 
 var d3 = Object.assign({}, d3selection);
 
@@ -213,6 +215,8 @@ function drawProcessedAnnots(annots) {
 
   layout = 'tracks';
   if (ideo.config.annotationsLayout) layout = ideo.config.annotationsLayout;
+
+  if ('legend' in ideo.config) writeLegend(ideo);
 
   if (layout === 'heatmap') {
     ideo.drawHeatmaps(annots);

--- a/src/js/annotations/heatmap.js
+++ b/src/js/annotations/heatmap.js
@@ -9,9 +9,10 @@ import * as d3selection from 'd3-selection';
 
 var d3 = Object.assign({}, d3selection);
 
+import { writeLegend } from './legend'
 import {
   startHideTrackLabelTimeout, writeTrackLabelContainer, showTrackLabel
-} from './track-labels'
+} from './track-labels';
 
 /**
  * Add canvases that will contain annotations.  One canvas per track.
@@ -237,6 +238,8 @@ function deserializeAnnotsForHeatmap(rawAnnotsContainer) {
 
   ideo.rawAnnots.keys = keys;
   ideo.rawAnnots.annots = newRaContainers;
+
+  writeLegend(ideo);
 
   reportPerformance(t0, ideo);
 }

--- a/src/js/annotations/heatmap.js
+++ b/src/js/annotations/heatmap.js
@@ -9,7 +9,6 @@ import * as d3selection from 'd3-selection';
 
 var d3 = Object.assign({}, d3selection);
 
-import { writeLegend } from './legend'
 import {
   startHideTrackLabelTimeout, writeTrackLabelContainer, showTrackLabel
 } from './track-labels';
@@ -238,8 +237,6 @@ function deserializeAnnotsForHeatmap(rawAnnotsContainer) {
 
   ideo.rawAnnots.keys = keys;
   ideo.rawAnnots.annots = newRaContainers;
-
-  writeLegend(ideo);
 
   reportPerformance(t0, ideo);
 }

--- a/src/js/annotations/legend.js
+++ b/src/js/annotations/legend.js
@@ -2,44 +2,61 @@ import * as d3selection from 'd3-selection';
 
 var d3 = Object.assign({}, d3selection);
 
+var lineHeight = 19;
+
+function getListItems(labels, svg, hasDisplayName, heatmap) {
+  var j, threshold, color, label, y;
+
+  for (j = 0; j < heatmap.thresholds.length; j++) {
+    threshold = heatmap.thresholds[j];
+    y = j * lineHeight;
+    if (hasDisplayName) y += lineHeight;
+    color = '<rect height="10" width="10" y="5" fill="' + threshold[1] + '"/>';
+    label = '<li>' + threshold[2] + '</li>';
+    svg += '<g transform="translate(0, ' + y + ')">' + color + '</g>'
+    labels += label;
+  }
+
+  return [labels, svg];
+}
+
+function getHeader(heatmap) {
+  var labels, hasDisplayName;
+  labels = '';
+  hasDisplayName = false;
+  if ('displayName' in heatmap) {
+    labels +=
+      '<span style="position: relative; left: -15px;">' +
+        heatmap.displayName +
+      '</span>';
+    hasDisplayName = true;
+  }
+  return [labels, hasDisplayName];
+}
+
 function writeHeatmapLegend(ideo) {
-  var heatmaps, thresholdHasLabel, i, j, thresholds, threshold, legend,
-    row, y, color, label, hasDisplayName, lineHeight, numPrevThresholds;
+  var heatmaps, thresholdHasLabel, i, heatmap, legend, hasDisplayName, svg,
+    labels, legendStyle;
 
-  lineHeight = 14
-
-  legend = [];
-  heatmaps = ideo.config.heatmaps,
+  heatmaps = ideo.config.heatmaps;
   thresholdHasLabel = heatmaps[0].thresholds[0].length > 2;
-
   if (!thresholdHasLabel) return;
 
+  legend = '';
+  legendStyle = 'position: relative; top: -11px; left: -14px;';
+
   for (i = 0; i < heatmaps.length; i++) {
-    thresholds = heatmaps[i].thresholds;
-    hasDisplayName = false;
-    if (i !== 0) numPrevThresholds = heatmaps[i - 1].thresholds.length;
-    if ('displayName' in heatmaps[i]) {
-      y = lineHeight;
-      if (i !== 0) y += numPrevThresholds * lineHeight + lineHeight*2;
-      legend.push('<text y="' + y + '">' + heatmaps[i].displayName + '</text>');
-      hasDisplayName = true;
-    }
-    for (j = 0; j < thresholds.length; j++) {
-      threshold = thresholds[j];
-      y = (j + 1) * lineHeight;
-      if (i !== 0) y += numPrevThresholds * lineHeight + lineHeight;
-      if (hasDisplayName && i > 0) y += lineHeight;
-      color = '<rect height="10" width="10" y="5" fill="' + threshold[1] + '"/>';
-      label = '<text x="15" y="14">' + threshold[2] + '</text>';
-      row = color + label
-      row = '<g transform="translate(0, ' + y + ')">' + row + '</g>'
-      legend.push(row);
-    }
+    heatmap = heatmaps[i];
+    [labels, hasDisplayName] = getHeader(heatmap);
+    svg = '<svg width="' + lineHeight + '" style="float: left">';
+    [labels, svg] = getListItems(labels, svg, hasDisplayName, heatmap);
+    svg += '</svg>'
+    legend += svg + '<ul style="' + legendStyle + '">' + labels + '</ul>';
   }
 
   d3.select(ideo.config.container + ' #_ideogramOuterWrap')
-    .append('svg')
-      .attr('id', 'legend')
+    .append('div')
+      .attr('id', '_ideogramLegend')
       .html(legend);
 }
 

--- a/src/js/annotations/legend.js
+++ b/src/js/annotations/legend.js
@@ -13,18 +13,37 @@ var legendStyle =
   '} ' +
   '#_ideogramLegend ul span {position: relative; left: -15px;} ';
 
+function getIcon(row) {
+  var icon, triangleAttrs, circleAttrs, rectAttrs,
+    fill = 'fill="' + row.color + '" style="stroke: #AAA;"',
+    shape = row.shape;
+
+  triangleAttrs = 'd="m7,3 l -5 9 l 9 0 z"';
+  circleAttrs = 'd="m2,9a 4.5,4.5 0 1,0 9,0a 4.5,4.5 0 1,0 -9,0"';
+  rectAttrs = 'height="10" width="10"  y="3"';
+
+  if ('shape' in row && ['circle', 'triangle'].includes(shape)) {
+    if (shape === 'circle') {
+      icon = '<path ' + circleAttrs + ' ' + fill + '></path>';
+    } else if (shape === 'triangle') {
+      icon = '<path ' + triangleAttrs + ' ' + fill + '></path>';
+    }
+  } else {
+    icon = '<rect ' + rectAttrs + ' ' + fill + '/>';
+  }
+
+  return icon;
+}
+
 function getListItems(labels, svg, list) {
-  var i, color, y, rectAttrs, row;
-
-  rectAttrs = 'height="10" width="10"  y="4" style="stroke: #888;"';
-
+  var i, icon, y, row;
   for (i = 0; i < list.rows.length; i++) {
     row = list.rows[i];
     labels += '<li>' + row.name + '</li>';
     y = lineHeight * i;
     if ('name' in list) y += lineHeight;
-    color = '<rect ' + rectAttrs + ' fill="' + row.color + '"/>';
-    svg += '<g transform="translate(0, ' + y + ')">' + color + '</g>';
+    icon = getIcon(row);
+    svg += '<g transform="translate(0, ' + y + ')">' + icon + '</g>';
   }
 
   return [labels, svg];

--- a/src/js/annotations/legend.js
+++ b/src/js/annotations/legend.js
@@ -33,6 +33,8 @@ function getListItems(labels, svg, list) {
 function writeLegend(ideo) {
   var i, legend, svg, labels, list, content;
 
+  d3.select(ideo.config.container + ' #_ideogramLegend').remove();
+
   legend = ideo.config.legend;
   content = '';
 

--- a/src/js/annotations/legend.js
+++ b/src/js/annotations/legend.js
@@ -9,14 +9,14 @@ var legendStyle =
   '#_ideogramLegend svg {float: left;} ' +
   '#_ideogramLegend ul {' +
     'position: relative; left: -14px; list-style: none; float: left; ' +
-    'padding-left: 10px;' +
+    'padding-left: 10px; margin-top: 0px;' +
   '} ' +
   '#_ideogramLegend ul span {position: relative; left: -15px;} ';
 
 function getListItems(labels, svg, hasName, list) {
   var i, color, y, rectAttrs, row;
 
-  rectAttrs = 'height="10" width="10"  y="5" style="stroke: #888;"';
+  rectAttrs = 'height="10" width="10"  y="4" style="stroke: #888;"';
 
   for (i = 0; i < list.rows.length; i++) {
     row = list.rows[i];

--- a/src/js/annotations/legend.js
+++ b/src/js/annotations/legend.js
@@ -7,7 +7,7 @@ function writeHeatmapLegend(ideo) {
     row, y, color, label;
 
   legend = [];
-  heatmaps = config.heatmaps,
+  heatmaps = ideo.config.heatmaps,
   thresholdHasLabel = heatmaps[0].thresholds[0].length > 2;
 
   if (!thresholdHasLabel) return;
@@ -25,9 +25,6 @@ function writeHeatmapLegend(ideo) {
       legend.push(row);
     }
   }
-  // legend = '<g>' + legend.join('</g><g>') + '</g>';
-
-  console.log(legend);
 
   d3.select(ideo.config.container + ' #_ideogramOuterWrap')
     .append('svg')

--- a/src/js/annotations/legend.js
+++ b/src/js/annotations/legend.js
@@ -1,0 +1,41 @@
+import * as d3selection from 'd3-selection';
+
+var d3 = Object.assign({}, d3selection);
+
+function writeHeatmapLegend(ideo) {
+  var heatmaps, thresholdHasLabel, i, j, thresholds, threshold, legend,
+    color, label;
+
+  legend = [];
+  heatmaps = config.heatmaps,
+  thresholdHasLabel = heatmaps[0].thresholds[0].length > 2;
+
+  if (!thresholdHasLabel) return;
+
+  for (i = 0; i < heatmaps.length; i++) {
+    thresholds = heatmaps[i].thresholds;
+    for (j = 0; j < thresholds.length; j++) {
+      threshold = thresholds[j];
+      color = '<rect style="clear: left; height: 10px;" fill="' + threshold[1] + '"/>';
+      label = '<text>' + threshold[2] + '</text>';
+      legend.push(color + label);
+    }
+  }
+  legend = '<g>' + legend.join('</g><g>') + '</g>';
+
+  console.log(legend);
+
+  d3.select(ideo.config.container + ' #_ideogramOuterWrap')
+    .append('svg')
+      .attr('id', 'legend')
+      .html(legend);
+}
+
+function writeLegend(ideo) {
+  var config = ideo.config;
+  if (config.heatmaps) {
+    writeHeatmapLegend(ideo);
+  }
+}
+
+export { writeLegend }

--- a/src/js/annotations/legend.js
+++ b/src/js/annotations/legend.js
@@ -4,6 +4,14 @@ var d3 = Object.assign({}, d3selection);
 
 var lineHeight = 19;
 
+var legendStyle =
+  '#_ideogramLegend {font: 12px Arial, line-height: 19.6px;} ' +
+  '#_ideogramLegend svg {float: left;} ' +
+  '#_ideogramLegend ul {' +
+    'position: relative; left: -14px; list-style: none, float: left;' +
+  '} ' +
+  '#_ideogramLegend ul span {position: relative; left: -15px;} ';
+
 function getListItems(labels, svg, hasName, list) {
   var i, color, y, rectAttrs, row;
 
@@ -26,35 +34,30 @@ function getHeader(list) {
   labels = '';
   hasName = false;
   if ('name' in list) {
-    labels +=
-      '<span style="position: relative; left: -15px;">' +
-        list.name +
-      '</span>';
+    labels += '<span>' + list.name + '</span>';
     hasName = true;
   }
   return [labels, hasName];
 }
 
 function writeLegend(ideo) {
-  var i, legend, hasName, svg, labels, legendStyle, list, content;
+  var i, legend, hasName, svg, labels, list, content;
 
   legend = ideo.config.legend;
   content = '';
-  legendStyle = 'position: relative; top: -11px; left: -14px;';
 
   for (i = 0; i < legend.length; i++) {
     list = legend[i];
     [labels, hasName] = getHeader(list);
-    svg = '<svg width="' + lineHeight + '" style="float: left">';
+    svg = '<svg width="' + lineHeight + '">';
     [labels, svg] = getListItems(labels, svg, hasName, list);
     svg += '</svg>'
-    content += svg + '<ul style="' + legendStyle + '">' + labels + '</ul>';
+    content += svg + '<ul>' + labels + '</ul>';
   }
 
-  d3.select(ideo.config.container + ' #_ideogramOuterWrap')
-    .append('div')
-      .attr('id', '_ideogramLegend')
-      .html(content);
+  var target = d3.select(ideo.config.container + ' #_ideogramOuterWrap');
+  target.append('style').html(legendStyle)
+  target.append('div').attr('id', '_ideogramLegend').html(content);
 }
 
 export { writeLegend }

--- a/src/js/annotations/legend.js
+++ b/src/js/annotations/legend.js
@@ -4,69 +4,57 @@ var d3 = Object.assign({}, d3selection);
 
 var lineHeight = 19;
 
-function getListItems(labels, svg, hasDisplayName, heatmap) {
-  var j, threshold, color, label, y, rectAttrs;
+function getListItems(labels, svg, hasName, list) {
+  var i, color, y, rectAttrs, row;
 
   rectAttrs = 'height="10" width="10"  y="5" style="stroke: #888;"';
 
-  for (j = 0; j < heatmap.thresholds.length; j++) {
-    threshold = heatmap.thresholds[j];
-    y = j * lineHeight;
-    if (hasDisplayName) y += lineHeight;
-    color = '<rect ' + rectAttrs + ' fill="' + threshold[1] + '"/>';
-    label = '<li>' + threshold[2] + '</li>';
-    svg += '<g transform="translate(0, ' + y + ')">' + color + '</g>'
-    labels += label;
+  for (i = 0; i < list.rows.length; i++) {
+    row = list.rows[i];
+    labels += '<li>' + row.name + '</li>';
+    y = lineHeight * i;
+    if (hasName) y += lineHeight;
+    color = '<rect ' + rectAttrs + ' fill="' + row.color + '"/>';
+    svg += '<g transform="translate(0, ' + y + ')">' + color + '</g>';
   }
 
   return [labels, svg];
 }
 
-function getHeader(heatmap) {
-  var labels, hasDisplayName;
+function getHeader(list) {
+  var labels, hasName;
   labels = '';
-  hasDisplayName = false;
-  if ('displayName' in heatmap) {
+  hasName = false;
+  if ('name' in list) {
     labels +=
       '<span style="position: relative; left: -15px;">' +
-        heatmap.displayName +
+        list.name +
       '</span>';
-    hasDisplayName = true;
+    hasName = true;
   }
-  return [labels, hasDisplayName];
+  return [labels, hasName];
 }
 
-function writeHeatmapLegend(ideo) {
-  var heatmaps, thresholdHasLabel, i, heatmap, legend, hasDisplayName, svg,
-    labels, legendStyle;
+function writeLegend(ideo) {
+  var i, legend, hasName, svg, labels, legendStyle, list, content;
 
-  heatmaps = ideo.config.heatmaps;
-  thresholdHasLabel = heatmaps[0].thresholds[0].length > 2;
-  if (!thresholdHasLabel) return;
-
-  legend = '';
+  legend = ideo.config.legend;
+  content = '';
   legendStyle = 'position: relative; top: -11px; left: -14px;';
 
-  for (i = 0; i < heatmaps.length; i++) {
-    heatmap = heatmaps[i];
-    [labels, hasDisplayName] = getHeader(heatmap);
+  for (i = 0; i < legend.length; i++) {
+    list = legend[i];
+    [labels, hasName] = getHeader(list);
     svg = '<svg width="' + lineHeight + '" style="float: left">';
-    [labels, svg] = getListItems(labels, svg, hasDisplayName, heatmap);
+    [labels, svg] = getListItems(labels, svg, hasName, list);
     svg += '</svg>'
-    legend += svg + '<ul style="' + legendStyle + '">' + labels + '</ul>';
+    content += svg + '<ul style="' + legendStyle + '">' + labels + '</ul>';
   }
 
   d3.select(ideo.config.container + ' #_ideogramOuterWrap')
     .append('div')
       .attr('id', '_ideogramLegend')
-      .html(legend);
-}
-
-function writeLegend(ideo) {
-  var config = ideo.config;
-  if (config.heatmaps) {
-    writeHeatmapLegend(ideo);
-  }
+      .html(content);
 }
 
 export { writeLegend }

--- a/src/js/annotations/legend.js
+++ b/src/js/annotations/legend.js
@@ -13,7 +13,7 @@ var legendStyle =
   '} ' +
   '#_ideogramLegend ul span {position: relative; left: -15px;} ';
 
-function getListItems(labels, svg, hasName, list) {
+function getListItems(labels, svg, list) {
   var i, color, y, rectAttrs, row;
 
   rectAttrs = 'height="10" width="10"  y="4" style="stroke: #888;"';
@@ -22,7 +22,7 @@ function getListItems(labels, svg, hasName, list) {
     row = list.rows[i];
     labels += '<li>' + row.name + '</li>';
     y = lineHeight * i;
-    if (hasName) y += lineHeight;
+    if ('name' in list) y += lineHeight;
     color = '<rect ' + rectAttrs + ' fill="' + row.color + '"/>';
     svg += '<g transform="translate(0, ' + y + ')">' + color + '</g>';
   }
@@ -30,28 +30,17 @@ function getListItems(labels, svg, hasName, list) {
   return [labels, svg];
 }
 
-function getHeader(list) {
-  var labels, hasName;
-  labels = '';
-  hasName = false;
-  if ('name' in list) {
-    labels += '<span>' + list.name + '</span>';
-    hasName = true;
-  }
-  return [labels, hasName];
-}
-
 function writeLegend(ideo) {
-  var i, legend, hasName, svg, labels, list, content;
+  var i, legend, svg, labels, list, content;
 
   legend = ideo.config.legend;
   content = '';
 
   for (i = 0; i < legend.length; i++) {
     list = legend[i];
-    [labels, hasName] = getHeader(list);
+    if ('name' in list) labels = '<span>' + list.name + '</span>';
     svg = '<svg width="' + lineHeight + '">';
-    [labels, svg] = getListItems(labels, svg, hasName, list);
+    [labels, svg] = getListItems(labels, svg, list);
     svg += '</svg>'
     content += svg + '<ul>' + labels + '</ul>';
   }

--- a/src/js/annotations/legend.js
+++ b/src/js/annotations/legend.js
@@ -5,13 +5,15 @@ var d3 = Object.assign({}, d3selection);
 var lineHeight = 19;
 
 function getListItems(labels, svg, hasDisplayName, heatmap) {
-  var j, threshold, color, label, y;
+  var j, threshold, color, label, y, rectAttrs;
+
+  rectAttrs = 'height="10" width="10"  y="5" style="stroke: #888;"';
 
   for (j = 0; j < heatmap.thresholds.length; j++) {
     threshold = heatmap.thresholds[j];
     y = j * lineHeight;
     if (hasDisplayName) y += lineHeight;
-    color = '<rect height="10" width="10" y="5" fill="' + threshold[1] + '"/>';
+    color = '<rect ' + rectAttrs + ' fill="' + threshold[1] + '"/>';
     label = '<li>' + threshold[2] + '</li>';
     svg += '<g transform="translate(0, ' + y + ')">' + color + '</g>'
     labels += label;

--- a/src/js/annotations/legend.js
+++ b/src/js/annotations/legend.js
@@ -4,7 +4,9 @@ var d3 = Object.assign({}, d3selection);
 
 function writeHeatmapLegend(ideo) {
   var heatmaps, thresholdHasLabel, i, j, thresholds, threshold, legend,
-    row, y, color, label;
+    row, y, color, label, hasDisplayName, lineHeight, numPrevThresholds;
+
+  lineHeight = 14
 
   legend = [];
   heatmaps = ideo.config.heatmaps,
@@ -14,10 +16,19 @@ function writeHeatmapLegend(ideo) {
 
   for (i = 0; i < heatmaps.length; i++) {
     thresholds = heatmaps[i].thresholds;
+    hasDisplayName = false;
+    if (i !== 0) numPrevThresholds = heatmaps[i - 1].thresholds.length;
+    if ('displayName' in heatmaps[i]) {
+      y = lineHeight;
+      if (i !== 0) y += numPrevThresholds * lineHeight + lineHeight*2;
+      legend.push('<text y="' + y + '">' + heatmaps[i].displayName + '</text>');
+      hasDisplayName = true;
+    }
     for (j = 0; j < thresholds.length; j++) {
       threshold = thresholds[j];
-      y = (j + 1) * 14;
-      if (i !== 0) y += heatmaps[i - 1].thresholds.length * 14 + 14;
+      y = (j + 1) * lineHeight;
+      if (i !== 0) y += numPrevThresholds * lineHeight + lineHeight;
+      if (hasDisplayName && i > 0) y += lineHeight;
       color = '<rect height="10" width="10" y="5" fill="' + threshold[1] + '"/>';
       label = '<text x="15" y="14">' + threshold[2] + '</text>';
       row = color + label

--- a/src/js/annotations/legend.js
+++ b/src/js/annotations/legend.js
@@ -4,7 +4,7 @@ var d3 = Object.assign({}, d3selection);
 
 function writeHeatmapLegend(ideo) {
   var heatmaps, thresholdHasLabel, i, j, thresholds, threshold, legend,
-    color, label;
+    row, y, color, label;
 
   legend = [];
   heatmaps = config.heatmaps,
@@ -16,12 +16,16 @@ function writeHeatmapLegend(ideo) {
     thresholds = heatmaps[i].thresholds;
     for (j = 0; j < thresholds.length; j++) {
       threshold = thresholds[j];
-      color = '<rect style="clear: left; height: 10px;" fill="' + threshold[1] + '"/>';
-      label = '<text>' + threshold[2] + '</text>';
-      legend.push(color + label);
+      y = (j + 1) * 14;
+      if (i !== 0) y += heatmaps[i - 1].thresholds.length * 14 + 14;
+      color = '<rect height="10" width="10" y="5" fill="' + threshold[1] + '"/>';
+      label = '<text x="15" y="14">' + threshold[2] + '</text>';
+      row = color + label
+      row = '<g transform="translate(0, ' + y + ')">' + row + '</g>'
+      legend.push(row);
     }
   }
-  legend = '<g>' + legend.join('</g><g>') + '</g>';
+  // legend = '<g>' + legend.join('</g><g>') + '</g>';
 
   console.log(legend);
 

--- a/src/js/annotations/legend.js
+++ b/src/js/annotations/legend.js
@@ -5,10 +5,11 @@ var d3 = Object.assign({}, d3selection);
 var lineHeight = 19;
 
 var legendStyle =
-  '#_ideogramLegend {font: 12px Arial, line-height: 19.6px;} ' +
+  '#_ideogramLegend {font: 12px Arial; line-height: 19px;} ' +
   '#_ideogramLegend svg {float: left;} ' +
   '#_ideogramLegend ul {' +
-    'position: relative; left: -14px; list-style: none, float: left;' +
+    'position: relative; left: -14px; list-style: none; float: left; ' +
+    'padding-left: 10px;' +
   '} ' +
   '#_ideogramLegend ul span {position: relative; left: -15px;} ';
 

--- a/test/web-test.js
+++ b/test/web-test.js
@@ -446,23 +446,32 @@ describe('Ideogram', function() {
     ideogram = new Ideogram(config);
   });
 
-  it('should have 1000 annotations and 5 tracks in tracks annotations example', function(done) {
+  it('should have 1000 annotations and legend in annotations example', function(done) {
     // Tests use case from ../examples/vanilla/annotations-tracks.html
     // TODO: Add class to annots indicating track
 
     function callback() {
       var numAnnots = document.getElementsByClassName('annot').length;
       assert.equal(numAnnots, 1000);
+      var numLegendRows = document.querySelectorAll('#_ideogramLegend li').length;
+      assert.equal(numLegendRows, 3);
       done();
     }
 
     var annotationTracks = [
       {id: 'pathogenicTrack', displayName: 'Pathogenic', color: '#F00'},
-      {id: 'likelyPathogenicTrack', displayName: 'Likely pathogenic', color: '#DB9'},
       {id: 'uncertainSignificanceTrack', displayName: 'Uncertain significance', color: '#CCC'},
-      {id: 'likelyBenignTrack', displayName: 'Likely benign', color: '#BD9'},
       {id: 'benignTrack', displayName: 'Benign', color: '#8D4'}
     ];
+
+    var legend = [{
+      name: 'Clinical significance (simulated)',
+      rows: [
+        {name: 'Pathogenic', color: '#F00'},
+        {name: 'Uncertain significance', color: '#CCC'},
+        {name: 'Benign', color: '#8D4'}
+      ]
+    }];
 
     var config = {
       taxid: 9606,
@@ -472,6 +481,7 @@ describe('Ideogram', function() {
       showChromosomeLabels: true,
       annotationsPath: '../dist/data/annotations/1000_virtual_snvs.json',
       annotationTracks: annotationTracks,
+      legend: legend,
       annotationHeight: 2.5,
       orientation: 'vertical',
       dataDir: '/dist/data/bands/native/',
@@ -513,6 +523,15 @@ describe('Ideogram', function() {
       {id: 'benignTrack', displayName: 'Benign', color: '#8D4'}
     ];
 
+    var legend = [{
+      name: 'Clinical significance (simulated)',
+      rows: [
+        {name: 'Pathogenic', color: '#F00', shape: 'triangle'},
+        {name: 'Uncertain significance', color: '#CCC', shape: 'triangle'},
+        {name: 'Benign', color: '#8D4', shape: 'triangle'}
+      ]
+    }];
+
     var config = {
       organism: 'human',
       chrWidth: 8,
@@ -520,6 +539,7 @@ describe('Ideogram', function() {
       annotationsPath: '../dist/data/annotations/1000_virtual_snvs.json',
       annotationTracks: annotationTracks,
       annotHeight: 3.5,
+      legend: legend,
       dataDir: '/dist/data/bands/native/',
       onLoad: loadCallback,
       onDidRotate: callback
@@ -1442,13 +1462,20 @@ describe('Ideogram', function() {
       done();
     }
 
+    var shape = 'circle';
     var annotationTracks = [
-      {id: 'pathogenicTrack', displayName: 'Pathogenic', color: '#F00'},
-      {id: 'likelyPathogenicTrack', displayName: 'Likely pathogenic', color: '#DB9'},
-      {id: 'uncertainSignificanceTrack', displayName: 'Uncertain significance', color: '#CCC'},
-      {id: 'likelyBenignTrack', displayName: 'Likely benign', color: '#BD9'},
-      {id: 'benignTrack', displayName: 'Benign', color: '#8D4'}
+      {id: 'pathogenicTrack', displayName: 'Pathogenic', color: '#F00', shape: shape},
+      {id: 'uncertainSignificanceTrack', displayName: 'Uncertain significance', color: '#CCC', shape: shape},
+      {id: 'benignTrack', displayName: 'Benign', color: '#8D4', shape: shape}
     ];
+
+    var legend = [{
+      rows: [
+        {name: 'Pathogenic', color: '#F00', shape: shape},
+        {name: 'Uncertain significance', color: '#CCC', shape: shape},
+        {name: 'Benign', color: '#8D4', shape: shape}
+      ]
+    }];
 
     var config = {
       organism: 'human',
@@ -1457,6 +1484,7 @@ describe('Ideogram', function() {
       annotationsPath: '../dist/data/annotations/1000_virtual_snvs.json',
       annotationTracks: annotationTracks,
       annotationHeight: 2.5,
+      legend: legend,
       dataDir: '/dist/data/bands/native/'
     };
     config.onDrawAnnots = callback;


### PR DESCRIPTION
This adds basic support for legends that describe annotations.  Such legends appear below the ideogram.

Example:
<img width="1128" alt="legend_ideogram" src="https://user-images.githubusercontent.com/1334561/49055516-d63d6800-f1c5-11e8-9c6f-3ba89efa8591.png">
