### PR TITLE
Work around broken GenColl ELink

### DIFF
--- a/examples/vanilla/eukaryotes.html
+++ b/examples/vanilla/eukaryotes.html
@@ -49,19 +49,21 @@
         <li><label for="rattus-norvegicus"><input type="radio" name="org" value="rattus-norvegicus" id="rattus-norvegicus">Rat (Rattus norvegicus)</label></li>
         <li><label for="drosophila-melanogaster"><input type="radio" name="org" value="drosophila-melanogaster" id="drosophila-melanogaster">Fly (Drosophila melanogaster)</label>
         <li><label for="caenorhabditis-elegans"><input type="radio" name="org" value="caenorhabditis-elegans" id="caenorhabditis-elegans">Worm (Caenorhabditis elegans)</label></li>
-        <li><label for="danio-rerio"><input type="radio" name="org" value="danio-rerio" id="danio-rerio">Zebrafish (Danio rerio)</label></li>
+        <!-- <li><label for="danio-rerio"><input type="radio" name="org" value="danio-rerio" id="danio-rerio">Zebrafish (Danio rerio)</label></li> -->
         <li><label for="arabidopsis-thaliana"><input type="radio" name="org" value="arabidopsis-thaliana" id="arabidopsis-thaliana">Thale cress (Arabidopsis thaliana)</label></li>
+        <li><label for="saccharomyces-cerevisiae"><input type="radio" name="org" value="saccharomyces-cerevisiae" id="saccharomyces-cerevisiae">Yeast (Saccharomyces cerevisiae)</label></li>
       </ul>
     </li>
     <li>
       Vertebrates
       <ul>
         <li><label for="pan-troglodytes"><input type="radio" name="org" value="pan-troglodytes" id="pan-troglodytes">Chimpanzee (Pan troglodytes)</label></li>
+        <li><label for="macaca-mulatta"><input type="radio" name="org" value="macaca-mulatta" id="macaca-mulatta">Macaque (Macaca mulatta)</label></li>
         <li><label for="felis-catus"><input type="radio" name="org" value="felis-catus" id="felis-catus">Cat (Felis catus)</label></li>
         <!-- <li><label for="canis-lupus-familiaris"><input type="radio" name="org" value="canis-lupus-familiaris" id="canis-lupus-familiaris">Dog (Canis lupus familiaris)</label></li> -->
         <!-- <li><label for="gallus-gallus"><input type="radio" name="org" value="gallus-gallus" id="gallus-gallus">Chicken (Gallus gallus)</label></li> -->
         <!-- <li><label for="bos-taurus"><input type="radio" name="org" value="bos-taurus" id="bos-taurus">Cow (Bos taurus)</label></li> -->
-        <li><label for="sus-scrofa"><input type="radio" name="org" value="sus-scrofa" id="sus-scrofa">Pig (Sus scrofa)</label></li>
+        <!-- <li><label for="sus-scrofa"><input type="radio" name="org" value="sus-scrofa" id="sus-scrofa">Pig (Sus scrofa)</label></li> -->
       </ul>
     </li>
     <li>
@@ -69,9 +71,10 @@
       <ul>
         <li><label for="zea-mays"><input type="radio" name="org" value="zea-mays" id="zea-mays">Maize (Zea mays)</label></li>
         <li><label for="oryza-sativa"><input type="radio" name="org" value="oryza-sativa" id="oryza-sativa">Rice (Oryza sativa)</label>
-        <li><label for="solanum-lycopersicum"><input type="radio" name="org" value="solanum-lycopersicum" id="solanum-lycopersicum">Tomato (Solanum lycopersicum)</label></li>
+        <!-- <li><label for="solanum-lycopersicum"><input type="radio" name="org" value="solanum-lycopersicum" id="solanum-lycopersicum">Tomato (Solanum lycopersicum)</label></li> -->
         <li><label for="musa-acuminata"><input type="radio" name="org" value="musa-acuminata" id="musa-acuminata">Banana (Musa acuminata)</label></li>
-        <li><label for="vitis-vinifera"><input type="radio" name="org" value="vitis-vinifera" id="vitis-vinifera">Grape (Vitis vinifera)</label></li>
+        <!-- <li><label for="vitis-vinifera"><input type="radio" name="org" value="vitis-vinifera" id="vitis-vinifera">Grape (Vitis vinifera)</label></li> -->
+        <li><label for="micromonas-commoda"><input type="radio" name="org" value="micromonas-commoda" id="micromonas-commoda">Green algae</label></li>
       </ul>
     </li>
     <li>

