### PR TITLE
Fully restore support for eukaryotes

### DIFF
--- a/examples/vanilla/eukaryotes.html
+++ b/examples/vanilla/eukaryotes.html
@@ -49,7 +49,7 @@
         <li><label for="rattus-norvegicus"><input type="radio" name="org" value="rattus-norvegicus" id="rattus-norvegicus">Rat (Rattus norvegicus)</label></li>
         <li><label for="drosophila-melanogaster"><input type="radio" name="org" value="drosophila-melanogaster" id="drosophila-melanogaster">Fly (Drosophila melanogaster)</label>
         <li><label for="caenorhabditis-elegans"><input type="radio" name="org" value="caenorhabditis-elegans" id="caenorhabditis-elegans">Worm (Caenorhabditis elegans)</label></li>
-        <!-- <li><label for="danio-rerio"><input type="radio" name="org" value="danio-rerio" id="danio-rerio">Zebrafish (Danio rerio)</label></li> -->
+        <li><label for="danio-rerio"><input type="radio" name="org" value="danio-rerio" id="danio-rerio">Zebrafish (Danio rerio)</label></li>
         <li><label for="arabidopsis-thaliana"><input type="radio" name="org" value="arabidopsis-thaliana" id="arabidopsis-thaliana">Thale cress (Arabidopsis thaliana)</label></li>
         <li><label for="saccharomyces-cerevisiae"><input type="radio" name="org" value="saccharomyces-cerevisiae" id="saccharomyces-cerevisiae">Yeast (Saccharomyces cerevisiae)</label></li>
       </ul>
@@ -63,7 +63,7 @@
         <!-- <li><label for="canis-lupus-familiaris"><input type="radio" name="org" value="canis-lupus-familiaris" id="canis-lupus-familiaris">Dog (Canis lupus familiaris)</label></li> -->
         <!-- <li><label for="gallus-gallus"><input type="radio" name="org" value="gallus-gallus" id="gallus-gallus">Chicken (Gallus gallus)</label></li> -->
         <!-- <li><label for="bos-taurus"><input type="radio" name="org" value="bos-taurus" id="bos-taurus">Cow (Bos taurus)</label></li> -->
-        <!-- <li><label for="sus-scrofa"><input type="radio" name="org" value="sus-scrofa" id="sus-scrofa">Pig (Sus scrofa)</label></li> -->
+        <li><label for="sus-scrofa"><input type="radio" name="org" value="sus-scrofa" id="sus-scrofa">Pig (Sus scrofa)</label></li>
       </ul>
     </li>
     <li>
@@ -71,10 +71,10 @@
       <ul>
         <li><label for="zea-mays"><input type="radio" name="org" value="zea-mays" id="zea-mays">Maize (Zea mays)</label></li>
         <li><label for="oryza-sativa"><input type="radio" name="org" value="oryza-sativa" id="oryza-sativa">Rice (Oryza sativa)</label>
-        <!-- <li><label for="solanum-lycopersicum"><input type="radio" name="org" value="solanum-lycopersicum" id="solanum-lycopersicum">Tomato (Solanum lycopersicum)</label></li> -->
+        <li><label for="solanum-lycopersicum"><input type="radio" name="org" value="solanum-lycopersicum" id="solanum-lycopersicum">Tomato (Solanum lycopersicum)</label></li>
         <li><label for="musa-acuminata"><input type="radio" name="org" value="musa-acuminata" id="musa-acuminata">Banana (Musa acuminata)</label></li>
-        <!-- <li><label for="vitis-vinifera"><input type="radio" name="org" value="vitis-vinifera" id="vitis-vinifera">Grape (Vitis vinifera)</label></li> -->
-        <li><label for="micromonas-commoda"><input type="radio" name="org" value="micromonas-commoda" id="micromonas-commoda">Green algae</label></li>
+        <li><label for="vitis-vinifera"><input type="radio" name="org" value="vitis-vinifera" id="vitis-vinifera">Grape (Vitis vinifera)</label></li>
+        <li><label for="micromonas-commoda"><input type="radio" name="org" value="micromonas-commoda" id="micromonas-commoda">Green algae (Micromonas commoda)</label></li>
       </ul>
     </li>
     <li>

