### PR TITLE
Adjustable 2D heatmap threshold

### DIFF
--- a/examples/vanilla/geometry-collinear.html
+++ b/examples/vanilla/geometry-collinear.html
@@ -44,8 +44,8 @@
 
     d3 = Ideogram.d3;
 
-    function addControls() {
-        chrMargin = (typeof chrMargin === 'undefined' ? 10 : chrMargin)
+    function addMarginControl() {
+      chrMargin = (typeof chrMargin === 'undefined' ? 10 : chrMargin)
         marginSlider =
           `<label id="chrMarginContainer">
             Chromosome margin:
@@ -66,11 +66,53 @@
           </datalist>`;
         d3.select('#_ideogramLegend').node().innerHTML += marginSlider;
 
-        d3.selectAll('input[type="range"]').on('change', function() {
+        d3.selectAll('#chrMargin').on('change', function() {
           window.chrMargin = parseInt(d3.select(this).node().value);
           config.chrMargin = chrMargin;
           ideogram = new Ideogram(config);
         });
+    }
+
+    function addThresholdControl() {
+      if (typeof(sensitivity) === 'undefined') {
+        sensitivity = 1;
+        window.originalHeatmapThresholds = ideogram.config.heatmapThresholds;
+      }
+
+      sensitivitySlider =
+        `<div>
+          <label id="sensitivityContainer">
+            Heatmap threshold:
+          <input type="range" id="sensitivity" min="0.5" max="1.5" step="0.1" value="` + sensitivity + `">
+        </div>`;
+      d3.select('#_ideogramLegend').node().innerHTML += sensitivitySlider;
+
+      d3.selectAll('#sensitivity').on('change', function() {
+        var thresholds, newThreshold, numThresholds, i;
+
+        window.sensitivity = parseFloat(d3.select(this).node().value);
+        thresholds = window.originalHeatmapThresholds;
+        numThresholds = thresholds.length;
+
+        // If sensitivity > 1, increase thresholds above middle, decrease below
+        // If sensitivity < 1, decrease thresholds above middle, increase below
+        for (i = 0; i < numThresholds; i++) {
+          if (i + 1 > numThresholds/2) {
+            newThreshold = thresholds[i] * sensitivity;
+          } else {
+            newThreshold = thresholds[i] * 1/sensitivity;
+          }
+          config.heatmapThresholds[i] = newThreshold;
+        }
+
+        ideogram = new Ideogram(config);
+      });
+
+    }
+
+    function addControls() {
+        addMarginControl();
+        addThresholdControl();
     }
 
     var legend = [{
@@ -123,7 +165,7 @@
             legend: legend,
             onLoad: setOnChromosomeClick,
             annotationsPath: rawMatrixPath,
-            heatmapThresholds: [0, 0.13, 0.27, 0.4, 0.53, 0.67, 0.8, 0.93, 1.1, 1.2, 1.33, 1.47, 1.6, 1.73, 1.87, 2],
+            heatmapThresholds: [0.533, 0.8, 1.2, 1.433],
             annotationHeight: 3,
             annotationsLayout: 'heatmap-2d',
           }
@@ -143,6 +185,7 @@
       legend: legend,
       annotationHeight: 30,
       annotationsLayout: 'heatmap',
+      heatmapThresholds: [0.533, 0.8, 1.2, 1.433],
       annotationsPath: '../../data/annotations/oligodendroglioma_cnv_expression.json',
       onDrawAnnots: addControls
     }

--- a/examples/vanilla/geometry-collinear.html
+++ b/examples/vanilla/geometry-collinear.html
@@ -9,13 +9,18 @@
     a, a:hover, a:visited, a:active {color: #0366d6;}
   </style>
   <style>
-    #chrMargin {
+    #chrMargin, #expressionThreshold {
       position: relative;
       top: 5px;
     }
-    #chrMarginContainer {
+    #expressionThresholdContainer {
       position: relative;
       top: -6px;
+    }
+
+    #chrMarginContainer {
+      position: relative;
+      top: -18px;
     }
   </style>
   <script type="text/javascript" src="../../dist/js/ideogram.min.js"></script>
@@ -48,7 +53,7 @@
       chrMargin = (typeof chrMargin === 'undefined' ? 10 : chrMargin)
         marginSlider =
           `<label id="chrMarginContainer">
-            Chromosome margin:
+            Chromosome margin
           <input type="range" id="chrMargin" list="chrMarginList" value="` + chrMargin + `">
           </label>
           <datalist id="chrMarginList">
@@ -65,42 +70,58 @@
             <option value="100" label="100%">
           </datalist>`;
         d3.select('#_ideogramLegend').node().innerHTML += marginSlider;
-
-        d3.selectAll('#chrMargin').on('change', function() {
-          window.chrMargin = parseInt(d3.select(this).node().value);
+        document.addEventListener('change', function(event) {
+          if (event.target.id !== 'chrMargin') return;
+          window.chrMargin = parseInt(event.target.value);
           config.chrMargin = chrMargin;
           ideogram = new Ideogram(config);
         });
     }
 
     function addThresholdControl() {
-      if (typeof(sensitivity) === 'undefined') {
-        sensitivity = 1;
+      if (typeof(expressionThreshold) === 'undefined') {
+        expressionThreshold = 50;
         window.originalHeatmapThresholds = ideogram.config.heatmapThresholds;
       }
 
-      sensitivitySlider =
-        `<div>
-          <label id="sensitivityContainer">
-            Heatmap threshold:
-          <input type="range" id="sensitivity" min="0.5" max="1.5" step="0.1" value="` + sensitivity + `">
-        </div>`;
-      d3.select('#_ideogramLegend').node().innerHTML += sensitivitySlider;
+      expressionThresholdSlider =
+        `<label id="expressionThresholdContainer">
+            Expression threshold
+          <input type="range" id="expressionThreshold" list="expressionThresholdList" value="` + expressionThreshold + `">
+          <datalist id="expressionThresholdList">
+            <option value="0" label="0.5">
+            <option value="10">
+            <option value="20">
+            <option value="30">
+            <option value="40">
+            <option value="50" label="1">
+            <option value="60">
+            <option value="70">
+            <option value="80">
+            <option value="90">
+            <option value="100" label="1.5">
+          </datalist>
+          <br/><br/>`;
+      d3.select('#_ideogramLegend').node().innerHTML += expressionThresholdSlider;
 
-      d3.selectAll('#sensitivity').on('change', function() {
+      document.addEventListener('change', function(event) {
         var thresholds, newThreshold, numThresholds, i;
 
-        window.sensitivity = parseFloat(d3.select(this).node().value);
+        if (event.target.id !== 'expressionThreshold') return;
+
+        window.expressionThreshold = parseFloat(event.target.value);
+
+        window.adjustedexpressionThreshold = expressionThreshold/100 + 0.5
         thresholds = window.originalHeatmapThresholds;
         numThresholds = thresholds.length;
 
-        // If sensitivity > 1, increase thresholds above middle, decrease below
-        // If sensitivity < 1, decrease thresholds above middle, increase below
+        // If expressionThreshold > 1, increase thresholds above middle, decrease below
+        // If expressionThreshold < 1, decrease thresholds above middle, increase below
         for (i = 0; i < numThresholds; i++) {
           if (i + 1 > numThresholds/2) {
-            newThreshold = thresholds[i] * sensitivity;
+            newThreshold = thresholds[i] * adjustedexpressionThreshold;
           } else {
-            newThreshold = thresholds[i] * 1/sensitivity;
+            newThreshold = thresholds[i] * 1/adjustedexpressionThreshold;
           }
           config.heatmapThresholds[i] = newThreshold;
         }
@@ -111,8 +132,8 @@
     }
 
     function addControls() {
-        addMarginControl();
-        addThresholdControl();
+      addThresholdControl();
+      addMarginControl();
     }
 
     var legend = [{

--- a/examples/vanilla/geometry-collinear.html
+++ b/examples/vanilla/geometry-collinear.html
@@ -81,7 +81,7 @@
     function addThresholdControl() {
       if (typeof(expressionThreshold) === 'undefined') {
         expressionThreshold = 50;
-        window.originalHeatmapThresholds = ideogram.config.heatmapThresholds;
+        window.originalHeatmapThresholds = ideogram.rawAnnots.metadata.heatmapThresholds;
       }
 
       expressionThresholdSlider =
@@ -89,7 +89,7 @@
             Expression threshold
           <input type="range" id="expressionThreshold" list="expressionThresholdList" value="` + expressionThreshold + `">
           <datalist id="expressionThresholdList">
-            <option value="0" label="0.5">
+            <option value="0" label="0.">
             <option value="10">
             <option value="20">
             <option value="30">
@@ -111,19 +111,20 @@
 
         window.expressionThreshold = parseFloat(event.target.value);
 
-        window.adjustedexpressionThreshold = expressionThreshold/100 + 0.5
+        window.adjustedExpressionThreshold = expressionThreshold/10 - 4;
         thresholds = window.originalHeatmapThresholds;
         numThresholds = thresholds.length;
+        config.heatmapThresholds = []
 
         // If expressionThreshold > 1, increase thresholds above middle, decrease below
         // If expressionThreshold < 1, decrease thresholds above middle, increase below
         for (i = 0; i < numThresholds; i++) {
           if (i + 1 > numThresholds/2) {
-            newThreshold = thresholds[i] * adjustedexpressionThreshold;
+            newThreshold = thresholds[i + adjustedExpressionThreshold];
           } else {
-            newThreshold = thresholds[i] * 1/adjustedexpressionThreshold;
+            newThreshold = thresholds[i - adjustedExpressionThreshold];
           }
-          config.heatmapThresholds[i] = newThreshold;
+          config.heatmapThresholds.push(newThreshold);
         }
 
         ideogram = new Ideogram(config);
@@ -206,7 +207,7 @@
       legend: legend,
       annotationHeight: 30,
       annotationsLayout: 'heatmap',
-      heatmapThresholds: [0.533, 0.8, 1.2, 1.433],
+      // heatmapThresholds: [0.533, 0.8, 1.2, 1.433],
       annotationsPath: '../../data/annotations/oligodendroglioma_cnv_expression.json',
       onDrawAnnots: addControls
     }

--- a/examples/vanilla/geometry-collinear.html
+++ b/examples/vanilla/geometry-collinear.html
@@ -49,6 +49,12 @@
 
     d3 = Ideogram.d3;
 
+    function updateMargin(event) {
+      window.chrMargin = parseInt(event.target.value);
+      config.chrMargin = chrMargin;
+      ideogram = new Ideogram(config);
+    }
+
     function addMarginControl() {
       chrMargin = (typeof chrMargin === 'undefined' ? 10 : chrMargin)
         marginSlider =
@@ -70,12 +76,29 @@
             <option value="100" label="100%">
           </datalist>`;
         d3.select('#_ideogramLegend').node().innerHTML += marginSlider;
-        document.addEventListener('change', function(event) {
-          if (event.target.id !== 'chrMargin') return;
-          window.chrMargin = parseInt(event.target.value);
-          config.chrMargin = chrMargin;
-          ideogram = new Ideogram(config);
-        });
+    }
+
+    function updateThreshold(event) {
+      var thresholds, newThreshold, numThresholds, i;
+
+      window.expressionThreshold = parseFloat(event.target.value);
+
+      window.adjustedExpressionThreshold = expressionThreshold/10 - 4;
+      thresholds = window.originalHeatmapThresholds;
+      numThresholds = thresholds.length;
+      config.heatmapThresholds = []
+
+      // If expressionThreshold > 1, increase thresholds above middle, decrease below
+      // If expressionThreshold < 1, decrease thresholds above middle, increase below
+      for (i = 0; i < numThresholds; i++) {
+        if (i + 1 > numThresholds/2) {
+          newThreshold = thresholds[i + adjustedExpressionThreshold];
+        } else {
+          newThreshold = thresholds[i - adjustedExpressionThreshold];
+        }
+        config.heatmapThresholds.push(newThreshold);
+      }
+      ideogram = new Ideogram(config);
     }
 
     function addThresholdControl() {
@@ -103,38 +126,20 @@
           </datalist>
           <br/><br/>`;
       d3.select('#_ideogramLegend').node().innerHTML += expressionThresholdSlider;
+    }
 
-      document.addEventListener('change', function(event) {
-        var thresholds, newThreshold, numThresholds, i;
-
-        if (event.target.id !== 'expressionThreshold') return;
-
-        window.expressionThreshold = parseFloat(event.target.value);
-
-        window.adjustedExpressionThreshold = expressionThreshold/10 - 4;
-        thresholds = window.originalHeatmapThresholds;
-        numThresholds = thresholds.length;
-        config.heatmapThresholds = []
-
-        // If expressionThreshold > 1, increase thresholds above middle, decrease below
-        // If expressionThreshold < 1, decrease thresholds above middle, increase below
-        for (i = 0; i < numThresholds; i++) {
-          if (i + 1 > numThresholds/2) {
-            newThreshold = thresholds[i + adjustedExpressionThreshold];
-          } else {
-            newThreshold = thresholds[i - adjustedExpressionThreshold];
-          }
-          config.heatmapThresholds.push(newThreshold);
-        }
-
-        ideogram = new Ideogram(config);
-      });
-
+    function changeEventHandler(event) {
+      var id = event.target.id;
+      if (id === 'expressionThreshold') updateThreshold(event);
+      if (id === 'chrMargin') updateMargin(event);
     }
 
     function addControls() {
       addThresholdControl();
       addMarginControl();
+
+      document.removeEventListener('change', changeEventHandler);
+      document.addEventListener('change', changeEventHandler);
     }
 
     var legend = [{

--- a/src/js/annotations/heatmap-lib.js
+++ b/src/js/annotations/heatmap-lib.js
@@ -6,14 +6,11 @@ var reservedTrackKeys = [
   'name', 'start', 'length', 'trackIndex', 'trackIndexOriginal', 'color'
 ];
 
-var defaultHeatmapColors = [
-  ['00B', 'F00'],
-  ['00B', 'DDD', 'F00'],
-  ['00B', 'AAB', 'FAA', 'F00'],
-  ['00B', 'AAB', 'DDD', 'FAA', 'F00'],
-  [], [], [], [], [], [], [], [], [], [], [], // TODO: Use color palette module
-  ['00D', '22D', '44D', '66D', '88D', 'AAD', 'CCD', 'DDD', 'FCC', 'FAA', 'F88', 'F66', 'F44', 'F22', 'F00']
-]
+var defaultHeatmapColors = {
+  3: ['00B', 'DDD', 'F00'],
+  5: ['00D', '66D', 'DDD', 'F88', 'F00'],
+  17: ['00D', '00D', '00D', '00D', '44D', '44D', 'DDD', 'DDD', 'DDD', 'DDD', 'F88', 'F66', 'F22', 'F22', 'F00']
+}
 
 /**
  * Get label text for displayed tracks from annotation container metadata,
@@ -48,7 +45,7 @@ function getLabels(ideo) {
  * Apply heatmap thresholds that are passed in as annotation metadata
  */
 function inflateThresholds(ideo) {
-  var thresholds, colors, crudeThresholds,
+  var thresholds, colors,
     rawAnnots = ideo.rawAnnots;
 
   if (
@@ -63,25 +60,13 @@ function inflateThresholds(ideo) {
   } else {
     thresholds = ideo.rawAnnots.metadata.heatmapThresholds;
   }
-  
-  colors = defaultHeatmapColors[thresholds.length - 1];
+
+  colors = defaultHeatmapColors[thresholds.length + 1];
   thresholds = thresholds.map((d, i) => {
     return [d, '#' + colors[i]];
   });
 
-  // Coarsen thresholds, emphasize outliers, widen normal range.
-  // TODO: Generalize this for arbitrary number of thresholds.
-  crudeThresholds = [
-    [thresholds[4][0], thresholds[0][1]],
-    [thresholds[6][0], thresholds[3][1]],
-    [thresholds[9][0], thresholds[7][1]],
-    [thresholds[11][0], thresholds[10][1]],
-    [thresholds[14][0], thresholds[14][1]]
-  ]
-
-  thresholds = crudeThresholds;
-
-  thresholds[thresholds.length - 1][0] = '+';
+  thresholds.push(['+', '#' + colors.slice(-1)[0]]);
 
   return thresholds;
 }


### PR DESCRIPTION
This enables adjustable thresholds for heatmaps plotted on collinear ideograms.  This can help adjust the sensitivity of a given metric, e.g. for denoising.

Example:
![ideogram_adjustable_heatmap_threshold](https://user-images.githubusercontent.com/1334561/55875157-54415080-5b62-11e9-84f8-b79020bfc0e8.gif)
