### PR TITLE
Allow fetch of bands on change of bands source

### DIFF
--- a/src/js/bands/fetch.js
+++ b/src/js/bands/fetch.js
@@ -1,3 +1,21 @@
+import {hasNonGenBankAssembly} from '../lib';
+
+var lastBandDataUrl = '';
+
+function getBandUrl(bandDataFileNames, taxid, ideo) {
+  return ideo.config.dataDir + bandDataFileNames[taxid];
+}
+
+function shouldFetchBands(bandDataFileNames, taxid, ideo) {
+  var bandDataUrl = getBandUrl(bandDataFileNames, taxid, ideo);
+  return (
+    !(typeof window.chrBands !== 'undefined' && lastBandDataUrl === '')
+      || lastBandDataUrl !== bandDataUrl
+  )
+    && hasNonGenBankAssembly(ideo)
+    && taxid in bandDataFileNames;
+}
+
 function setBandData(url, fileNames, chrBands, ideo) {
   var taxid, fetchedTaxid, fileName;
 
@@ -15,13 +33,14 @@ function setBandData(url, fileNames, chrBands, ideo) {
 }
 
 function fetchBands(bandDataFileNames, taxid, t0, ideo) {
-  var bandDataUrl = ideo.config.dataDir + bandDataFileNames[taxid];
+  var bandDataUrl = getBandUrl(bandDataFileNames, taxid, ideo);
 
   if (!ideo.numBandDataResponses) ideo.numBandDataResponses = 0;
 
   fetch(bandDataUrl)
     .then(function(response) {
       return response.json().then(function(rawBands) {
+        lastBandDataUrl = bandDataUrl;
 
         delete window.chrBands; // Remove any previous chrBands variable
         window.chrBands = rawBands.chrBands;
@@ -39,4 +58,4 @@ function fetchBands(bandDataFileNames, taxid, t0, ideo) {
     });
 }
 
-export {fetchBands}
+export {shouldFetchBands, fetchBands}

--- a/src/js/init/init.js
+++ b/src/js/init/init.js
@@ -2,11 +2,11 @@
  * @fileoveriew Methods for initialization
  */
 
-import {d3, hasNonGenBankAssembly} from '../lib';
+import {d3} from '../lib';
 import {configure} from './configure';
 import {finishInit} from './finish-init';
 import {writeContainer} from './write-container';
-import {fetchBands} from '../bands/fetch';
+import {shouldFetchBands, fetchBands} from '../bands/fetch';
 import {organismMetadata} from './organism-metadata';
 
 function isHeterogameticChromosome(chrModel, chrIndex, ideo) {
@@ -157,10 +157,7 @@ function getBandFileNames(taxid, bandFileNames, ideo) {
 function prepareContainer(taxid, bandFileNames, t0, ideo) {
   var bandsArray;
 
-  if (
-    hasNonGenBankAssembly(ideo) &&
-    typeof chrBands === 'undefined' && taxid in bandFileNames
-  ) {
+  if (shouldFetchBands(bandFileNames, taxid, ideo)) {
     fetchBands(bandFileNames, taxid, t0, ideo);
   } else {
     if (typeof chrBands !== 'undefined') {


### PR DESCRIPTION
Noticed that when changing the bands source (via changing assembly for example) after loading in an initial data source, the updated bands are not fetched. This PR aims to allow different data sources to be loaded after the initial load.