### PR TITLE
Rendering Optimization

### DIFF
--- a/src/js/init/write-container.js
+++ b/src/js/init/write-container.js
@@ -77,6 +77,7 @@ function writeContainerDom(taxid, ideo) {
     .attr('id', '_ideogramMiddleWrap') // needed for overflow and scrolling
       .style('position', 'relative')
       .style('overflow-x', 'auto')
+      .style('transform', 'translateZ(0)') // promote ideogram ele to own compositing layer
     .append('div')
     .attr('id', '_ideogramInnerWrap') // needed for overflow and scrolling
     .append('svg')


### PR DESCRIPTION
Hey there! Noticed that with ideograms with large numbers of annotations (but this applies to ideograms with large numbers of elements in general), scrolling produced a good amount of lag. Did some digging into the cause and found that the following fixed it. Basically the following is an optimization trick to prevent repainting of every ideogram ele on page repaint. Here is an gif of the trick in action.

![prob](https://user-images.githubusercontent.com/14062458/59077611-4af60b00-88a9-11e9-9845-968bedb9aacd.gif)

Thank you!