### PR TITLE
Remove undefined exported variables

### DIFF
--- a/src/js/init/init.js
+++ b/src/js/init/init.js
@@ -221,6 +221,6 @@ function init() {
 }
 
 export {
-  configure, initDrawChromosomes, handleRotateOnClick, setOverflowScroll,
+  configure, initDrawChromosomes, handleRotateOnClick,
   onLoad, init, finishInit, writeContainer
 }

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -174,7 +174,5 @@ function getScientificName(taxid) {
 
 export {
   assemblyIsAccession, hasNonGenBankAssembly, hasGenBankAssembly, getDataDir,
-  drawChromosomeLabels, rotateChromosomeLabels, round, appendHomolog,
-  drawChromosome, rotateAndToggleDisplay, onDidRotate, getSvg, fetch,
-  setOverflowScroll, d3, getTaxid, getCommonName, getScientificName
+  round, onDidRotate, getSvg, fetch, d3, getTaxid, getCommonName, getScientificName
 };


### PR DESCRIPTION
Just some cleaning up, was using the library from src and a linter picked up some of these undefined exported variables.