### PR TITLE
Add "accessToken" option for authentication and authorization

### DIFF
--- a/examples/vanilla/auth.html
+++ b/examples/vanilla/auth.html
@@ -23,7 +23,7 @@
   <a href="annotations-overlaid">Next</a> |
   <a href="https://github.com/eweitz/ideogram/blob/gh-pages/annotations-basic.html" target="_blank">Source</a>
   <p>
-  Authentication and authorization via Google APIs.
+  Authentication and authorization via Google APIs.  Signing in grants access to protected Ideogram data by including your "Authentication: Bearer" token in the request.
   </p>
   <button id="sign-in-or-out-button" style="margin-left: 25px">Sign In/Authorize</button>
   <button id="revoke-access-button" style="display: none; margin-left: 25px">Revoke access</button>
@@ -43,6 +43,7 @@
       // Get API key and client ID from API Console.
       // 'scope' field specifies space-delimited list of access scopes.
       gapi.client.init({
+          // This clientId is for  the Ideogram project in Google Cloud Platform.
           'clientId': '829416742843-558e4gu9cfvdamcb727gh9au8lh7b7tk.apps.googleusercontent.com',
           'scope': SCOPE
       }).then(function () {
@@ -79,7 +80,7 @@
     function revokeAccess() {
       GoogleAuth.disconnect();
     }
-  
+
     function setSigninStatus(isSignedIn) {
       var user = GoogleAuth.currentUser.get();
       var isAuthorized = user.hasGrantedScopes(SCOPE);
@@ -97,7 +98,7 @@
           annotationHeight: 3,
           accessToken: accessToken,
           annotationsLayout: 'heatmap-2d',
-          annotationsPath: 'https://www.googleapis.com/storage/v1/b/ideogram-dev/o/oligodendroglioma%2finfercnv.observations.optimized.txt?alt=media'
+          annotationsPath: 'https://www.googleapis.com/storage/v1/b/ideogram-auth/o/oligodendroglioma%2finfercnv.observations.optimized.txt?alt=media'
         }
 
         ideogram = new Ideogram(config);

--- a/examples/vanilla/auth.html
+++ b/examples/vanilla/auth.html
@@ -9,6 +9,7 @@
     a, a:hover, a:visited, a:active {color: #0366d6;}
   </style>
   <script type="text/javascript" src="../../dist/js/ideogram.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
   <script async defer src="https://apis.google.com/js/api.js" 
         onload="this.onload=function(){};handleClientLoad()" 
         onreadystatechange="if (this.readyState === 'complete') this.onload()">
@@ -24,10 +25,12 @@
   <p>
   Authentication and authorization via Google APIs.
   </p>
+  <button id="sign-in-or-out-button" style="margin-left: 25px">Sign In/Authorize</button>
+  <button id="revoke-access-button" style="display: none; margin-left: 25px">Revoke access</button>
 
   <script>
     var GoogleAuth;
-    var SCOPE = 'https://www.googleapis.com/auth/drive.metadata.readonly';
+    var SCOPE = 'https://www.googleapis.com/auth/devstorage.read_only';
     function handleClientLoad() {
       // Load the API's client and auth2 modules.
       // Call the initClient function after the modules load.
@@ -35,17 +38,12 @@
     }
   
     function initClient() {
-      // Retrieve the discovery document for version 3 of Google Drive API.
-      // In practice, your app can retrieve one or more discovery documents.
-      var discoveryUrl = 'https://www.googleapis.com/discovery/v1/apis/drive/v3/rest';
   
       // Initialize the gapi.client object, which app uses to make API requests.
       // Get API key and client ID from API Console.
       // 'scope' field specifies space-delimited list of access scopes.
       gapi.client.init({
-          'apiKey': 'YOUR_API_KEY',
-          'discoveryDocs': [discoveryUrl],
-          'clientId': 'YOUR_CLIENT_ID',
+          'clientId': '829416742843-558e4gu9cfvdamcb727gh9au8lh7b7tk.apps.googleusercontent.com',
           'scope': SCOPE
       }).then(function () {
         GoogleAuth = gapi.auth2.getAuthInstance();
@@ -86,6 +84,25 @@
       var user = GoogleAuth.currentUser.get();
       var isAuthorized = user.hasGrantedScopes(SCOPE);
       if (isAuthorized) {
+        accessToken = user.getAuthResponse().access_token;
+
+        config = {
+          organism: 'human',
+          orientation: 'vertical',
+          chromosome: '1',
+          chrHeight: 450,
+          showBandLabels: false,
+          legend: legend,
+          heatmapThresholds: [0, 0.13, 0.27, 0.4, 0.53, 0.67, 0.8, 0.93, 1.1, 1.2, 1.33, 1.47, 1.6, 1.73, 1.87, 2],
+          annotationHeight: 3,
+          accessToken: accessToken,
+          annotationsLayout: 'heatmap-2d',
+          annotationsPath: 'https://www.googleapis.com/storage/v1/b/ideogram-dev/o/oligodendroglioma%2finfercnv.observations.optimized.txt?alt=media'
+        }
+
+        ideogram = new Ideogram(config);
+
+
         $('#sign-in-or-out-button').html('Sign out');
         $('#revoke-access-button').css('display', 'inline-block');
         $('#auth-status').html('You are currently signed in and have granted ' +
@@ -105,20 +122,26 @@
 
 <script type="text/javascript">
 
-  var config = {
-    organism: 'human',
-    chromosome: '17',
-    chrHeight: 600,
-    orientation: 'horizontal',
-    annotations: [{
-      name: 'BRCA1',
-      chr: '17',
-      start: 43044294,
-      stop: 43125482
-    }]
-  };
+  d3 = Ideogram.d3;
 
-  var ideogram = new Ideogram(config);
+  var legend = [{
+    name: 'Expression level',
+    rows: [
+      {name: 'Low', color: '#33F'},
+      {name: 'Normal', color: '#CCC'},
+      {name: 'High', color: '#F33'}
+    ]
+  }];
+
+  config = {
+    organism: 'human',
+    orientation: 'vertical',
+    chromosome: '1',
+    chrHeight: 450,
+    showBandLabels: false
+  }
+
+  ideogram = new Ideogram(config);
 
 </script>
 

--- a/examples/vanilla/auth.html
+++ b/examples/vanilla/auth.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Auth | Ideogram</title>
+  <style>
+    body {font: 14px Arial; line-height: 19.6px; padding: 0 15px;}
+    a, a:visited {text-decoration: none;}
+    a:hover {text-decoration: underline;}
+    a, a:hover, a:visited, a:active {color: #0366d6;}
+  </style>
+  <script type="text/javascript" src="../../dist/js/ideogram.min.js"></script>
+  <script async defer src="https://apis.google.com/js/api.js" 
+        onload="this.onload=function(){};handleClientLoad()" 
+        onreadystatechange="if (this.readyState === 'complete') this.onload()">
+  </script>
+<link rel="icon" type="image/x-icon" href="img/ideogram_favicon.ico">
+</head>
+<body>
+  <h1>Auth | Ideogram</h1>
+  <a href="../">Overview</a> |
+  <a href="homology-interspecies">Previous</a> |
+  <a href="annotations-overlaid">Next</a> |
+  <a href="https://github.com/eweitz/ideogram/blob/gh-pages/annotations-basic.html" target="_blank">Source</a>
+  <p>
+  Authentication and authorization via Google APIs.
+  </p>
+
+  <script>
+    var GoogleAuth;
+    var SCOPE = 'https://www.googleapis.com/auth/drive.metadata.readonly';
+    function handleClientLoad() {
+      // Load the API's client and auth2 modules.
+      // Call the initClient function after the modules load.
+      gapi.load('client:auth2', initClient);
+    }
+  
+    function initClient() {
+      // Retrieve the discovery document for version 3 of Google Drive API.
+      // In practice, your app can retrieve one or more discovery documents.
+      var discoveryUrl = 'https://www.googleapis.com/discovery/v1/apis/drive/v3/rest';
+  
+      // Initialize the gapi.client object, which app uses to make API requests.
+      // Get API key and client ID from API Console.
+      // 'scope' field specifies space-delimited list of access scopes.
+      gapi.client.init({
+          'apiKey': 'YOUR_API_KEY',
+          'discoveryDocs': [discoveryUrl],
+          'clientId': 'YOUR_CLIENT_ID',
+          'scope': SCOPE
+      }).then(function () {
+        GoogleAuth = gapi.auth2.getAuthInstance();
+  
+        // Listen for sign-in state changes.
+        GoogleAuth.isSignedIn.listen(updateSigninStatus);
+  
+        // Handle initial sign-in state. (Determine if user is already signed in.)
+        var user = GoogleAuth.currentUser.get();
+        setSigninStatus();
+  
+        // Call handleAuthClick function when user clicks on
+        //      "Sign In/Authorize" button.
+        $('#sign-in-or-out-button').click(function() {
+          handleAuthClick();
+        }); 
+        $('#revoke-access-button').click(function() {
+          revokeAccess();
+        }); 
+      });
+    }
+  
+    function handleAuthClick() {
+      if (GoogleAuth.isSignedIn.get()) {
+        // User is authorized and has clicked 'Sign out' button.
+        GoogleAuth.signOut();
+      } else {
+        // User is not signed in. Start Google auth flow.
+        GoogleAuth.signIn();
+      }
+    }
+  
+    function revokeAccess() {
+      GoogleAuth.disconnect();
+    }
+  
+    function setSigninStatus(isSignedIn) {
+      var user = GoogleAuth.currentUser.get();
+      var isAuthorized = user.hasGrantedScopes(SCOPE);
+      if (isAuthorized) {
+        $('#sign-in-or-out-button').html('Sign out');
+        $('#revoke-access-button').css('display', 'inline-block');
+        $('#auth-status').html('You are currently signed in and have granted ' +
+            'access to this app.');
+      } else {
+        $('#sign-in-or-out-button').html('Sign In/Authorize');
+        $('#revoke-access-button').css('display', 'none');
+        $('#auth-status').html('You have not authorized this app or you are ' +
+            'signed out.');
+      }
+    }
+  
+    function updateSigninStatus(isSignedIn) {
+      setSigninStatus();
+    }
+  </script>
+
+<script type="text/javascript">
+
+  var config = {
+    organism: 'human',
+    chromosome: '17',
+    chrHeight: 600,
+    orientation: 'horizontal',
+    annotations: [{
+      name: 'BRCA1',
+      chr: '17',
+      start: 43044294,
+      stop: 43125482
+    }]
+  };
+
+  var ideogram = new Ideogram(config);
+
+</script>
+
+</body>
+</html>

--- a/src/js/ideogram.js
+++ b/src/js/ideogram.js
@@ -41,7 +41,7 @@ import {convertBpToPx, convertPxToBp} from './coordinate-converters';
 import {unpackAnnots, packAnnots, initCrossFilter, filterAnnots} from './filter';
 
 import {
-  assemblyIsAccession, getDataDir, round, onDidRotate, getSvg, d3
+  assemblyIsAccession, getDataDir, round, onDidRotate, getSvg, fetch, d3
 } from './lib';
 
 import {
@@ -134,6 +134,7 @@ export default class Ideogram {
     this.round = round;
     this.onDidRotate = onDidRotate;
     this.getSvg = getSvg;
+    this.fetch = fetch;
 
     // Functions from views/chromosome-model.js
     this.getChromosomeModel = getChromosomeModel;

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -118,7 +118,7 @@ function fetch(url, contentType) {
     headers = new Headers();
 
   if (config.accessToken) {
-    headers = new Headers({'Authorization': 'Bearer ' + accessToken});
+    headers = new Headers({'Authorization': 'Bearer ' + config.accessToken});
   }
 
   if (contentType === 'text') {

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -112,9 +112,25 @@ function getSvg() {
   return d3.select(this.selector).node();
 }
 
+function fetch(url, contentType) {
+  var ideo = this,
+    config = ideo.config,
+    headers = new Headers();
+
+  if (config.accessToken) {
+    headers = new Headers({'Authorization': 'Bearer ' + accessToken});
+  }
+
+  if (contentType === 'text') {
+    return d3.text(url, {headers: headers});
+  } else {
+    return d3.json(url, {headers: headers});
+  }
+}
+
 export {
   assemblyIsAccession, hasNonGenBankAssembly, hasGenBankAssembly, getDataDir,
   drawChromosomeLabels, rotateChromosomeLabels, round, appendHomolog,
-  drawChromosome, rotateAndToggleDisplay, onDidRotate, getSvg,
+  drawChromosome, rotateAndToggleDisplay, onDidRotate, getSvg, fetch,
   setOverflowScroll, d3
 };

--- a/src/js/parsers/expression-matrix-parser.js
+++ b/src/js/parsers/expression-matrix-parser.js
@@ -50,7 +50,7 @@ export class ExpressionMatrixParser {
         '../../annotations/Homo_sapiens,_Ensembl_80.tsv';
 
       return new Promise(function(resolve) {
-        d3.text(ensemblData).then(function(data) {
+        ideo.fetch(ensemblData, 'text').then(function(data) {
           var tsvLines, i, start, stop, gene, geneType, chr, length;
           
           tsvLines = data.split(/\r\n|\n/).slice(1,);

--- a/test/web-test.js
+++ b/test/web-test.js
@@ -2205,5 +2205,38 @@ describe('Ideogram', function() {
     });
   });
 
+  it('should add "Authentication: Bearer" when access token is provided', function(done) {
+    // Tests use case from ../examples/vanilla/auth.html
 
+    // Monkey patch the fetch method to intercept request and inspect HTTP
+    // "Authorization" header for test access token.
+    var originalFetch = window.fetch;
+    window.fetch = function() {
+      if (arguments.length > 1 && /googleapis/.test(arguments[0])) {
+        var bearer = arguments[1].headers.get("authorization");
+        assert.equal(bearer, 'Bearer mockAccessToken');
+        done();
+        return; // Don't send request for remote resource, as test passed
+      }
+      return originalFetch.apply(this, arguments);
+    }
+
+    var accessToken = 'mockAccessToken';
+
+    config = {
+      organism: 'human',
+      orientation: 'vertical',
+      chromosome: '1',
+      chrHeight: 450,
+      showBandLabels: false,
+      heatmapThresholds: [0, 0.13, 0.27, 0.4, 0.53, 0.67, 0.8, 0.93, 1.1, 1.2, 1.33, 1.47, 1.6, 1.73, 1.87, 2],
+      annotationHeight: 3,
+      accessToken: accessToken,
+      annotationsLayout: 'heatmap-2d',
+      annotationsPath: 'https://www.googleapis.com/storage/v1/b/ideogram-dev/o/oligodendroglioma%2finfercnv.observations.optimized.txt?alt=media',
+      dataDir: '/dist/data/bands/native/'
+    }
+
+    ideogram = new Ideogram(config);
+  });
 });


### PR DESCRIPTION
This adds an "accessToken" Ideogram configuration option, which enables authentication and authorization via OAuth 2.0.  This can be useful for controlling access to private annotation data.