### PR TITLE
Fix issue 124 - Changed overflow-x to auto for #_ideogramOuterWrap

### DIFF
--- a/src/js/init/write-container.js
+++ b/src/js/init/write-container.js
@@ -80,7 +80,7 @@ function writeContainerDom(taxid, ideo) {
   d3.select(ideo.config.container + ' #_ideogramOuterWrap').append('div')
     .attr('id', '_ideogramMiddleWrap') // needed for overflow and scrolling
       .style('position', 'relative')
-      .style('overflow-x', 'scroll')
+      .style('overflow-x', 'auto')
     .append('div')
     .attr('id', '_ideogramInnerWrap') // needed for overflow and scrolling
     .append('svg')


### PR DESCRIPTION
Changed `overflow-x: scroll` to `overflow-x: auto` for `#_ideogramOuterwrap`, so `overflow-x` is only used/seen when it is necessary.

closes #124 