### PR TITLE
Expand source genomes available for comparative genomics

### DIFF
--- a/examples/vanilla/homology-grape-tomato.html
+++ b/examples/vanilla/homology-grape-tomato.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Homology, interspecies | Ideogram</title>
+  <style>
+    body {font: 14px Arial; line-height: 19.6px; padding: 0 15px;}
+    a, a:visited {text-decoration: none;}
+    a:hover {text-decoration: underline;}
+    a, a:hover, a:visited, a:active {color: #0366d6;}
+  </style>
+  <script type="text/javascript" src="../../dist/js/ideogram.min.js"></script>
+<link rel="icon" type="image/x-icon" href="img/ideogram_favicon.ico">
+</head>
+<body>
+  <h1>Homology, grape and tomato | Ideogram</h1>
+  <a href="../">Overview</a> |
+  <a href="homology-advanced">Previous</a> |
+  <a href="annotations-basic">Next</a> |
+  <a href="https://github.com/eweitz/ideogram/blob/gh-pages/homology-interspecies.html" target="_blank">Source</a>
+
+  <p>
+    This demonstrates support for drawing features between two genomes that
+    lack centromere data.
+  </p>
+  <p>
+    See also: <a href='homology-human-chimpanzee'>Homology, human and chimpanzee</a>
+  </p>
+
+  <script type="text/javascript">
+
+    function onIdeogramLoad() {
+
+      var chrs, chr1, chr4, syntheticRegions, humanTaxid, mouseTaxid;
+
+      humanTaxid = ideogram.getTaxid('vitis-vinifera');
+      mouseTaxid = ideogram.getTaxid('solanum-lycopersicum');
+
+      var chrs = ideogram.chromosomes,
+        chr1 = chrs[humanTaxid]['1'],
+        chr4 = chrs[mouseTaxid]['1'],
+        syntenicRegions = [];
+
+      range1 = {
+        chr: chr1,
+        start: 11106530,
+        stop: 11262550,
+        orientation: 'reverse'
+      };
+
+      range2 = {
+        chr: chr4,
+        start: 94844850,
+        stop: 94855760
+      };
+
+      syntenicRegions.push({'r1': range1, 'r2': range2});
+
+      ideogram.drawSynteny(syntenicRegions);
+
+    }
+
+  var config = {
+    organism: ['vitis-vinifera', 'solanum-lycopersicum'],
+    chromosomes: {
+      'vitis-vinifera': ['1'],
+      'solanum-lycopersicum': ['1']
+    },
+    chrHeight: 400,
+    chrMargin: 50,
+    fullChromosomeLabels: true,
+    perspective: 'comparative',
+    rotatable: false,
+    onLoad: onIdeogramLoad
+  };
+
+  var ideogram = new Ideogram(config);
+
+  </script>
+</body>
+</html>

--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -39,7 +39,7 @@
       <option>Mouse (Mus musculus)</option>
       <option>Rat (Rattus norvegicus)</option>
       <option>Chicken (Gallus gallus)</option>
-      <!-- <option>Zebrafish (Danio rerio)</option> -->
+      <option>Zebrafish (Danio rerio)</option>
       <option>Fly (Drosophila melanogaster)</option>
       <option>Worm (Caenorhabditis elegans)</option>
       <option>Thale cress (Arabidopsis thaliana)</option>

--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -38,6 +38,8 @@
       <option>Chimpanzee (Pan troglodytes)</option>
       <option>Mouse (Mus musculus)</option>
       <option>Rat (Rattus norvegicus)</option>
+      <option>Chicken (Gallus gallus)</option>
+      <!-- <option>Zebrafish (Danio rerio)</option> -->
       <option>Fly (Drosophila melanogaster)</option>
       <option>Worm (Caenorhabditis elegans)</option>
       <option>Thale cress (Arabidopsis thaliana)</option>
@@ -52,6 +54,8 @@
         <option>Chimpanzee (Pan troglodytes)</option>
         <option selected>Mouse (Mus musculus)</option>
         <option>Rat (Rattus norvegicus)</option>
+        <option>Chicken (Gallus gallus)</option>
+        <option>Zebrafish (Danio rerio)</option>
         <option>Fly (Drosophila melanogaster)</option>
         <option>Worm (Caenorhabditis elegans)</option>
         <option>Thale cress (Arabidopsis thaliana)</option>

--- a/src/js/ideogram.js
+++ b/src/js/ideogram.js
@@ -167,13 +167,6 @@ export default class Ideogram {
   }
 
   /**
-  * e.g. "Homo sapiens" -> "homo-sapiens"
-  */
-  static slugify(value) {
-    return value.toLowerCase().replace(' ', '-');
-  }
-
-  /**
    * Sorts two chromosome objects by type and name
    * - Nuclear chromosomes come before non-nuclear chromosomes.
    * - Among nuclear chromosomes, use "natural sorting", e.g.

--- a/src/js/init/init.js
+++ b/src/js/init/init.js
@@ -2,7 +2,7 @@
  * @fileoveriew Methods for initialization
  */
 
-import {d3} from '../lib';
+import {d3, slug} from '../lib';
 import {configure} from './configure';
 import {finishInit} from './finish-init';
 import {writeContainer} from './write-container';
@@ -106,7 +106,7 @@ function onLoad() {
 
 function getBandFileName(taxid, accession, ideo) {
   var organism = ideo.organisms[taxid];
-  var bandFileName = [Ideogram.slugify(organism.scientificName)];
+  var bandFileName = [slug(organism.scientificName)];
   var assemblies = organism.assemblies;
   var resolution = ideo.config.resolution;
 

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -136,12 +136,12 @@ function getTaxid(name) {
     ideo = this,
     organisms = ideo.organisms;
 
-  name = name.toLowerCase();
+  name = slug(name);
 
   for (taxid in organisms) {
     organism = organisms[taxid];
-    commonName = organism.commonName.toLowerCase();
-    scientificName = organism.scientificName.toLowerCase();
+    commonName = slug(organism.commonName);
+    scientificName = slug(organism.scientificName);
     if (commonName === name || scientificName === name) {
       return taxid;
     }
@@ -172,7 +172,15 @@ function getScientificName(taxid) {
   return null;
 }
 
+/**
+* e.g. "Homo sapiens" -> "homo-sapiens"
+*/
+function slug(value) {
+  return value.toLowerCase().replace(' ', '-');
+}
+
 export {
   assemblyIsAccession, hasNonGenBankAssembly, hasGenBankAssembly, getDataDir,
-  round, onDidRotate, getSvg, fetch, d3, getTaxid, getCommonName, getScientificName
+  round, onDidRotate, getSvg, fetch, d3, getTaxid, getCommonName,
+  getScientificName, slug
 };

--- a/src/js/services/services.js
+++ b/src/js/services/services.js
@@ -175,8 +175,8 @@ function parseChromosomes(results, taxid, ideo) {
   chromosomes.forEach(chr => {
     if (chr.length > maxLength.bp) maxLength.bp = chr.length;
   });
+  if (maxLength.bp > ideo.maxLength.bp) ideo.maxLength.bp = maxLength.bp;
   ideo.maxLength[taxid] = maxLength;
-
   ideo.coordinateSystem = 'bp';
 
   return chromosomes;

--- a/src/js/views/chromosome-model.js
+++ b/src/js/views/chromosome-model.js
@@ -140,7 +140,7 @@ function getCentromerePosition(hasBands, bands) {
  * bands, centromere position, etc.
  */
 function getChromosomeModel(bands, chrName, taxid, chrIndex) {
-  var hasBands,
+  var hasBands, org, abbreviatedName, splitName,
     chr = {},
     ideo = this;
 
@@ -152,9 +152,12 @@ function getChromosomeModel(bands, chrName, taxid, chrIndex) {
   chr.id = 'chr' + chr.name + '-' + taxid;
 
   if (ideo.config.fullChromosomeLabels === true) {
-    var name = this.organisms[taxid].scientificName.split(' ');
-    var scientificNameAbbr = name[0][0].toUpperCase() + '. ' + name[1];
-    chr.name = scientificNameAbbr + ' chr' + chr.name;
+    org = this.organisms[taxid];
+    console.log(org.scientificName);
+    splitName = org.scientificName.split(' ');
+    abbreviatedName = splitName[0][0] + '. ' + splitName[1];
+
+    chr.name = abbreviatedName + ' chr' + chr.name;
   }
 
   chr.bands = bands;


### PR DESCRIPTION
Studying worm (_C. elegans_), zebrafish (_Danio rerio_), chicken (_Gallus gallus_), soybean (_Glycine max_), or any other organism that has a chromosome-level assembly?  Now you can compare genes in that organism to other organisms.

This is possible because Ideogram can now use organisms that lack centromere data as a source genome in orthology analysis.

Example showing [where the zebrafish myod1 gene exists in the human genome](https://eweitz.github.io/ideogram/orthologs?org=danio-rerio&org2=homo-sapiens&genes=myod1&backend=orthodb):
[<img width="831" alt="ideogram_zebrafish_human_ortholog" src="https://user-images.githubusercontent.com/1334561/67763423-09aff480-fa1e-11e9-8240-f12e507bccf2.png">](https://eweitz.github.io/ideogram/orthologs?org=danio-rerio&org2=homo-sapiens&genes=myod1&backend=orthodb)
