### PR TITLE
Prevent race condition when init called multiple times in quick succession

### DIFF
--- a/src/js/init/init.js
+++ b/src/js/init/init.js
@@ -208,13 +208,31 @@ function getBandsAndPrepareContainer(taxids, t0, ideo) {
  * fetches band and annotation data if needed, and
  * writes an SVG element to the document to contain the ideogram
  */
-function init() {
-  var t0 = new Date().getTime(),
-    ideo = this;
+var ideoNext = {};
+var ideoQueued = false;
+var ideoWait = false;
 
-  initializeTaxids(ideo).then(function(taxids) {
-    getBandsAndPrepareContainer(taxids, t0, ideo);
-  });
+function init(ideo) {
+  ideo = ideo || this;
+
+  if(ideoWait) {
+    ideoQueued = true;
+    ideoNext = ideo;
+  }
+  else {
+    ideoWait = true;
+    initializeTaxids(ideo)
+      .then(function(taxids) {
+        var t0 = new Date().getTime();
+        getBandsAndPrepareContainer(taxids, t0, ideo);
+
+        ideoWait = false;
+        if(ideoQueued) {
+          ideoQueued = false;
+          init(ideoNext);
+        }
+      });
+  }
 }
 
 export {

--- a/src/js/init/init.js
+++ b/src/js/init/init.js
@@ -209,27 +209,28 @@ function getBandsAndPrepareContainer(taxids, t0, ideo) {
  * writes an SVG element to the document to contain the ideogram
  */
 var ideoNext = {};
-var ideoQueued = false;
-var ideoWait = false;
+var ideoQueued = {};
+var ideoWait = {};
 
 function init(ideo) {
   ideo = ideo || this;
+  var containerId = ideo.config.container;
 
-  if(ideoWait) {
-    ideoQueued = true;
-    ideoNext = ideo;
+  if(ideoWait[containerId]) {
+    ideoQueued[containerId] = true;
+    ideoNext[containerId] = ideo;
   }
   else {
-    ideoWait = true;
+    ideoWait[containerId] = true;
     initializeTaxids(ideo)
       .then(function(taxids) {
         var t0 = new Date().getTime();
         getBandsAndPrepareContainer(taxids, t0, ideo);
 
-        ideoWait = false;
-        if(ideoQueued) {
-          ideoQueued = false;
-          init(ideoNext);
+        ideoWait[containerId] = false;
+        if(ideoQueued[containerId]) {
+          ideoQueued[containerId] = false;
+          init(ideoNext[containerId]);
         }
       });
   }

--- a/src/js/init/init.js
+++ b/src/js/init/init.js
@@ -208,6 +208,8 @@ function getBandsAndPrepareContainer(taxids, t0, ideo) {
  * fetches band and annotation data if needed, and
  * writes an SVG element to the document to contain the ideogram
  */
+// Prevents race condition when init is called multiple times in quick succession.  
+// See https://github.com/eweitz/ideogram/pull/154.
 var ideoNext = {};
 var ideoQueued = {};
 var ideoWait = {};

--- a/test/web-test.js
+++ b/test/web-test.js
@@ -54,6 +54,54 @@ describe('Ideogram', function() {
     }
   });
 
+  it('should not have race condition when init is quickly called multiple times', function(done) {
+    // Verifies handling for a Plotly use case.
+    // See https://github.com/eweitz/ideogram/pull/154
+
+    /**
+    * Differences in remotely cached (static) vs. uncached (queried via EUtils)
+    * response times is the likely cause of the race condition that's tested
+    * against here.
+    **/
+
+    var numTimesOnLoadHasBeenCalled = 0;
+
+    function testRaceCondition() {
+      var ideo = this;
+      numTimesOnLoadHasBeenCalled++;
+      var numChimpChromosomes = 25; // See e.g. https://eweitz.github.io/ideogram/eukaryotes?org=pan-troglodytes
+      var numHumanChromosomes = 24; // (22,X,Y)
+      var numChromosomes = ideo.chromosomesArray.length;
+
+      if(numTimesOnLoadHasBeenCalled === 1) {
+        assert.equal(numChromosomes, numChimpChromosomes);
+      }
+      else if(numTimesOnLoadHasBeenCalled === 2) {
+        assert.equal(numChromosomes, numHumanChromosomes);
+        done();
+      }
+    }
+
+    function startRaceCondition() {
+      new Ideogram({
+        organism: 'pan-troglodytes',
+        dataDir: '/dist/data/bands/native/',
+        onLoad: testRaceCondition
+      });
+      new Ideogram({
+        organism: 'human',
+        dataDir: '/dist/data/bands/native/',
+        onLoad: testRaceCondition
+      });
+    }
+
+    var ideogram = new Ideogram({
+      organism: 'human',
+      dataDir: '/dist/data/bands/native/',
+      onLoad: startRaceCondition
+    });
+  });
+
   it('should have a non-body container when specified', function() {
     config.container = '.small-ideogram';
     var ideogram = new Ideogram(config);


### PR DESCRIPTION
Hey! Noticed that for example, when ideogram is initialized with species chimpanzee and then is quickly initialized again with human, the human ideogram finishes first and then the chimpanzee ideogram finishes second, meaning that a chimpanzee ideogram would be displayed in the end even though it was called before the human ideogram.

The following fixes this problem so that if ideogram is called while its still executing a previous call, it will not attempt to execute the two calls simultaneously but instead queue it. If ideogram is called multiple times while its working on a previous call, it will execute the last call made while it was busy and ignore the rest.

Edit: Change made so that each container has its own separate queue so that init calls for different containers can execute simultaneously 