--- a/src/js/ideogram.js
+++ b/src/js/ideogram.js
@@ -24,11 +24,10 @@ import {
 } from './annotations/annotations'
 
 import {
-  getTaxids,
-  // esearch, esummary, elink,
-  // getTaxidFromEutils, getOrganismFromEutils,
-  // setTaxidData,
-  // getAssemblyAndChromosomesFromEutils
+  esearch, esummary, elink,
+  getTaxidFromEutils, getOrganismFromEutils, getTaxids,
+  setTaxidAndAssemblyAndChromosomes, setTaxidData,
+  getAssemblyAndChromosomesFromEutils
 } from './services/services';
 
 import {
@@ -92,16 +91,15 @@ export default class Ideogram {
     this.afterRawAnnots = afterRawAnnots;
 
     // Variables and functions from services.js
-
+    this.esearch = esearch;
+    this.esummary = esummary;
+    this.elink = elink;
+    this.getTaxidFromEutils = getTaxidFromEutils;
+    this.setTaxidData = setTaxidData;
+    this.setTaxidAndAssemblyAndChromosomes = setTaxidAndAssemblyAndChromosomes;
+    this.getOrganismFromEutils = getOrganismFromEutils;
     this.getTaxids = getTaxids;
-    // this.esearch = esearch;
-    // this.esummary = esummary;
-    // this.elink = elink;
-    // this.getTaxidFromEutils = getTaxidFromEutils;
-    // this.setTaxidData = setTaxidData;
-    // this.setTaxidAndAssemblyAndChromosomes = setTaxidAndAssemblyAndChromosomes;
-    // this.getOrganismFromEutils = getOrganismFromEutils;
-    // this.getAssemblyAndChromosomesFromEutils = getAssemblyAndChromosomesFromEutils;
+    this.getAssemblyAndChromosomesFromEutils = getAssemblyAndChromosomesFromEutils;
 
     // Functions from bands.js
     this.parseBands = parseBands;
@@ -181,41 +179,41 @@ export default class Ideogram {
   }
 
 
-  // /**
-  //  * Sorts two chromosome objects by type and name
-  //  * - Nuclear chromosomes come before non-nuclear chromosomes.
-  //  * - Among nuclear chromosomes, use "natural sorting", e.g.
-  //  *   numbers come before letters
-  //  * - Among non-nuclear chromosomes, i.e. "MT" (mitochondrial DNA) and
-  //  *   "CP" (chromoplast DNA), MT comes first
-  //  *
-  //  *
-  //  * @param a Chromosome object "A"
-  //  * @param b Chromosome object "B"
-  //  * @returns {Number} JavaScript sort order indicator
-  //  */
-  // static sortChromosomes(a, b) {
-  //   var aIsNuclear = a.type === 'nuclear',
-  //     bIsNuclear = b.type === 'nuclear',
-  //     aIsCP = a.type === 'chloroplast',
-  //     bIsCP = b.type === 'chloroplast',
-  //     aIsMT = a.type === 'mitochondrion',
-  //     bIsMT = b.type === 'mitochondrion',
-  //     aIsAP = a.type === 'apicoplast',
-  //     bIsAP = b.type === 'apicoplast';
-  //   // aIsPlastid = aIsMT && a.name !== 'MT', // e.g. B1 in rice genome GCF_001433935.1
-  //   // bIsPlastid = bIsMT && b.name !== 'MT';
+  /**
+   * Sorts two chromosome objects by type and name
+   * - Nuclear chromosomes come before non-nuclear chromosomes.
+   * - Among nuclear chromosomes, use "natural sorting", e.g.
+   *   numbers come before letters
+   * - Among non-nuclear chromosomes, i.e. "MT" (mitochondrial DNA) and
+   *   "CP" (chromoplast DNA), MT comes first
+   *
+   *
+   * @param a Chromosome object "A"
+   * @param b Chromosome object "B"
+   * @returns {Number} JavaScript sort order indicator
+   */
+  static sortChromosomes(a, b) {
+    var aIsNuclear = a.type === 'nuclear',
+      bIsNuclear = b.type === 'nuclear',
+      aIsCP = a.type === 'chloroplast',
+      bIsCP = b.type === 'chloroplast',
+      aIsMT = a.type === 'mitochondrion',
+      bIsMT = b.type === 'mitochondrion',
+      aIsAP = a.type === 'apicoplast',
+      bIsAP = b.type === 'apicoplast';
+    // aIsPlastid = aIsMT && a.name !== 'MT', // e.g. B1 in rice genome GCF_001433935.1
+    // bIsPlastid = bIsMT && b.name !== 'MT';
 
-  //   if (aIsNuclear && bIsNuclear) {
-  //     return naturalSort(a.name, b.name);
-  //   } else if (!aIsNuclear && bIsNuclear) {
-  //     return 1;
-  //   } else if (aIsMT && bIsCP) {
-  //     return 1;
-  //   } else if (aIsCP && bIsMT) {
-  //     return -1;
-  //   } else if (!aIsAP && !aIsMT && !aIsCP && (bIsMT || bIsCP || bIsAP)) {
-  //     return -1;
-  //   }
-  // }
+    if (aIsNuclear && bIsNuclear) {
+      return naturalSort(a.name, b.name);
+    } else if (!aIsNuclear && bIsNuclear) {
+      return 1;
+    } else if (aIsMT && bIsCP) {
+      return 1;
+    } else if (aIsCP && bIsMT) {
+      return -1;
+    } else if (!aIsAP && !aIsMT && !aIsCP && (bIsMT || bIsCP || bIsAP)) {
+      return -1;
+    }
+  }
 }

--- a/src/js/init/init.js
+++ b/src/js/init/init.js
@@ -180,14 +180,14 @@ function prepareContainer(taxid, bandFileNames, t0, ideo) {
 
 function initializeTaxids(ideo) {
   return new Promise(function(resolve) {
-    // if (typeof ideo.config.organism === 'number') {
-    //   // 'organism' is a taxid, e.g. 9606
-    //   ideo.getOrganismFromEutils(function() {
-    //     ideo.getTaxids(resolve);
-    //   });
-    // } else {
+    if (typeof ideo.config.organism === 'number') {
+      // 'organism' is a taxid, e.g. 9606
+      ideo.getOrganismFromEutils(function() {
+        ideo.getTaxids(resolve);
+      });
+    } else {
       ideo.getTaxids(resolve);
-    // }
+    }
   });
 }
 

--- a/src/js/model-adapter.js
+++ b/src/js/model-adapter.js
@@ -6,11 +6,11 @@ export class ModelAdapter {
   }
 
   static getInstance(model) {
-    // if (model.bands) {
+    if (model.bands) {
       return new ModelAdapter(model);
-    // } else {
-    //   return new ModelNoBandsAdapter(model);
-    // }
+    } else {
+      return new ModelNoBandsAdapter(model);
+    }
   }
 
   getModel() {
@@ -22,36 +22,37 @@ export class ModelAdapter {
   }
 }
 
-// export class ModelNoBandsAdapter extends ModelAdapter {
+export class ModelNoBandsAdapter extends ModelAdapter {
 
-//   constructor(model) {
-//     super(model);
-//     this._class = 'ModelNoBandsAdapter';
-//   }
+  constructor(model) {
+    super(model);
+    this._class = 'ModelNoBandsAdapter';
+  }
 
-//   getModel() {
-//     this._model.bands = [];
+  getModel() {
+    this._model.bands = [];
 
-//     // If chromosome width more than 1, add single band to bands array
-//     if (this._model.width > 1) {
-//       this._model.bands.push({
-//         name: 'q',
-//         px: {
-//           start: 0,
-//           stop: this._model.width,
-//           width: this._model.width
-//         },
-//         bp: {
-//           start: 1,
-//           stop: this._model.length
-//         }
-//       });
-//     }
+    // If chromosome width more than 1, add single band to bands array
+    if (this._model.width > 1) {
+      this._model.bands.push({
+        name: 'q',
+        px: {
+          start: 0,
+          stop: this._model.width,
+          width: this._model.width
+        },
+        bp: {
+          start: 1,
+          stop: this._model.length
+        }
+      });
+    }
 
-//     return this._model;
-//   }
+    return this._model;
+  }
 
-//   getCssClass() {
-//     return 'noBands';
-//   }
-// }
+  getCssClass() {
+    return 'noBands';
+  }
+
+}

--- a/src/js/services/organisms.js
+++ b/src/js/services/organisms.js
@@ -1,122 +1,122 @@
-// import {d3} from '../lib';
+import {d3} from '../lib';
 
-// /**
-//  *  Returns an NCBI taxonomy identifier (taxid) for the configured organism
-//  */
-// function getTaxidFromEutils(callback) {
-//   var organism, taxonomySearch, taxid,
-//     ideo = this;
+/**
+ *  Returns an NCBI taxonomy identifier (taxid) for the configured organism
+ */
+function getTaxidFromEutils(callback) {
+  var organism, taxonomySearch, taxid,
+    ideo = this;
 
-//   organism = ideo.config.organism;
+  organism = ideo.config.organism;
 
-//   taxonomySearch = ideo.esearch + '&db=taxonomy&term=' + organism;
+  taxonomySearch = ideo.esearch + '&db=taxonomy&term=' + organism;
 
-//   d3.json(taxonomySearch).then(function(data) {
-//     taxid = data.esearchresult.idlist[0];
-//     if (typeof ideo.config.taxids === 'undefined') {
-//       ideo.config.taxids = [taxid];
-//     } else {
-//       ideo.config.taxids.push(taxid);
-//     }
-//     return callback(taxid);
-//   });
-// }
+  d3.json(taxonomySearch).then(function(data) {
+    taxid = data.esearchresult.idlist[0];
+    if (typeof ideo.config.taxids === 'undefined') {
+      ideo.config.taxids = [taxid];
+    } else {
+      ideo.config.taxids.push(taxid);
+    }
+    return callback(taxid);
+  });
+}
 
-// function setTaxidData(taxid) {
-//   var organism, dataDir, urlOrg, taxids,
-//     ideo = this;
+function setTaxidData(taxid) {
+  var organism, dataDir, urlOrg, taxids,
+    ideo = this;
 
-//   organism = ideo.config.organism;
-//   dataDir = ideo.config.dataDir;
-//   urlOrg = organism.replace(' ', '-');
+  organism = ideo.config.organism;
+  dataDir = ideo.config.dataDir;
+  urlOrg = organism.replace(' ', '-');
 
-//   taxids = [taxid];
+  taxids = [taxid];
 
-//   ideo.organisms[taxid] = {
-//     commonName: '',
-//     scientificName: organism,
-//     scientificNameAbbr: ''
-//   };
+  ideo.organisms[taxid] = {
+    commonName: '',
+    scientificName: organism,
+    scientificNameAbbr: ''
+  };
 
-//   var fullyBandedTaxids = ['9606', '10090', '10116'];
-//   if (fullyBandedTaxids.includes(taxid) && !ideo.config.showFullyBanded) {
-//     urlOrg += '-no-bands';
-//   }
-//   var chromosomesUrl = dataDir + urlOrg + '.json';
+  var fullyBandedTaxids = ['9606', '10090', '10116'];
+  if (fullyBandedTaxids.includes(taxid) && !ideo.config.showFullyBanded) {
+    urlOrg += '-no-bands';
+  }
+  var chromosomesUrl = dataDir + urlOrg + '.json';
 
-//   var promise2 = new Promise(function(resolve, reject) {
-//     fetch(chromosomesUrl).then(function(response) {
-//       if (response.ok === false) {
-//         reject(Error('Fetch failed for ' + chromosomesUrl));
-//       } else {
-//         return response.json().then(function(json) {
-//           resolve(json);
-//         });
-//       }
-//     });
-//   });
+  var promise2 = new Promise(function(resolve, reject) {
+    fetch(chromosomesUrl).then(function(response) {
+      if (response.ok === false) {
+        reject(Error('Fetch failed for ' + chromosomesUrl));
+      } else {
+        return response.json().then(function(json) {
+          resolve(json);
+        });
+      }
+    });
+  });
 
-//   return promise2
-//   .then(function(data) {
-//     // Check if chromosome data exists locally.
-//     // This is used for pre-processed centromere data,
-//     // which is not accessible via EUtils.  See get_chromosomes.py.
+  return promise2
+  .then(function(data) {
+    // Check if chromosome data exists locally.
+    // This is used for pre-processed centromere data,
+    // which is not accessible via EUtils.  See get_chromosomes.py.
 
-//     var asmAndChrTaxidsArray = [''],
-//         chromosomes = [],
-//         seenChrs = {},
-//         chr;
+    var asmAndChrTaxidsArray = [''],
+        chromosomes = [],
+        seenChrs = {},
+        chr;
 
-//     window.chrBands = data.chrBands;
+    window.chrBands = data.chrBands;
 
-//     for (var i = 0; i < chrBands.length; i++) {
-//       chr = chrBands[i].split(' ')[0];
-//       if (chr in seenChrs) {
-//         continue;
-//       } else {
-//         chromosomes.push({name: chr, type: 'nuclear'});
-//         seenChrs[chr] = 1;
-//       }
-//     }
-//     chromosomes = chromosomes.sort(Ideogram.sortChromosomes);
-//     asmAndChrTaxidsArray.push(chromosomes);
-//     asmAndChrTaxidsArray.push(taxids);
-//     ideo.coordinateSystem = 'iscn';
-//     return asmAndChrTaxidsArray;
-//   },
-//   function() {
-//     return new Promise(function(resolve) {
-//       ideo.coordinateSystem = 'bp';
-//       ideo.getAssemblyAndChromosomesFromEutils(resolve);
-//     });
-//   });
-// }
+    for (var i = 0; i < chrBands.length; i++) {
+      chr = chrBands[i].split(' ')[0];
+      if (chr in seenChrs) {
+        continue;
+      } else {
+        chromosomes.push({name: chr, type: 'nuclear'});
+        seenChrs[chr] = 1;
+      }
+    }
+    chromosomes = chromosomes.sort(Ideogram.sortChromosomes);
+    asmAndChrTaxidsArray.push(chromosomes);
+    asmAndChrTaxidsArray.push(taxids);
+    ideo.coordinateSystem = 'iscn';
+    return asmAndChrTaxidsArray;
+  },
+  function() {
+    return new Promise(function(resolve) {
+      ideo.coordinateSystem = 'bp';
+      ideo.getAssemblyAndChromosomesFromEutils(resolve);
+    });
+  });
+}
 
-// function setTaxidAndAssemblyAndChromosomes(callback) {
-//   var assembly, chromosomes, getTaxidsFromEutils, taxid, taxids,
-//     ideo = this;
+function setTaxidAndAssemblyAndChromosomes(callback) {
+  var assembly, chromosomes, getTaxidsFromEutils, taxid, taxids,
+    ideo = this;
 
-//   getTaxidsFromEutils = new Promise(function(resolve) {
-//     ideo.getTaxidFromEutils(resolve);
-//   });
+  getTaxidsFromEutils = new Promise(function(resolve) {
+    ideo.getTaxidFromEutils(resolve);
+  });
 
-//   getTaxidsFromEutils
-//   .then(function(data) {
-//     taxid = data;
-//     return ideo.setTaxidData(taxid);
-//   })
-//   .then(function(asmChrTaxidsArray) {
-//     assembly = asmChrTaxidsArray[0];
-//     chromosomes = asmChrTaxidsArray[1];
-//     taxids = ideo.config.taxids;
-//     ideo.config.chromosomes = chromosomes;
-//     ideo.organisms[taxid].assemblies = {
-//       default: assembly
-//     };
+  getTaxidsFromEutils
+  .then(function(data) {
+    taxid = data;
+    return ideo.setTaxidData(taxid);
+  })
+  .then(function(asmChrTaxidsArray) {
+    assembly = asmChrTaxidsArray[0];
+    chromosomes = asmChrTaxidsArray[1];
+    taxids = ideo.config.taxids;
+    ideo.config.chromosomes = chromosomes;
+    ideo.organisms[taxid].assemblies = {
+      default: assembly
+    };
 
-//     callback(taxids);
-//   });
-// }
+    callback(taxids);
+  });
+}
 
 function isOrganismSupported(sourceOrg, targetTaxid, ideo) {
   var org = sourceOrg,
@@ -162,18 +162,18 @@ function getTaxidsForOrganismInConfig(taxids, callback, ideo) {
 
   [tmpChrs, taxids] = prepareTmpChrsAndTaxids(ideo);
 
-  // if (
-  //   taxids.length === 0 ||
-  //   ideo.assemblyIsAccession() && /GCA_/.test(ideo.config.assembly)
-  // ) {
-  //   ideo.setTaxidAndAssemblyAndChromosomes(callback);
-  // } else {
+  if (
+    taxids.length === 0 ||
+    ideo.assemblyIsAccession() && /GCA_/.test(ideo.config.assembly)
+  ) {
+    ideo.setTaxidAndAssemblyAndChromosomes(callback);
+  } else {
     ideo.config.taxids = taxids;
     if (ideo.config.multiorganism) {
       ideo.config.chromosomes = tmpChrs;
     }
     callback(taxids);
-  // }
+  }
 }
 
 function getIsMultiorganism(taxidInit, ideo) {
@@ -183,20 +183,20 @@ function getIsMultiorganism(taxidInit, ideo) {
   );
 }
 
-// function getTaxidsForOrganismNotInConfig(taxids, taxidInit, callback, ideo) {
-//   if (ideo.config.multiorganism) {
-//     ideo.coordinateSystem = 'bp';
-//     if (taxidInit) {
-//       taxids = ideo.config.taxid;
-//     }
-//   } else {
-//     if (taxidInit) {
-//       taxids = [ideo.config.taxid];
-//     }
-//     ideo.config.taxids = taxids;
-//   }
-//   callback(taxids);
-// }
+function getTaxidsForOrganismNotInConfig(taxids, taxidInit, callback, ideo) {
+  if (ideo.config.multiorganism) {
+    ideo.coordinateSystem = 'bp';
+    if (taxidInit) {
+      taxids = ideo.config.taxid;
+    }
+  } else {
+    if (taxidInit) {
+      taxids = [ideo.config.taxid];
+    }
+    ideo.config.taxids = taxids;
+  }
+  callback(taxids);
+}
 
 /**
  * Returns an array of taxids for the current ideogram
@@ -211,36 +211,35 @@ function getTaxids(callback) {
 
   ideo.config.multiorganism = getIsMultiorganism(taxidInit, ideo);
 
-  // if ('organism' in ideo.config) {
+  if ('organism' in ideo.config) {
     getTaxidsForOrganismInConfig(taxids, callback, ideo)
-  // } else {
-  //  getTaxidsForOrganismNotInConfig(taxids, taxidInit, callback, ideo);
-  // }
+  } else {
+    getTaxidsForOrganismNotInConfig(taxids, taxidInit, callback, ideo);
+  }
 }
 
-// /**
-//  * Searches NCBI EUtils for the common organism name for this ideogram
-//  * instance's taxid (i.e. NCBI Taxonomy ID)
-//  *
-//  * @param callback Function to call upon completing ESearch request
-//  */
-// function getOrganismFromEutils(callback) {
-//   var organism, taxonomySearch, taxid,
-//     ideo = this;
+/**
+ * Searches NCBI EUtils for the common organism name for this ideogram
+ * instance's taxid (i.e. NCBI Taxonomy ID)
+ *
+ * @param callback Function to call upon completing ESearch request
+ */
+function getOrganismFromEutils(callback) {
+  var organism, taxonomySearch, taxid,
+    ideo = this;
 
-//   taxid = ideo.config.organism;
+  taxid = ideo.config.organism;
 
-//   taxonomySearch = ideo.esummary + '&db=taxonomy&id=' + taxid;
+  taxonomySearch = ideo.esummary + '&db=taxonomy&id=' + taxid;
 
-//   d3.json(taxonomySearch).then(function(data) {
-//     organism = data.result[String(taxid)].commonname;
-//     ideo.config.organism = organism;
-//     return callback(organism);
-//   });
-// }
+  d3.json(taxonomySearch).then(function(data) {
+    organism = data.result[String(taxid)].commonname;
+    ideo.config.organism = organism;
+    return callback(organism);
+  });
+}
 
 export {
-  getTaxids,
-  getTaxidFromEutils,
+  getTaxidFromEutils, setTaxidAndAssemblyAndChromosomes, getTaxids,
   setTaxidData, getOrganismFromEutils
 }

--- a/src/js/services/services.js
+++ b/src/js/services/services.js
@@ -1,232 +1,231 @@
-// import {d3, hasGenBankAssembly} from '../lib';
-// import {
-//   esearch, esummary, elink, getAssemblySearchUrl
-// } from './eutils-config.js';
+import {d3, hasGenBankAssembly} from '../lib';
 import {
-  getTaxids,
-  // getTaxidFromEutils,
-  // setTaxidData, getOrganismFromEutils
+  esearch, esummary, elink, getAssemblySearchUrl
+} from './eutils-config.js';
+import {
+  getTaxidFromEutils, getTaxids, setTaxidAndAssemblyAndChromosomes,
+  setTaxidData, getOrganismFromEutils
 } from './organisms.js';
 
-// function getNuccoreQueryString(gbUid, asmUid, recovering, ideo) {
-//   var qs;
+function getNuccoreQueryString(gbUid, asmUid, recovering, ideo) {
+  var qs;
 
-//   // Get a list of IDs for the chromosomes in this genome.
-//   //
-//   // If this is our first pass, or if assembly is GenBank-only, or if
-//   // a GenBank assembly was explicitly requested (GCA_), then query RefSeq
-//   // sequences in Nucleotide DB.  Otherwise, query the lesser-known
-//   // GenColl (Genomic Collections) DB.
-//   if (hasGenBankAssembly(ideo) || typeof recovering !== 'undefined') {
-//     // TODO: account for GenBank-only
-//     qs = '&db=nuccore&linkname=gencoll_nuccore_chr&from_uid=' + gbUid;
-//   } else {
-//     qs = '&db=nuccore&linkname=assembly_nuccore_refseq&from_uid=' + asmUid;
-//   }
+  // Get a list of IDs for the chromosomes in this genome.
+  //
+  // If this is our first pass, or if assembly is GenBank-only, or if
+  // a GenBank assembly was explicitly requested (GCA_), then query RefSeq
+  // sequences in Nucleotide DB.  Otherwise, query the lesser-known
+  // GenColl (Genomic Collections) DB.
+  if (hasGenBankAssembly(ideo) || typeof recovering !== 'undefined') {
+    // TODO: account for GenBank-only
+    qs = '&db=nuccore&linkname=assembly_nuccore_insdc&from_uid=' + asmUid;
+  } else {
+    qs = '&db=nuccore&linkname=assembly_nuccore_refseq&from_uid=' + asmUid;
+  }
 
-//   return qs;
-// }
+  return qs;
+}
 
-// function getAssemblyAndNuccoreLink(data, asmAndChrArray, recovering, ideo) {
-//   var assembly, qs, gbUid, nuccoreLink, asmUid;
+function getAssemblyAndNuccoreLink(data, asmAndChrArray, recovering, ideo) {
+  var assembly, qs, gbUid, nuccoreLink, asmUid;
 
-//   asmUid = data.result.uids[0];
-//   assembly = data.result[asmUid];
-//   // rsUid = assembly.rsuid; // RefSeq UID for this assembly
-//   gbUid = assembly.gbuid; // GenBank UID
+  asmUid = data.result.uids[0];
+  assembly = data.result[asmUid];
+  // rsUid = assembly.rsuid; // RefSeq UID for this assembly
+  gbUid = assembly.gbuid; // GenBank UID
 
-//   asmAndChrArray.push(assembly.assemblyaccession);
+  asmAndChrArray.push(assembly.assemblyaccession);
 
-//   qs = getNuccoreQueryString(gbUid, asmUid, recovering, ideo);
-//   nuccoreLink = ideo.elink + qs;
+  qs = getNuccoreQueryString(gbUid, asmUid, recovering, ideo);
+  nuccoreLink = ideo.elink + qs;
 
-//   return [asmAndChrArray, nuccoreLink];
-// }
+  return [asmAndChrArray, nuccoreLink];
+}
 
-// /**
-//  *  If the list of presumed chromosomes is longer than 100 elements, then
-//  * we've likely fetched scaffolds instead of chromosomes.  This
-//  * happens with e.g. Sus scrofa (pig).  Try recovering once via a
-//  * different query, and throw an error upon any subsequent failure.
-//  */
-// function handleScaffoldData(data, asmAndChrArray, context) {
-//   var assemblyAccession = asmAndChrArray[0],
-//     ideo = context.ideo;
-//   if (data.linksets[0].linksetdbs[0].links.length > 100) {
-//     if (typeof context.recovering === 'undefined') {
-//       ideo.getAssemblyAndChromosomesFromEutils(context.callback, true);
-//       return Promise.reject(
-//         'Unexpectedly found genomic scaffolds instead of chromosomes ' +
-//         'while querying RefSeq.  Recovering.'
-//       );
-//     } else {
-//       // Avoid flooding NCBI with EUtils requests.
-//       throw Error(
-//         'Failed to find chromosomes for genome ' + assemblyAccession
-//       );
-//     }
-//   }
-// }
+/**
+ *  If the list of presumed chromosomes is longer than 100 elements, then
+ * we've likely fetched scaffolds instead of chromosomes.  This
+ * happens with e.g. Sus scrofa (pig).  Try recovering once via a
+ * different query, and throw an error upon any subsequent failure.
+ */
+function handleScaffoldData(data, asmAndChrArray, context) {
+  var assemblyAccession = asmAndChrArray[0],
+    linksets = data.linksets[0],
+    ideo = context.ideo;
+  if ('linksetdbs' in linksets && linksets.linksetdbs[0].links.length > 100) {
+    if (typeof context.recovering === 'undefined') {
+      ideo.getAssemblyAndChromosomesFromEutils(context.callback, true);
+      return Promise.reject(
+        'Unexpectedly found genomic scaffolds instead of chromosomes ' +
+        'while querying RefSeq.  Recovering.'
+      );
+    } else {
+      // Avoid flooding NCBI with EUtils requests.
+      throw Error(
+        'Failed to find chromosomes for genome ' + assemblyAccession
+      );
+    }
+  }
+}
 
-// function fetchNucleotideSummary(data, assemblyAccession, context) {
-//   var links, ntSummary;
+function fetchNucleotideSummary(data, assemblyAccession, context) {
+  var links, ntSummary;
 
-//   handleScaffoldData(data, assemblyAccession, context);
+  handleScaffoldData(data, assemblyAccession, context);
 
-//   links = data.linksets[0].linksetdbs[0].links.join(',');
-//   ntSummary = context.ideo.esummary + '&db=nucleotide&id=' + links;
+  links = data.linksets[0].linksetdbs[0].links.join(',');
+  ntSummary = context.ideo.esummary + '&db=nucleotide&id=' + links;
 
-//   return d3.json(ntSummary);
-// }
+  return d3.json(ntSummary);
+}
 
-// function parseMitochondrion(result, ideo) {
-//   var type, cnIndex, chrName;
+function parseMitochondrion(result, ideo) {
+  var type, cnIndex, chrName;
 
-//   if (ideo.config.showNonNuclearChromosomes) {
-//     type = result.genome;
-//     cnIndex = result.subtype.split('|').indexOf('plasmid');
-//     if (cnIndex === -1) {
-//       chrName = 'MT';
-//     } else {
-//       // Seen in e.g. rice genome IRGSP-1.0 (GCF_001433935.1),
-//       // From https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?retmode=json&db=nucleotide&id=996703432,996703431,996703430,996703429,996703428,996703427,996703426,996703425,996703424,996703423,996703422,996703421,194033210,11466763,7524755
-//       // genome: 'mitochondrion',
-//       // subtype: 'cell_line|plasmid',
-//       // subname: 'A-58 CMS|B1',
-//       chrName = result.subname.split('|')[cnIndex];
-//     }
-//   } else {
-//     return [null, null];
-//   }
+  if (ideo.config.showNonNuclearChromosomes) {
+    type = result.genome;
+    cnIndex = result.subtype.split('|').indexOf('plasmid');
+    if (cnIndex === -1) {
+      chrName = 'MT';
+    } else {
+      // Seen in e.g. rice genome IRGSP-1.0 (GCF_001433935.1),
+      // From https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?retmode=json&db=nucleotide&id=996703432,996703431,996703430,996703429,996703428,996703427,996703426,996703425,996703424,996703423,996703422,996703421,194033210,11466763,7524755
+      // genome: 'mitochondrion',
+      // subtype: 'cell_line|plasmid',
+      // subname: 'A-58 CMS|B1',
+      chrName = result.subname.split('|')[cnIndex];
+    }
+  } else {
+    return [null, null];
+  }
 
-//   return [chrName, type];
-// }
+  return [chrName, type];
+}
 
-// function parseChloroplastOrPlastid(ideo) {
-//   // Plastid encountered with rice genome IRGSP-1.0 (GCF_001433935.1)
-//   if (ideo.config.showNonNuclearChromosomes) {
-//     return ['CP', 'chloroplast'];
-//   } 
-//   return [null, null];
-// }
+function parseChloroplastOrPlastid(ideo) {
+  // Plastid encountered with rice genome IRGSP-1.0 (GCF_001433935.1)
+  if (ideo.config.showNonNuclearChromosomes) {
+    return ['CP', 'chloroplast'];
+  } 
+  return [null, null];
+}
 
-// function parseApicoplast(ideo) {
-//   if (ideo.config.showNonNuclearChromosomes) {
-//     return ['AP', 'apicoplast'];
-//   } 
-//   return [null, null];
-// }
+function parseApicoplast(ideo) {
+  if (ideo.config.showNonNuclearChromosomes) {
+    return ['AP', 'apicoplast'];
+  } 
+  return [null, null];
+}
 
-// function parseNuclear(result) {
-//   var type, cnIndex, chrName;
+function parseNuclear(result) {
+  var type, cnIndex, chrName;
 
-//   type = 'nuclear';
-//   cnIndex = result.subtype.split('|').indexOf('chromosome');
-//   chrName = result.subname.split('|')[cnIndex];
+  type = 'nuclear';
+  cnIndex = result.subtype.split('|').indexOf('chromosome');
+  chrName = result.subname.split('|')[cnIndex];
 
-//   if (typeof chrName !== 'undefined' && chrName.substr(0, 3) === 'chr') {
-//     // Convert "chr12" to "12", e.g. for banana (GCF_000313855.2)
-//     chrName = chrName.substr(3);
-//   }
+  if (typeof chrName !== 'undefined' && chrName.substr(0, 3) === 'chr') {
+    // Convert "chr12" to "12", e.g. for banana (GCF_000313855.2)
+    chrName = chrName.substr(3);
+  }
 
-//   return [chrName, type];
-// }
+  return [chrName, type];
+}
 
-// function getChrNameAndType(result, ideo) {
-//   var genome = result.genome;
-//   if (genome === 'mitochondrion') {
-//     return parseMitochondrion(result, ideo);
-//   } else if (genome === 'chloroplast' || genome === 'plastid') {
-//     return parseChloroplastOrPlastid(ideo);
-//   } else if (genome === 'apicoplast') {
-//     return parseApicoplast(ideo);
-//   } else {
-//     return parseNuclear(result);
-//   }
-// }
+function getChrNameAndType(result, ideo) {
+  var genome = result.genome;
+  if (genome === 'mitochondrion') {
+    return parseMitochondrion(result, ideo);
+  } else if (genome === 'chloroplast' || genome === 'plastid') {
+    return parseChloroplastOrPlastid(ideo);
+  } else if (genome === 'apicoplast') {
+    return parseApicoplast(ideo);
+  } else {
+    return parseNuclear(result);
+  }
+}
 
-// function parseChromosome(result, ideo) {
-//   var chrName, type, chromosome, result,
+function parseChromosome(result, ideo) {
+  var chrName, type, chromosome, result,
 
-//   [chrName, type] = getChrNameAndType(result, ideo);
+  [chrName, type] = getChrNameAndType(result, ideo);
 
-//   chromosome = {
-//     name: chrName,
-//     length: result.slen,
-//     type: type
-//   };
+  chromosome = {
+    name: chrName,
+    length: result.slen,
+    type: type
+  };
 
-//   return chromosome;
-// }
+  return chromosome;
+}
 
-// function parseChromosomes(results, asmAndChrArray, ideo) {
-//   var x, chromosome,
-//     chromosomes = [];
+function parseChromosomes(results, asmAndChrArray, ideo) {
+  var x, chromosome,
+    chromosomes = [];
 
-//   for (x in results) {
-//     // omit list of result uids
-//     if (x === 'uids') continue;
+  for (x in results) {
+    // omit list of result uids
+    if (x === 'uids') continue;
 
-//     chromosome = parseChromosome(results[x], ideo);
-//     chromosomes.push(chromosome);
-//   }
+    chromosome = parseChromosome(results[x], ideo);
+    chromosomes.push(chromosome);
+  }
 
-//   chromosomes = chromosomes.sort(Ideogram.sortChromosomes);
+  chromosomes = chromosomes.sort(Ideogram.sortChromosomes);
 
-//   ideo.coordinateSystem = 'bp';
+  ideo.coordinateSystem = 'bp';
 
-//   asmAndChrArray.push(chromosomes);
+  asmAndChrArray.push(chromosomes);
 
-//   return asmAndChrArray;
-// }
+  return asmAndChrArray;
+}
 
-// function fetchAssemblySummary(data, ideo) {
-//   var asmUid, asmSummaryUrl;
+function fetchAssemblySummary(data, ideo) {
+  var asmUid, asmSummaryUrl;
 
-//   // NCBI Assembly database's internal identifier (uid) for this assembly
-//   asmUid = data.esearchresult.idlist[0];
-//   asmSummaryUrl = ideo.esummary + '&db=assembly&id=' + asmUid;
+  // NCBI Assembly database's internal identifier (uid) for this assembly
+  asmUid = data.esearchresult.idlist[0];
+  asmSummaryUrl = ideo.esummary + '&db=assembly&id=' + asmUid;
 
-//   return d3.json(asmSummaryUrl);
-// }
+  return d3.json(asmSummaryUrl);
+}
 
-// /**
-//  * Returns names and lengths of chromosomes for an organism's best-known
-//  * genome assembly, or for a specified assembly.  Gets data from NCBI
-//  * EUtils web API.
-//  *
-//  * @param callback Function to call upon completion of this async method
-//  * @param recovering Boolean indicating attempt at failure recovery
-//  */
-// function getAssemblyAndChromosomesFromEutils(callback, recovering) {
-//   var asmSearchUrl, nuccoreLink,
-//     asmAndChrArray = [],
-//     ideo = this,
-//     context = {callback: callback, recovering: recovering, ideo: ideo};
+/**
+ * Returns names and lengths of chromosomes for an organism's best-known
+ * genome assembly, or for a specified assembly.  Gets data from NCBI
+ * EUtils web API.
+ *
+ * @param callback Function to call upon completion of this async method
+ * @param recovering Boolean indicating attempt at failure recovery
+ */
+function getAssemblyAndChromosomesFromEutils(callback, recovering) {
+  var asmSearchUrl, nuccoreLink,
+    asmAndChrArray = [],
+    ideo = this,
+    context = {callback: callback, recovering: recovering, ideo: ideo};
 
-//   asmSearchUrl = getAssemblySearchUrl(ideo);
+  asmSearchUrl = getAssemblySearchUrl(ideo);
 
-//   d3.json(asmSearchUrl)
-//     .then(function(data) { return fetchAssemblySummary(data, ideo); })
-//     .then(function(data) {
-//       [asmAndChrArray, nuccoreLink] =
-//         getAssemblyAndNuccoreLink(data, asmAndChrArray, recovering, ideo);
-//       return d3.json(nuccoreLink);
-//     })
-//     .then(function(data) {
-//       return fetchNucleotideSummary(data, asmAndChrArray, context);
-//     })
-//     .then(function(data) {
-//       asmAndChrArray = parseChromosomes(data.result, asmAndChrArray, ideo);
-//       return callback(asmAndChrArray);
-//     }, function(rejectedReason) {
-//       console.warn(rejectedReason);
-//     });
-// }
+  d3.json(asmSearchUrl)
+    .then(function(data) { return fetchAssemblySummary(data, ideo); })
+    .then(function(data) {
+      [asmAndChrArray, nuccoreLink] =
+        getAssemblyAndNuccoreLink(data, asmAndChrArray, recovering, ideo);
+      return d3.json(nuccoreLink);
+    })
+    .then(function(data) {
+      return fetchNucleotideSummary(data, asmAndChrArray, context);
+    })
+    .then(function(data) {
+      asmAndChrArray = parseChromosomes(data.result, asmAndChrArray, ideo);
+      return callback(asmAndChrArray);
+    }, function(rejectedReason) {
+      console.warn(rejectedReason);
+    });
+}
 
 export {
-  getTaxids,
   esearch, esummary, elink, getTaxidFromEutils, getOrganismFromEutils,
-  setTaxidData,
+  getTaxids, setTaxidAndAssemblyAndChromosomes, setTaxidData,
   getAssemblyAndChromosomesFromEutils
 }

--- a/test/web-test.js
+++ b/test/web-test.js
@@ -1295,57 +1295,189 @@ describe('Ideogram', function() {
     var ideogram = new Ideogram(config);
   });
 
+  ////
   // BEGIN NCBI INTEGRATION TESTS
-  // eweitz 2019-07-29: These tests fail due to an upstream
-  // change in NCBI E-Utils
-  // it('should use GRCh37 when specified in "assembly" parameter', function(done) {
-  //   // Tests use case from ../examples/vanilla/human.html
+  //
+  // These tests require an Internet connection, as they make
+  // HTTP requests to NCBI E-Utilities (EUtils).
+  //
+  ////
+  it('should support mitochondrial and chloroplast chromosomes', function(done) {
+    // Tests use case from ../examples/vanilla/eukaryotes.html
 
-  //   function callback() {
-  //     var bands = ideogram.chromosomes['9606']['1'].bands;
-  //     var chr1Length = bands[bands.length - 1].bp.stop;
-  //     assert.equal(chr1Length, 249250621);
-  //     done();
-  //   }
+    function callback() {
+      var chromosomes = Array.from(document.querySelectorAll('.chromosome'));
+      var nonNuclearChrs = chromosomes.slice(-2);
+      assert.equal(chromosomes.length, 21);
+      assert.equal(nonNuclearChrs[0].id, 'chrCP-29760'); // chloroplast (CP)
+      assert.equal(nonNuclearChrs[1].id, 'chrMT-29760'); // mitochrondrion (MT)
+      done();
+    }
 
-  //   config.assembly = 'GRCh37';
-  //   config.onLoad = callback;
-  //   var ideogram = new Ideogram(config);
-  // });
+    var config = {
+      organism: 'vitis-vinifera', // grape
+      showNonNuclearChromosomes: true,
+      onLoad: callback
+    };
 
-  // it('should use GCF_000001405.12 when specified in "assembly" parameter', function(done) {
-  //   // Tests use case from ../examples/vanilla/human.html with NCBI36 / hg18
+    setTimeout(function() {
+      var ideogram = new Ideogram(config);
+    }, 1500);
+  });
 
-  //   function callback() {
-  //     var bands = ideogram.chromosomes['9606']['1'].bands;
-  //     var chr1Length = bands[bands.length - 1].bp.stop;
-  //     assert.equal(chr1Length, 247249719);
-  //     done();
-  //   }
+  it('should use GRCh37 when specified in "assembly" parameter', function(done) {
+    // Tests use case from ../examples/vanilla/human.html
+    function callback() {
+      var bands = ideogram.chromosomes['9606']['1'].bands;
+      var chr1Length = bands[bands.length - 1].bp.stop;
+      assert.equal(chr1Length, 249250621);
+      done();
+    }
+    config.assembly = 'GRCh37';
+    config.onLoad = callback;
+    var ideogram = new Ideogram(config);
+  });
 
-  //   config.assembly = 'GCF_000001405.12';
-  //   config.onLoad = callback;
-  //   var ideogram = new Ideogram(config);
-  // });
+  it('should use GCF_000001405.12 when specified in "assembly" parameter', function(done) {
+    // Tests use case from ../examples/vanilla/human.html with NCBI36 / hg18
 
-  // it('should support RefSeq accessions in "assembly" parameter', function(done) {
-  //   // Tests use case for non-default assemblies.
-  //   // GCF_000306695.2 is commonly called CHM1_1.1
-  //   // https://www.ncbi.nlm.nih.gov/assembly/GCF_000306695.2/
+    function callback() {
+      var bands = ideogram.chromosomes['9606']['1'].bands;
+      var chr1Length = bands[bands.length - 1].bp.stop;
+      assert.equal(chr1Length, 247249719);
+      done();
+    }
 
-  //   function callback() {
-  //     var chr1Length = ideogram.chromosomes['9606']['1'].length;
-  //     // For reference, see length section of LOCUS field in GenBank record at
-  //     // https://www.ncbi.nlm.nih.gov/nuccore/CM001609.2
-  //     assert.equal(chr1Length, 250522664);
-  //     done();
-  //   }
+    config.assembly = 'GCF_000001405.12';
+    config.onLoad = callback;
+    var ideogram = new Ideogram(config);
+  });
 
-  //   config.assembly = 'GCF_000306695.2';
-  //   config.onLoad = callback;
-  //   var ideogram = new Ideogram(config);
-  // });
+  it('should support RefSeq accessions in "assembly" parameter', function(done) {
+    // Tests use case for non-default assemblies.
+    // GCF_000306695.2 is commonly called CHM1_1.1
+    // https://www.ncbi.nlm.nih.gov/assembly/GCF_000306695.2/
 
+    function callback() {
+      var chr1Length = ideogram.chromosomes['9606']['1'].length;
+      // For reference, see length section of LOCUS field in GenBank record at
+      // https://www.ncbi.nlm.nih.gov/nuccore/CM001609.2
+      assert.equal(chr1Length, 250522664);
+      done();
+    }
+
+    config.assembly = 'GCF_000306695.2';
+    config.onLoad = callback;
+    var ideogram = new Ideogram(config);
+  });
+
+  it('should support using NCBI Taxonomy ID in "organism" option', function(done) {
+
+    function callback() {
+      var numChromosomes = Object.keys(ideogram.chromosomes[9606]).length;
+      assert.equal(numChromosomes, 24);
+      done();
+    }
+
+    var config = {
+      organism: 9606,
+      dataDir: '/dist/data/bands/native/'
+    };
+    config.onLoad = callback;
+    var ideogram = new Ideogram(config);
+  });
+
+   it('should show three unbanded, annotated primate genomes in one page', function(done) {
+    // Tests use case from ../examples/vanilla/multiple-primates.html
+
+    var config, containerIDs, id, i, container,
+      ideogramsLoaded = 0,
+      annotSetsDrawn = 0;
+
+    function callback() {
+      var numChromosomes;
+
+      ideogramsLoaded += 1;
+      if (ideogramsLoaded === 3) {
+        numChromosomes = document.querySelectorAll('.chromosome').length;
+        assert.equal(numChromosomes, 24 + 25 + 21);
+      }
+    }
+
+    function onDrawAnnotsCallback() {
+      var numAnnots;
+
+      annotSetsDrawn += 1;
+      if (annotSetsDrawn === 3) {
+        numAnnots = document.querySelectorAll('.annot').length;
+        assert.equal(numAnnots, 6);
+
+        // Test that default chimpanzee assembly has centromeres
+        var chimpanzeeQArmBand = document.querySelectorAll('#chr2A-9598-q1').length;
+        assert.equal(chimpanzeeQArmBand, 1);
+
+        // Test that selected human assembly has no cytobands
+        var human1Bands = document.querySelectorAll('#chr1-9606 .band').length;
+
+        // 2 bands = p, q.  Fully banded has 63.
+        assert.equal(human1Bands, 2);
+
+        done();
+      }
+    }
+
+    var orgConfigs = [
+      {
+        organism: 'homo-sapiens',
+        annotations: [
+          {name: 'APOB', chr: '2', start: 21001429, stop: 21044073, color: '#F00'},
+          {name: 'CTLA4', chr: '2', start: 203867788, stop: 203873960, color: '#77F', shape: 'circle'}
+        ]
+      },
+      {
+        organism: 'pan-troglodytes',
+        annotations: [
+          {name: 'APOB', chr: '2A', start: 21371172, stop: 21413720, color: '#F00'},
+          {name: 'CTLA4', chr: '2B', start: 94542849, stop: 94550230, color: '#77F', shape: 'circle'}
+        ]
+      },
+      {
+        organism: 'macaca-fascicularis',
+        annotations: [
+          {name: 'APOB', chr: '13', start: 89924186, stop: 89966894, color: '#F00'},
+          {name: 'CTLA4', chr: '12', start: 93412707, stop: 93419132, color: '#77F', shape: 'circle'}
+        ]
+      }
+    ];
+
+    config = {
+      chrHeight: 250,
+      chrMargin: 2,
+      orientation: 'horizontal',
+      showFullyBanded: false,
+      dataDir: '/dist/data/bands/native/',
+      onLoad: callback,
+      onDrawAnnots: onDrawAnnotsCallback
+    };
+
+    containerIDs = ['homo-sapiens', 'pan-troglodytes', 'macaca-fascicularis'];
+    for (i = 0; i < containerIDs.length; i++) {
+      id = containerIDs[i];
+      container = '<div id="' + id + '"></div>';
+      document.querySelector('body').innerHTML += container;
+      config.container = '#' + id;
+      config.organism = id;
+      config.annotations = orgConfigs[i].annotations;
+      new Ideogram(config);
+    }
+  });
+
+  // BEGIN REGRESSED INTEGRATION TESTS
+  //
+  // 2019-07-29:
+  // These tests fail due to an upstream breaking change in NCBI E-Utils.
+  // Specifically, the Entrez GenColl database was retired without notice.
+  //
   // it('should support GenBank accessions in "assembly" parameter', function(done) {
   //   // Tests use case for non-default assemblies.
   //   // GCA_000002125.2 is commonly called HuRef
@@ -1382,53 +1514,6 @@ describe('Ideogram', function() {
   //     var ideogram = new Ideogram(config);
   //   }, 1500);
 
-  // });
-
-  // it('should support mitochondrial and chloroplast chromosomes', function(done) {
-  //   // Tests use case from ../examples/vanilla/eukaryotes.html
-
-  //   function callback() {
-  //     var chromosomes = Array.from(document.querySelectorAll('.chromosome'));
-  //     var nonNuclearChrs = chromosomes.slice(-2);
-  //     assert.equal(chromosomes.length, 21);
-  //     assert.equal(nonNuclearChrs[0].id, 'chrCP-29760'); // chloroplast (CP)
-  //     assert.equal(nonNuclearChrs[1].id, 'chrMT-29760'); // mitochrondrion (MT)
-  //     done();
-  //   }
-
-  //   var config = {
-  //     organism: 'vitis-vinifera', // grape
-  //     showNonNuclearChromosomes: true,
-  //     onLoad: callback
-  //   };
-
-  //   setTimeout(function() {
-  //     var ideogram = new Ideogram(config);
-  //   }, 1500);
-  // });
-
-  // eweitz, 2018-10-18: This test passes locally and the apicoplast displays
-  // as expected in https://eweitz.github.io/ideogram/eukaryotes?org=plasmodium-falciparum,
-  // but the test fails on Travis CI, e.g. https://travis-ci.org/eweitz/ideogram/builds/443002664
-  // Why?  It seems like a Travis-specific false positive.  Disabling for now.
-  // it('should support apicoplast chromosomes of malaria parasite', function(done) {
-  //   // Tests use case from ../examples/vanilla/eukaryotes.html
-
-  //   function callback() {
-  //     var chromosomes = Array.from(document.querySelectorAll('.chromosome'));
-  //     var nonNuclearChrs = chromosomes.slice(-1);
-  //     assert.equal(chromosomes.length, 15);
-  //     assert.equal(nonNuclearChrs[0].id, 'chrAP-5833'); // apicoplast (CP)
-  //     done();
-  //   }
-
-  //   var config = {
-  //     organism: 'plasmodium-falciparum', // P. falciparum, malaria parasite
-  //     showNonNuclearChromosomes: true,
-  //     onLoad: callback
-  //   };
-
-  //   var ideogram = new Ideogram(config);
   // });
 
    // it('should not have race condition when init is quickly called multiple times', function(done) {
@@ -1478,108 +1563,37 @@ describe('Ideogram', function() {
   //     onLoad: startRaceCondition
   //   });
   // });
-    // 
-  // it('should show three unbanded, annotated primate genomes in one page', function(done) {
-  //   // Tests use case from ../examples/vanilla/multiple-primates.html
 
-  //   var config, containerIDs, id, i, container,
-  //     ideogramsLoaded = 0,
-  //     annotSetsDrawn = 0;
-
-  //   function callback() {
-  //     var numChromosomes;
-
-  //     ideogramsLoaded += 1;
-  //     if (ideogramsLoaded === 3) {
-  //       numChromosomes = document.querySelectorAll('.chromosome').length;
-  //       assert.equal(numChromosomes, 24 + 25 + 21);
-  //     }
-  //   }
-
-  //   function onDrawAnnotsCallback() {
-  //     var numAnnots;
-
-  //     annotSetsDrawn += 1;
-  //     if (annotSetsDrawn === 3) {
-  //       numAnnots = document.querySelectorAll('.annot').length;
-  //       assert.equal(numAnnots, 6);
-
-  //       // Test that default chimpanzee assembly has centromeres
-  //       var chimpanzeeQArmBand = document.querySelectorAll('#chr2A-9598-q1').length;
-  //       assert.equal(chimpanzeeQArmBand, 1);
-
-  //       // Test that selected human assembly has no cytobands
-  //       var human1Bands = document.querySelectorAll('#chr1-9606 .band').length;
-
-  //       // 2 bands = p, q.  Fully banded has 63.
-  //       assert.equal(human1Bands, 2);
-
-  //       done();
-  //     }
-  //   }
-
-  //   var orgConfigs = [
-  //     {
-  //       organism: 'homo-sapiens',
-  //       annotations: [
-  //         {name: 'APOB', chr: '2', start: 21001429, stop: 21044073, color: '#F00'},
-  //         {name: 'CTLA4', chr: '2', start: 203867788, stop: 203873960, color: '#77F', shape: 'circle'}
-  //       ]
-  //     },
-  //     {
-  //       organism: 'pan-troglodytes',
-  //       annotations: [
-  //         {name: 'APOB', chr: '2A', start: 21371172, stop: 21413720, color: '#F00'},
-  //         {name: 'CTLA4', chr: '2B', start: 94542849, stop: 94550230, color: '#77F', shape: 'circle'}
-  //       ]
-  //     },
-  //     {
-  //       organism: 'macaca-fascicularis',
-  //       annotations: [
-  //         {name: 'APOB', chr: '13', start: 89924186, stop: 89966894, color: '#F00'},
-  //         {name: 'CTLA4', chr: '12', start: 93412707, stop: 93419132, color: '#77F', shape: 'circle'}
-  //       ]
-  //     }
-  //   ];
-
-  //   config = {
-  //     chrHeight: 250,
-  //     chrMargin: 2,
-  //     orientation: 'horizontal',
-  //     showFullyBanded: false,
-  //     dataDir: '/dist/data/bands/native/',
-  //     onLoad: callback,
-  //     onDrawAnnots: onDrawAnnotsCallback
-  //   };
-
-  //   containerIDs = ['homo-sapiens', 'pan-troglodytes', 'macaca-fascicularis'];
-  //   for (i = 0; i < containerIDs.length; i++) {
-  //     id = containerIDs[i];
-  //     container = '<div id="' + id + '"></div>';
-  //     document.querySelector('body').innerHTML += container;
-  //     config.container = '#' + id;
-  //     config.organism = id;
-  //     config.annotations = orgConfigs[i].annotations;
-  //     new Ideogram(config);
-  //   }
-  // });
-  // 
-  // it('should support using NCBI Taxonomy ID in "organism" option', function(done) {
+  // eweitz, 2018-10-18: This test passes locally and the apicoplast displays
+  // as expected in https://eweitz.github.io/ideogram/eukaryotes?org=plasmodium-falciparum,
+  // but the test fails on Travis CI, e.g. https://travis-ci.org/eweitz/ideogram/builds/443002664
+  // Why?  It seems like a Travis-specific false positive.  Disabling for now.
+  // it('should support apicoplast chromosomes of malaria parasite', function(done) {
+  //   // Tests use case from ../examples/vanilla/eukaryotes.html
 
   //   function callback() {
-  //     var numChromosomes = Object.keys(ideogram.chromosomes[9606]).length;
-  //     assert.equal(numChromosomes, 24);
+  //     var chromosomes = Array.from(document.querySelectorAll('.chromosome'));
+  //     var nonNuclearChrs = chromosomes.slice(-1);
+  //     assert.equal(chromosomes.length, 15);
+  //     assert.equal(nonNuclearChrs[0].id, 'chrAP-5833'); // apicoplast (CP)
   //     done();
   //   }
 
   //   var config = {
-  //     organism: 9606,
-  //     dataDir: '/dist/data/bands/native/'
+  //     organism: 'plasmodium-falciparum', // P. falciparum, malaria parasite
+  //     showNonNuclearChromosomes: true,
+  //     onLoad: callback
   //   };
-  //   config.onLoad = callback;
+
   //   var ideogram = new Ideogram(config);
   // });
+  //
+  ////
+  // END REGRESSED NCBI INTEGRATION TESTS
+  ////
+  ////
   // END NCBI INTEGRATION TESTS
+  ////
 
   it('should handle arrayed objects in "annotations" parameter', function(done) {
     // Tests use case from ../examples/vanilla/human.html


### PR DESCRIPTION
This works around an upstream break involving GenColl, a public but little-known NCBI database.  That break removes Ideogram support for many organisms -- like pig, dog, cattle, and turkey.

Ideogram had used GenColl via NCBI ELink to fetch chromosomes for genome assemblies that contained many scaffolds, [as described in 2016](https://github.com/eweitz/ideogram/issues/45#issuecomment-229551817).  In its EUtils interface, the NCBI Assembly database does not distinguish between chromosomes and non-chromosomal scaffolds -- and calls both simply "scaffolds".  GenColl provided a way to distinguish them.

I hope to restore support for affected organisms, but it's unclear when that will be possible given ongoing Ideogram development in comparative genomics, etc.