### PR TITLE
Compare whole genomes for many more organisms

### DIFF
--- a/examples/vanilla/homology-chimpanzee-gorilla.html
+++ b/examples/vanilla/homology-chimpanzee-gorilla.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Homology, interspecies | Ideogram</title>
+  <style>
+    body {font: 14px Arial; line-height: 19.6px; padding: 0 15px;}
+    a, a:visited {text-decoration: none;}
+    a:hover {text-decoration: underline;}
+    a, a:hover, a:visited, a:active {color: #0366d6;}
+  </style>
+  <script type="text/javascript" src="../../dist/js/ideogram.min.js"></script>
+<link rel="icon" type="image/x-icon" href="img/ideogram_favicon.ico">
+</head>
+<body>
+  <h1>Homology, human and gorilla | Ideogram</h1>
+  <a href="../">Overview</a> |
+  <a href="homology-advanced">Previous</a> |
+  <a href="annotations-basic">Next</a> |
+  <a href="https://github.com/eweitz/ideogram/blob/gh-pages/homology-interspecies.html" target="_blank">Source</a>
+
+  <p>
+    This demonstrates support for drawing features between two genomes that
+    have centromere data.
+  </p>
+  <p>
+    See also: <a href='homology-human-chimpanzee'>Homology, human and chimpanzee</a>
+  </p>
+
+  <script type="text/javascript">
+
+    function onIdeogramLoad() {
+      // See HomoloGene entry for MTOR at
+      // http://www.ncbi.nlm.nih.gov/homologene/3637
+      // Placements for H. sapiens and M. musculus used below.
+      // Placements from latest annotation release in
+      // Human: http://www.ncbi.nlm.nih.gov/gene/2475#genomic-context
+      // Mouse: http://www.ncbi.nlm.nih.gov/gene/56717#genomic-context
+
+      var chrs, chr1, chr4, syntheticRegions, humanTaxid, mouseTaxid;
+
+      humanTaxid = ideogram.getTaxid('chimpanzee');
+      mouseTaxid = ideogram.getTaxid('gorilla');
+
+      var chrs = ideogram.chromosomes,
+        chr1 = chrs[humanTaxid]['1'],
+        chr4 = chrs[mouseTaxid]['4'],
+        syntenicRegions = [];
+
+      range1 = {
+        chr: chr1,
+        start: 11106531,
+        stop: 11262557,
+        orientation: 'reverse'
+      };
+
+      range2 = {
+        chr: chr4,
+        start: 148448582,
+        stop: 148557685
+      };
+
+      syntenicRegions.push({'r1': range1, 'r2': range2});
+
+      ideogram.drawSynteny(syntenicRegions);
+
+    }
+
+  var config = {
+    organism: ['chimpanzee', 'gorilla'],
+    chromosomes: {
+      chimpanzee: ['1'],
+      gorilla: ['4']
+    },
+    chrHeight: 400,
+    chrMargin: 50,
+    fullChromosomeLabels: true,
+    perspective: 'comparative',
+    rotatable: false,
+    onLoad: onIdeogramLoad
+  };
+
+  var ideogram = new Ideogram(config);
+
+  </script>
+</body>
+</html>

--- a/examples/vanilla/homology-human-chimpanzee.html
+++ b/examples/vanilla/homology-human-chimpanzee.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Homology, interspecies | Ideogram</title>
+  <style>
+    body {font: 14px Arial; line-height: 19.6px; padding: 0 15px;}
+    a, a:visited {text-decoration: none;}
+    a:hover {text-decoration: underline;}
+    a, a:hover, a:visited, a:active {color: #0366d6;}
+  </style>
+  <script type="text/javascript" src="../../dist/js/ideogram.min.js"></script>
+<link rel="icon" type="image/x-icon" href="img/ideogram_favicon.ico">
+</head>
+<body>
+  <h1>Homology, interspecies | Ideogram</h1>
+  <a href="../">Overview</a> |
+  <a href="homology-advanced">Previous</a> |
+  <a href="annotations-basic">Next</a> |
+  <a href="https://github.com/eweitz/ideogram/blob/gh-pages/homology-interspecies.html" target="_blank">Source</a>
+
+  <p>
+    This demonstrates support for drawing features between a fully-banded
+    genome and a genome that only has centromere data.
+  </p>
+  <p>
+    See also: <a href='homology-chimpanzee-gorilla'>Homology, chimpanzee and gorilla</a>
+  </p>
+
+  <script type="text/javascript">
+
+    function onIdeogramLoad() {
+      // See HomoloGene entry for MTOR at
+      // http://www.ncbi.nlm.nih.gov/homologene/3637
+      // Placements for H. sapiens and M. musculus used below.
+      // Placements from latest annotation release in
+      // Human: http://www.ncbi.nlm.nih.gov/gene/2475#genomic-context
+      // Mouse: http://www.ncbi.nlm.nih.gov/gene/56717#genomic-context
+
+      var chrs, chr1, chr4, syntheticRegions, humanTaxid, mouseTaxid;
+
+      humanTaxid = ideogram.getTaxid('human');
+      mouseTaxid = ideogram.getTaxid('chimpanzee');
+
+      var chrs = ideogram.chromosomes,
+        chr1 = chrs[humanTaxid]['1'],
+        chr4 = chrs[mouseTaxid]['4'],
+        syntenicRegions = [];
+
+      range1 = {
+        chr: chr1,
+        start: 11106531,
+        stop: 11262557,
+        orientation: 'reverse'
+      };
+
+      range2 = {
+        chr: chr4,
+        start: 148448582,
+        stop: 148557685
+      };
+
+      syntenicRegions.push({'r1': range1, 'r2': range2});
+
+      ideogram.drawSynteny(syntenicRegions);
+
+    }
+
+  var config = {
+    organism: ['human', 'chimpanzee'],
+    chromosomes: {
+      human: ['1'],
+      chimpanzee: ['4']
+    },
+    chrHeight: 400,
+    chrMargin: 50,
+    fullChromosomeLabels: true,
+    perspective: 'comparative',
+    rotatable: false,
+    onLoad: onIdeogramLoad
+  };
+
+  var ideogram = new Ideogram(config);
+
+  </script>
+</body>
+</html>

--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -53,8 +53,7 @@
     and animating genome-wide datasets.
     </p>
     <p>
-    In the examples below, genomic data is fetched from servers and rendered on the client using
-    <a href="http://d3js.org/" target="_blank">D3.js</a>.
+    Examples below show how Ideogram can be used to research and report findings on <a href="geometry-collinear">cancer</a>, <a href="annotations-external-data">clinical variants</a>, <a href="annotations-histogram">gene expression</a>, <a href="multiple-primates">evolution</a>, <a href="ploidy-recombination">agriculture</a>, and more.
   </p>
   <div class="cards">
 	<div class="card">

--- a/src/js/bands/bands.js
+++ b/src/js/bands/bands.js
@@ -60,11 +60,9 @@ function getBandsArray(chromosome, bandsByChr, taxid, ideo) {
  * Updates bandsArray, sets ideo.config.chromosomes and ideo.numChromosomes
  */
 function setChrsByTaxidsWithBands(taxid, chrs, bandsArray, ideo) {
-  var bandData, bandsByChr, chromosome, k, chrBandsArray;
+  var bandsByChr, chromosome, k, chrBandsArray;
 
-  bandData = ideo.bandData[taxid];
-
-  bandsByChr = parseBands(bandData, taxid, chrs);
+  bandsByChr = parseBands(taxid, chrs, ideo);
 
   chrs = Object.keys(bandsByChr).sort(function(a, b) {
     return naturalSort(a, b);

--- a/src/js/bands/bands.js
+++ b/src/js/bands/bands.js
@@ -76,7 +76,9 @@ function setChrsByTaxidsWithBands(taxid, chrs, bandsArray, ideo) {
   ) {
     ideo.config.chromosomes = {};
   }
-  ideo.config.chromosomes[taxid] = chrs.slice();
+  if (chrs.length > 0) {
+    ideo.config.chromosomes[taxid] = chrs.slice();
+  }
   ideo.numChromosomes += ideo.config.chromosomes[taxid].length;
 
   for (k = 0; k < chrs.length; k++) {

--- a/src/js/bands/parse.js
+++ b/src/js/bands/parse.js
@@ -71,6 +71,9 @@ function updateLines(lines, columns, taxid) {
   return lines;
 }
 
+/**
+ * Reports if a cytogenetic band should be included in parse results
+ */
 function shouldSkipBand(chrs, chr, taxid) {
   var hasChrs, chrsAreList, chrNotInList, chrsAreObject, taxidInChrs,
     innerChrsAreStrings, matchingChrObjs, chrNotInObject;

--- a/src/js/services/organisms.js
+++ b/src/js/services/organisms.js
@@ -105,21 +105,32 @@ function setTaxidData(taxid, ideo) {
 }
 
 function setAssemblyAndChromosomes(taxid, resolve, ideo) {
-  var assembly, chrs, originalChrs, filteredChrs;
+  var assembly, chrs, originalChrs, orgName, filteredChrs,
+    config = ideo.config;
 
   setTaxidData(taxid, ideo)
     .then(function(asmChrTaxidsArray) {
       assembly = asmChrTaxidsArray[0];
       chrs = asmChrTaxidsArray[1];
 
-      if ('chromosomes' in ideo.config === false) {
+      if ('chromosomes' in config === false || config.chromosomes === null) {
         ideo.config.chromosomes = {};
         ideo.config.chromosomes[taxid] = chrs;
       } else {
-        if (ideo.config.multiorganism) {
-          originalChrs = ideo.config.chromosomes[taxid];
+        if (config.multiorganism) {
+          if (taxid in config.chromosomes) {
+            // Encountered when either organism has centromere data
+            originalChrs = config.chromosomes[taxid];
+          } else {
+            // Encountered when neither organism has centromere data
+            orgName = ideo.getScientificName(taxid).toLowerCase();
+            ideo.config.chromosomes[taxid] =
+              config.chromosomes[orgName].slice();
+            originalChrs = ideo.config.chromosomes[taxid];
+            // delete ideo.config.chromosomes[orgName];
+          }
         } else {
-          originalChrs = ideo.config.chromosomes;
+          originalChrs = config.chromosomes;
         }
 
         filteredChrs = chrs.filter(d => originalChrs.includes(d.name));

--- a/src/js/services/organisms.js
+++ b/src/js/services/organisms.js
@@ -79,18 +79,27 @@ function setTaxidData(taxid, ideo) {
       var asmAndChrTaxidsArray = [''],
         chromosomes = [],
         seenChrs = {},
-        chr;
+        chr, maxLength, splitBand, length;
+
+      ideo.bandData[taxid] = chrBands;
 
       for (var i = 0; i < chrBands.length; i++) {
-        chr = chrBands[i].split(' ')[0];
+        splitBand = chrBands[i].split(' ');
+        chr = splitBand[0];
+        length = splitBand.slice(-1)[0];
         if (chr in seenChrs) {
           continue;
         } else {
-          chromosomes.push({name: chr, type: 'nuclear'});
+          chromosomes.push({name: chr, type: 'nuclear', length: length});
           seenChrs[chr] = 1;
         }
       }
       chromosomes = chromosomes.sort(Ideogram.sortChromosomes);
+      maxLength = {bp: 0, iscn: 0};
+      chromosomes.forEach(chr => {
+        if (chr.length > maxLength.bp) maxLength.bp = chr.length;
+      });
+      ideo.maxLength[taxid] = maxLength;
       asmAndChrTaxidsArray.push(chromosomes);
       asmAndChrTaxidsArray.push(taxids);
       return asmAndChrTaxidsArray;
@@ -136,6 +145,7 @@ function setAssemblyAndChromosomes(taxid, resolve, ideo) {
         filteredChrs = chrs.filter(d => originalChrs.includes(d.name));
         ideo.config.chromosomes[taxid] = filteredChrs;
       }
+      ideo.chromosomes[taxid] = ideo.config.chromosomes[taxid].slice();
       ideo.organisms[taxid].assemblies = {
         default: assembly
       };

--- a/src/js/services/services.js
+++ b/src/js/services/services.js
@@ -149,8 +149,8 @@ function parseChromosome(result, ideo) {
   return chromosome;
 }
 
-function parseChromosomes(results, ideo) {
-  var x, chromosome, seenChrId,
+function parseChromosomes(results, taxid, ideo) {
+  var x, chromosome, seenChrId, maxLength,
     seenChrs = {},
     chromosomes = [];
 
@@ -170,6 +170,12 @@ function parseChromosomes(results, ideo) {
   }
 
   chromosomes = chromosomes.sort(Ideogram.sortChromosomes);
+
+  maxLength = {bp: 0, iscn: 0};
+  chromosomes.forEach(chr => {
+    if (chr.length > maxLength.bp) maxLength.bp = chr.length;
+  });
+  ideo.maxLength[taxid] = maxLength;
 
   ideo.coordinateSystem = 'bp';
 
@@ -217,7 +223,7 @@ function getAssemblyAndChromosomesFromEutils(taxid, callback) {
     }).then(function(esearchUrl) { return d3.json(esearchUrl); })
     .then(function(data) { return fetchNucleotideSummary(data, ideo); })
     .then(function(data) {
-      var chromosomes = parseChromosomes(data.result, ideo);
+      var chromosomes = parseChromosomes(data.result, taxid, ideo);
       return callback([assemblyAccession, chromosomes]);
     }, function(rejectedReason) {
       console.warn(rejectedReason);

--- a/test/web-test.js
+++ b/test/web-test.js
@@ -315,7 +315,7 @@ describe('Ideogram', function() {
     var ideogram = new Ideogram(config);
   });
 
-  it('should have 1 syntenic region between a human and a mouse chromosome', function(done) {
+  it('should have 1 syntenic region between human and mouse chromosomes', function(done) {
     // Tests use case from ../examples/vanilla/homology-interspecies.html
 
     function callback() {
@@ -379,6 +379,111 @@ describe('Ideogram', function() {
     config.chromosomes = {
       human: ['1'],
       mouse: ['4']
+    };
+    config.orientation = 'vertical';
+    config.perspective = 'comparative';
+
+    config.onLoad = callback;
+    var ideogram = new Ideogram(config);
+  });
+
+  it('should have 1 syntenic region between human and chimpanzee chromosomes', function(done) {
+    // Tests support for drawing features between a fully-banded genome and a
+    // genome that only has centromere data, as is possible in "Orthologs"
+    // example
+
+    function callback() {
+
+      var chrs = ideogram.chromosomes,
+        humanTaxid = ideogram.getTaxid('human'),
+        chimpanzeeTaxid = ideogram.getTaxid('chimpanzee'),
+        chr1 = chrs[humanTaxid]['1'],
+        chr4 = chrs[chimpanzeeTaxid]['4'],
+        syntenicRegions = [],
+        range1, range2;
+
+      range1 = {
+        chr: chr1, start: 11106531, stop: 11262557, orientation: 'reverse'
+      };
+
+      range2 = {
+        chr: chr4, start: 148448582, stop: 148557685
+      };
+
+      syntenicRegions.push({r1: range1, r2: range2});
+
+      ideogram.drawSynteny(syntenicRegions);
+
+      var numHumanChromosomes = Object.keys(ideogram.chromosomes['9606']).length;
+      assert.equal(numHumanChromosomes, 1);
+
+      var numChimpanzeeChromosomes = Object.keys(ideogram.chromosomes['9598']).length;
+      assert.equal(numChimpanzeeChromosomes, 1);
+
+      var numSyntenicRegions = document.getElementsByClassName('syntenicRegion').length;
+      // console.log(d3.selectAll('.syntenicRegion'));
+
+      assert.equal(numSyntenicRegions, 1);
+
+      done();
+    }
+
+    config.organism = ['human', 'chimpanzee'];
+    config.chromosomes = {
+      human: ['1'],
+      chimpanzee: ['4']
+    };
+    config.orientation = 'vertical';
+    config.perspective = 'comparative';
+
+    config.onLoad = callback;
+    var ideogram = new Ideogram(config);
+  });
+
+  it('should have 1 syntenic region between a chimpanzee and gorilla chromosome', function(done) {
+    // Tests support for drawing two genomes that have centromere data,
+    // as is possible in "Orthologs" example
+
+    function callback() {
+
+      var chrs = ideogram.chromosomes,
+        chimpanzeeTaxid = ideogram.getTaxid('chimpanzee'),
+        gorillaTaxid = ideogram.getTaxid('gorilla'),
+        chr1 = chrs[chimpanzeeTaxid]['1'],
+        chr4 = chrs[gorillaTaxid]['4'],
+        syntenicRegions = [],
+        range1, range2;
+
+      range1 = {
+        chr: chr1, start: 11106531, stop: 11262557, orientation: 'reverse'
+      };
+
+      range2 = {
+        chr: chr4, start: 148448582, stop: 148557685
+      };
+
+      syntenicRegions.push({r1: range1, r2: range2});
+
+      ideogram.drawSynteny(syntenicRegions);
+
+      var numChimpanzeeChromosomes = Object.keys(ideogram.chromosomes[chimpanzeeTaxid]).length;
+      assert.equal(numChimpanzeeChromosomes, 1);
+
+      var numGorillaChromosomes = Object.keys(ideogram.chromosomes[gorillaTaxid]).length;
+      assert.equal(numGorillaChromosomes, 1);
+
+      var numSyntenicRegions = document.getElementsByClassName('syntenicRegion').length;
+      // console.log(d3.selectAll('.syntenicRegion'));
+
+      assert.equal(numSyntenicRegions, 1);
+
+      done();
+    }
+
+    config.organism = ['chimpanzee', 'gorilla'];
+    config.chromosomes = {
+      chimpanzee: ['1'],
+      gorilla: ['4']
     };
     config.orientation = 'vertical';
     config.perspective = 'comparative';


### PR DESCRIPTION
This expands whole-genome comparison to any pair of hundreds of organisms.  Previously, this was only available for 24 organisms.

More specifically, Ideogram now supports whole-genome comparison for chromosome-level assemblies.  Such genomes have data on the length of each chromosome, but lack data on centromere position and cytogenetic bands.  NCBI has over [1,400 eukaryotic chromosome-level assemblies](https://www.ncbi.nlm.nih.gov/assembly?term="chromosome"%5BAssembly%20Level%5D%20AND%20%28latest%5Bfilter%5D%20AND%20%28all%5Bfilter%5D%20NOT%20"derived%20from%20surveillance%20project"%5Bfilter%5D%20AND%20all%5Bfilter%5D%20NOT%20anomalous%5Bfilter%5D%29%29%20AND%20%28animals%5Bfilter%5D%20OR%20plants%5Bfilter%5D%20OR%20fungi%5Bfilter%5D%20OR%20protists%5Bfilter%5D%29&cmd=DetailsSearch), and Ideogram can now compare whole genomes for the hundreds of organisms that represents.

This means you can now depict multiple orthologous genes between organisms like human and organisms like worm (_C. elegans_), zebrafish (_Danio rerio_), chicken (_Gallus gallus_), soybean (_Glycine max_), and many others.

For example, [here are four DNA repair genes](https://eweitz.github.io/ideogram/orthologs?org=homo-sapiens&org2=caenorhabditis-elegans&genes=RAD51,MCM8,DMC1,MCM9&backend=orthodb) shared in human and _C. elegans_ -- interesting clusters!
[<img width="951" alt="ideogram_4_orthologs_between_human_and_worm" src="https://user-images.githubusercontent.com/1334561/67759516-f6009000-fa15-11e9-9320-03108492ab4e.png">](https://eweitz.github.io/ideogram/orthologs?org=homo-sapiens&org2=caenorhabditis-elegans&genes=RAD51,MCM8,DMC1,MCM9&backend=orthodb)

See #77 for related work.