--- a/src/js/views/chromosome-labels.js
+++ b/src/js/views/chromosome-labels.js
@@ -2,7 +2,6 @@ import {d3} from '../lib';
 
 function getChrSetLabelLines(d, i, ideo) {
   var lines;
-
   if (d.name.indexOf(' ') === -1) {
     lines = [d.name];
   } else {

--- a/test/web-test.js
+++ b/test/web-test.js
@@ -1590,7 +1590,7 @@ describe('Ideogram', function() {
   });
 
   it('should recover chromosomes when given scaffolds', function(done) {
-    // Tests use case from ../examples/vanilla/human.html
+    // Tests use case from ../examples/vanilla/eukaryotes?org=sus-scrofa
 
     function callback() {
       var numChromosomes = document.querySelectorAll('.chromosome').length;
@@ -1603,7 +1603,10 @@ describe('Ideogram', function() {
       onLoad: callback
     };
 
-    var ideogram = new Ideogram(config);
+    setTimeout(function() {
+      var ideogram = new Ideogram(config);
+    }, 2000);
+
   });
 
   // it('should not have race condition when init is quickly called multiple times', function(done) {

--- a/test/web-test.js
+++ b/test/web-test.js
@@ -1609,52 +1609,52 @@ describe('Ideogram', function() {
 
   });
 
-  // it('should not have race condition when init is quickly called multiple times', function(done) {
-  //   // Verifies handling for a Plotly use case.
-  //   // See https://github.com/eweitz/ideogram/pull/154
+  it('should not have race condition when init is quickly called multiple times', function(done) {
+    // Verifies handling for a Plotly use case.
+    // See https://github.com/eweitz/ideogram/pull/154
 
-  //   /**
-  //   * Differences in remotely cached (static) vs. uncached (queried via EUtils)
-  //   * response times is the likely cause of the race condition that's tested
-  //   * against here.
-  //   **/
+    /**
+    * Differences in remotely cached (static) vs. uncached (queried via EUtils)
+    * response times is the likely cause of the race condition that's tested
+    * against here.
+    **/
 
-  //   var numTimesOnLoadHasBeenCalled = 0;
+    var numTimesOnLoadHasBeenCalled = 0;
 
-  //   function testRaceCondition() {
-  //     var ideo = this;
-  //     numTimesOnLoadHasBeenCalled++;
-  //     var numChimpChromosomes = 25; // See e.g. https://eweitz.github.io/ideogram/eukaryotes?org=pan-troglodytes
-  //     var numHumanChromosomes = 24; // (22,X,Y)
-  //     var numChromosomes = ideo.chromosomesArray.length;
+    function testRaceCondition() {
+      var ideo = this;
+      numTimesOnLoadHasBeenCalled++;
+      var numChimpChromosomes = 25; // See e.g. https://eweitz.github.io/ideogram/eukaryotes?org=pan-troglodytes
+      var numHumanChromosomes = 24; // (22,X,Y)
+      var numChromosomes = ideo.chromosomesArray.length;
 
-  //     if (numTimesOnLoadHasBeenCalled === 1) {
-  //       assert.equal(numChromosomes, numChimpChromosomes);
-  //     } else if (numTimesOnLoadHasBeenCalled === 2) {
-  //       assert.equal(numChromosomes, numHumanChromosomes);
-  //       done();
-  //     }
-  //   }
+      if (numTimesOnLoadHasBeenCalled === 1) {
+        assert.equal(numChromosomes, numChimpChromosomes);
+      } else if (numTimesOnLoadHasBeenCalled === 2) {
+        assert.equal(numChromosomes, numHumanChromosomes);
+        done();
+      }
+    }
 
-  //   function startRaceCondition() {
-  //     new Ideogram({
-  //       organism: 'pan-troglodytes',
-  //       dataDir: '/dist/data/bands/native/',
-  //       onLoad: testRaceCondition
-  //     });
-  //     new Ideogram({
-  //       organism: 'human',
-  //       dataDir: '/dist/data/bands/native/',
-  //       onLoad: testRaceCondition
-  //     });
-  //   }
+    function startRaceCondition() {
+      new Ideogram({
+        organism: 'pan-troglodytes',
+        dataDir: '/dist/data/bands/native/',
+        onLoad: testRaceCondition
+      });
+      new Ideogram({
+        organism: 'human',
+        dataDir: '/dist/data/bands/native/',
+        onLoad: testRaceCondition
+      });
+    }
 
-  //   var ideogram = new Ideogram({
-  //     organism: 'human',
-  //     dataDir: '/dist/data/bands/native/',
-  //     onLoad: startRaceCondition
-  //   });
-  // });
+    var ideogram = new Ideogram({
+      organism: 'human',
+      dataDir: '/dist/data/bands/native/',
+      onLoad: startRaceCondition
+    });
+  });
 
   // eweitz, 2018-10-18: This test passes locally and the apicoplast displays
   // as expected in https://eweitz.github.io/ideogram/eukaryotes?org=plasmodium-falciparum,

--- a/test/web-test.js
+++ b/test/web-test.js
@@ -1589,25 +1589,22 @@ describe('Ideogram', function() {
     var ideogram = new Ideogram(config);
   });
 
-  // it('should recover chromosomes when given scaffolds', function(done) {
-  //   // Tests use case from ../examples/vanilla/human.html
+  it('should recover chromosomes when given scaffolds', function(done) {
+    // Tests use case from ../examples/vanilla/human.html
 
-  //   function callback() {
-  //     var numChromosomes = document.querySelectorAll('.chromosome').length;
-  //     assert.equal(numChromosomes, 20);
-  //     done();
-  //   }
+    function callback() {
+      var numChromosomes = document.querySelectorAll('.chromosome').length;
+      assert.equal(numChromosomes, 20);
+      done();
+    }
 
-  //   var config = {
-  //     organism: 'Sus scrofa', // pig
-  //     onLoad: callback
-  //   };
+    var config = {
+      organism: 'Sus scrofa', // pig
+      onLoad: callback
+    };
 
-  //   setTimeout(function() {
-  //     var ideogram = new Ideogram(config);
-  //   }, 1500);
-
-  // });
+    var ideogram = new Ideogram(config);
+  });
 
   // it('should not have race condition when init is quickly called multiple times', function(done) {
   //   // Verifies handling for a Plotly use case.

--- a/test/web-test.js
+++ b/test/web-test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-new */
 /* eslint-disable spaced-comment */
 /* eslint-disable no-use-before-define */
 /* eslint-disable no-unused-vars */
@@ -1570,23 +1571,23 @@ describe('Ideogram', function() {
   // These tests fail due to an upstream breaking change in NCBI E-Utils.
   // Specifically, the Entrez GenColl database was retired without notice.
   //
-  // it('should support GenBank accessions in "assembly" parameter', function(done) {
-  //   // Tests use case for non-default assemblies.
-  //   // GCA_000002125.2 is commonly called HuRef
-  //   // https://www.ncbi.nlm.nih.gov/assembly/GCA_000002125.2
+  it('should support GenBank accessions in "assembly" parameter', function(done) {
+    // Tests use case for non-default assemblies.
+    // GCA_000002125.2 is commonly called HuRef
+    // https://www.ncbi.nlm.nih.gov/assembly/GCA_000002125.2
 
-  //   function callback() {
-  //     var chr1Length = ideogram.chromosomes['9606']['1'].length;
-  //     // For reference, see length section of LOCUS field in GenBank record at
-  //     // https://www.ncbi.nlm.nih.gov/nuccore/CM001609.2
-  //     assert.equal(chr1Length, 219475005);
-  //     done();
-  //   }
+    function callback() {
+      var chr1Length = ideogram.chromosomes['9606']['1'].length;
+      // For reference, see length section of LOCUS field in GenBank record at
+      // https://www.ncbi.nlm.nih.gov/nuccore/CM001609.2
+      assert.equal(chr1Length, 219475005);
+      done();
+    }
 
-  //   config.assembly = 'GCA_000002125.2';
-  //   config.onLoad = callback;
-  //   var ideogram = new Ideogram(config);
-  // });
+    config.assembly = 'GCA_000002125.2';
+    config.onLoad = callback;
+    var ideogram = new Ideogram(config);
+  });
 
   // it('should recover chromosomes when given scaffolds', function(done) {
   //   // Tests use case from ../examples/vanilla/human.html
@@ -1627,10 +1628,9 @@ describe('Ideogram', function() {
   //     var numHumanChromosomes = 24; // (22,X,Y)
   //     var numChromosomes = ideo.chromosomesArray.length;
 
-  //     if(numTimesOnLoadHasBeenCalled === 1) {
+  //     if (numTimesOnLoadHasBeenCalled === 1) {
   //       assert.equal(numChromosomes, numChimpChromosomes);
-  //     }
-  //     else if(numTimesOnLoadHasBeenCalled === 2) {
+  //     } else if (numTimesOnLoadHasBeenCalled === 2) {
   //       assert.equal(numChromosomes, numHumanChromosomes);
   //       done();
   //     }


### PR DESCRIPTION
This brings back support for all eukaryotes with chromosome-level assemblies.  Many were affected by the upstream E-Utils issue detailed in #161.

Thanks are due to Paul Kitts from NCBI, and NLM Support.  Paul's suggestions were key to developing [a better API request](https://github.com/eweitz/ideogram/compare/master...restore-eukaryotes-via-eutils#diff-157a9a70f3ddf6cf210799aeccba8795R26), which greatly accelerated Ideogram's restored support for zebrafish, dog, tomato, and many other organisms.