### PR TITLE
Add d3-transition to the list of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "d3-fetch": "^1.1.2",
     "d3-scale": "^1.0.6",
     "d3-selection": "^1.3.2",
+    "d3-transition": "^1.2.0",
     "es6-natural-sort": "1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
When trying to build dash-bio with the newest version of ideogram (upgrading from 1.4.1), I get an error when changing layout. A screenshot of the error is linked below. I still don't fully understand the cause of the problem but I believe it has something to do with an update to the `d3-selection` library between versions `1.3.0` and all versions above. Basically below that version, everything works fine. Above, the `d3-transition` dependency needs to be specified in ideogram.

![Screenshot from 2019-07-23 15-36-24](https://user-images.githubusercontent.com/14062458/61741797-ab5ce100-ad5f-11e9-8e3f-b37d721e2f4e.png)

Note: this appears to only be a problem when using ideogram itself as a dependency.