### PR TITLE
Batch annotation changes

### DIFF
--- a/src/js/annotations/draw.js
+++ b/src/js/annotations/draw.js
@@ -1,4 +1,5 @@
 import {d3} from '../lib';
+import {batchSelections} from '../batch-selections';
 import {writeHistogramAnnots} from './histogram';
 import {writeLegend} from './legend'
 
@@ -190,14 +191,21 @@ function drawAnnotsByLayoutType(layout, annots, ideo) {
   filledAnnots = ideo.fillAnnots(annots);
 
   chrAnnot = getChrAnnotNodes(filledAnnots, ideo);
-
-  if (layout === 'tracks') {
-    writeTrackAnnots(chrAnnot, ideo);
-  } else if (layout === 'overlay') {
-    writeOverlayAnnots(chrAnnot, ideo);
-  } else if (layout === 'histogram') {
-    writeHistogramAnnots(chrAnnot, ideo);
-  }
+  batchSelections(
+    chrAnnot,
+    function(chrAnnotBatch) {
+      if (layout === 'tracks') {
+        writeTrackAnnots(chrAnnotBatch, ideo);
+      } else if (layout === 'overlay') {
+        writeOverlayAnnots(chrAnnotBatch, ideo);
+      } else if (layout === 'histogram') {
+        writeHistogramAnnots(chrAnnotBatch, ideo);
+      }
+    },
+    function() {
+      if (ideo.onDrawAnnotsCallback) ideo.onDrawAnnotsCallback()
+    }
+  );
 }
 
 /**
@@ -223,7 +231,6 @@ function drawProcessedAnnots(annots) {
   }
 
   drawAnnotsByLayoutType(layout, annots, ideo);
-  if (ideo.onDrawAnnotsCallback) ideo.onDrawAnnotsCallback();
 }
 
 export {drawAnnots, drawProcessedAnnots}

--- a/src/js/batch-selections.js
+++ b/src/js/batch-selections.js
@@ -1,0 +1,85 @@
+var maxPerBatch = 600;
+
+var queueBatch = typeof window.requestIdleCallback === 'function'
+  ? function(fn) {
+    window.requestIdleCallback(fn, {timeout: 500});
+  }
+  : setTimeout;
+
+var callNum = 0;
+
+function batchSelections(selection, batchFn, finishedFn) {
+  // Generate random call number and set instance num
+  callNum = Math.random();
+  var instanceNum = callNum;
+
+  // Initialize variables required to split selections object
+  var batchList = [Object.create(selection, {
+    _groups: {
+      value: []
+    },
+    _parents: {
+      value: []
+    }
+  })];
+  var batchNumber = 0;
+  var batchParentsIndex = -1;
+  var batchItemCounter = 0;
+
+  // Split existing selections object into batches
+  for(var parentsIndex = 0; parentsIndex < selection._parents.length; parentsIndex++) {
+    // Start a new parent in current batch
+    batchParentsIndex++;
+    batchList[batchNumber]._parents.push(
+      selection._parents[parentsIndex]
+    );
+    batchList[batchNumber]._groups.push([]);
+
+    for(var groupsIndex = 0; groupsIndex < selection._groups[parentsIndex].length; groupsIndex++) {
+      if(batchItemCounter >= maxPerBatch) {
+        // Start a new batch
+        batchList.push(Object.create(selection, {
+          _groups: {
+            value: [[]]
+          },
+          _parents: {
+            value: [selection._parents[parentsIndex]]
+          }
+        }));
+        batchNumber++;
+        batchParentsIndex = 0;
+        batchItemCounter = 0;
+      }
+
+      // Push node into current batch
+      batchList[batchNumber]._groups[batchParentsIndex].push(
+        selection._groups[parentsIndex][groupsIndex]
+      );
+      batchItemCounter++;
+    }
+  }
+
+  // Setup batch processing queue
+  var batchIndex = 0;
+  function renderBatch(){
+    // If callNum does not match instanceNum cancel
+    // This means that batchSelections has been called again elsewhere
+    // We do not wish to have multiple batches running concurrently
+    if(callNum !== instanceNum) {
+      return;
+    }
+
+    batchFn(batchList[batchIndex++]);
+    if(batchIndex < batchList.length) {
+      queueBatch(renderBatch);
+    }
+    else {
+      finishedFn && finishedFn();
+    }
+  };
+
+  // Start batch processing
+  queueBatch(renderBatch);
+}
+
+export {batchSelections};


### PR DESCRIPTION
We are using ideogram with way over 2000 annotations and as result when these annotations are added or modifed there is a very noticeable hit to performance which is to be expected. It was found that the reason for this slowdown is that D3 adds all the annotations to the DOM in a single function call regardless of the number of annotations being added. Therefore if the function call takes 5 seconds for example, then the page will effectively freeze for those 5 seconds until all the annotations are added.

The solution I have attempted is the following. While it is not possible to speed up the time required to add annotations to the DOM, we can break up the processing of the annotations, so that instead of trying to process them all in one go, it will process them in multiple batches. The idea is so that in between batches the browser can do whatever else it needs to do to ensure the user experience is smooth and the page is functioning normally. I did find that there is a performance hit in terms of total time required to load the annotations completely (on my computer with 31148 annotations, ~9 seconds with these changes, ~ 4 seconds without). This is the result of the browser repainting multiple times while the annotations load, in addition to executing whatever else it needs to. However in terms of user experience it is much better since there is 0 freezing or noticeable lag on the page and the user gets feedback on the load progress from watching the annotations load in gradually.

Here is a test run loading > 30k annotations.
![load](https://user-images.githubusercontent.com/14062458/59316892-a6037580-8c8e-11e9-9f58-25cc3bc669d0.gif)


What are your thoughts on this change? Thanks!

Edit: looking at unit test failures
