### PR TITLE
Compare dog genome, refine orthology for fly

### DIFF
--- a/examples/vanilla/compare-whole-genomes.html
+++ b/examples/vanilla/compare-whole-genomes.html
@@ -105,6 +105,7 @@
       chrs = ideogram.chromosomes;
       humanTaxid = ideogram.getTaxid('human');
       plantTaxid = ideogram.getTaxid('thale cress'); // Arabidopsis thaliana
+      // plantTaxid = ideogram.getTaxid('mus-musculus'); // Mouse
       humanChrs = chrs[humanTaxid];
       plantChrs = chrs[plantTaxid];
 
@@ -198,6 +199,7 @@
 
       config = {
         organism: ['human', 'thale cress'],
+        // organism: ['human', 'mus musculus'],
         orientation: orientation,
         geometry: 'collinear',
         chromosomeScale: chromosomeScale,

--- a/examples/vanilla/homology-human-fly.html
+++ b/examples/vanilla/homology-human-fly.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Homology, human and fly | Ideogram</title>
+  <style>
+    body {font: 14px Arial; line-height: 19.6px; padding: 0 15px;}
+    a, a:visited {text-decoration: none;}
+    a:hover {text-decoration: underline;}
+    a, a:hover, a:visited, a:active {color: #0366d6;}
+  </style>
+  <script type="text/javascript" src="../../dist/js/ideogram.min.js"></script>
+<link rel="icon" type="image/x-icon" href="img/ideogram_favicon.ico">
+</head>
+<body>
+  <h1>Homology, human and fly | Ideogram</h1>
+  <a href="../">Overview</a> |
+  <a href="homology-advanced">Previous</a> |
+  <a href="annotations-basic">Next</a> |
+  <a href="https://github.com/eweitz/ideogram/blob/gh-pages/homology-interspecies.html" target="_blank">Source</a>
+
+  <p>
+    This demonstrates support for drawing features on a target genome that has
+    very many cytogenetic bands
+  </p>
+  <p>
+    See also: <a href='homology-human-chimpanzee'>Homology, human and chimpanzee</a>
+  </p>
+
+  <script type="text/javascript">
+
+    function onIdeogramLoad() {
+
+      var chrs, chr1, chr4, syntheticRegions, taxid1, taxid2;
+
+      taxid1 = ideogram.getTaxid('homo-sapiens');
+      // taxid2 = ideogram.getTaxid('mus-musculus');
+      taxid2 = ideogram.getTaxid('drosophila-melanogaster');
+
+      var chrs = ideogram.chromosomes,
+        chr1 = chrs[taxid1]['1'],
+        chr17 = chrs[taxid1]['17'],
+        // chr3 = chrs[taxid2]['3'],
+        // chr4 = chrs[taxid2]['4'],
+        chr2L = chrs[taxid2]['2L'],
+        chr2R = chrs[taxid2]['2R'],
+        chr3L = chrs[taxid2]['3L'],
+        chr3R = chrs[taxid2]['3R'],
+        chr4 = chrs[taxid2]['4'],
+        chrX = chrs[taxid2]['X'],
+        syntenicRegions = [];
+
+      range1 = {
+        chr: chr1,
+        start: 11106530,
+        stop: 11262550,
+        orientation: 'reverse'
+      };
+      
+
+      range17 = {
+        chr: chr17,
+        start: 11106530,
+        stop: 11262550,
+        orientation: 'reverse'
+      };
+
+      range2 = {
+        chr: chr2L,
+        // chr: chr3,
+        start: 9484485,
+        stop: 9485576
+      };
+
+      range3 = {
+        chr: chr2R,
+        // chr: chr4,
+        start: 9484485,
+        stop: 9485576
+      };
+
+      range4 = {
+        chr: chr3L,
+        // chr: chr4,
+        start: 9484485,
+        stop: 9485576
+      };
+
+      range5 = {
+        chr: chr3R,
+        // chr: chr4,
+        start: 9484485,
+        stop: 9485576
+      };
+
+      range6 = {
+        chr: chr4,
+        // chr: chr4,
+        start: 9484,
+        stop: 9485
+      };
+
+      range7 = {
+        chr: chrX,
+        start: 9484485,
+        stop: 9485576
+      };
+
+      syntenicRegions.push({'r1': range1, 'r2': range2});
+      syntenicRegions.push({'r1': range1, 'r2': range3});
+      syntenicRegions.push({'r1': range1, 'r2': range4});
+      syntenicRegions.push({'r1': range1, 'r2': range5});
+      syntenicRegions.push({'r1': range1, 'r2': range6});
+      syntenicRegions.push({'r1': range1, 'r2': range7});
+      syntenicRegions.push({'r1': range17, 'r2': range7});
+      syntenicRegions.push({'r1': range17, 'r2': range2});
+
+      ideogram.drawSynteny(syntenicRegions);
+
+    }
+
+  var config = {
+    organism: ['homo-sapiens', 'drosophila-melanogaster'],
+    // organism: ['homo-sapiens', 'mus-musculus'],
+    chrHeight: 50,
+    chrMargin: 5,
+    perspective: 'comparative',
+    chromosomeScale: 'relative',
+    geometry: 'collinear',
+    rotatable: false,
+    onLoad: onIdeogramLoad
+  };
+
+  var ideogram = new Ideogram(config);
+
+  </script>
+</body>
+</html>

--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -76,7 +76,6 @@
   <script type="text/javascript">
 
     var prevState = {};
-    var loci1, loci2;
     var orthologs = []; // arrays of [loci1, loci2]
 
     function shouldUpdateState() {
@@ -93,12 +92,10 @@
 
     // Process text input for the "Gene" field.
     async function handleGene(event) {
-      var geneNames, loci1, loci2;
-
       // Ignore non-"Enter" keyups
       if (event.type === 'keyup' && event.keyCode !== 13) return;
 
-      geneNames = event.target.value;
+      var geneNames = event.target.value;
 
       // Ignore when input value is unchanged
       if (urlParams['genes'] === geneNames) return;
@@ -123,7 +120,7 @@
 
     function splitList(csvList) {
       return csvList
-        .replace('%20', '')
+        .replace(/%20/g, '')
         .replace(/^\s+|\s+$/g, '')
         .split(',');
     }
@@ -176,6 +173,8 @@
     }
 
     async function processUrl() {
+      var genesList;
+
       document.querySelector('#ideogram-container').innerHTML = '';
       document.querySelector('#status-container').innerHTML = 'Loading...';
       parseUrlParams();
@@ -223,13 +222,8 @@
 
       if (shouldUpdateState()) {
         try {
-          orthologs = [];
-          var geneList = splitList(genes);
-          for (i = 0; i < geneList.length; i++) {
-            gene = geneList[i];
-            [loci1, loci2] = await fetchOrthologs(gene, org1, [org2], backend);
-            orthologs.push([loci1, loci2]);
-          }
+          genesList = splitList(genes);
+          orthologs = await fetchOrthologs(genesList, org1, [org2], backend);
         } catch (error) {
           document.querySelector('#status-container').innerHTML =
             `<span id="error-container">${error}</span>`;
@@ -242,13 +236,13 @@
     }
 
     function parseGenomicRawRanges(ortholog) {
-      loci1 = ortholog[0];
-      loci2 = ortholog[1];
 
-      [loci1Chr, loci1Range] = loci1.split(':');
-      [loci2Chr, loci2Range] = loci2.split(':');
-      [loci1Start, loci1Stop] = loci1Range.split('-');
-      [loci2Start, loci2Stop] = loci2Range.split('-');
+      var [loci1, loci2] = ortholog;
+
+      var [loci1Chr, loci1Range] = loci1.split(':');
+      var [loci2Chr, loci2Range] = loci2.split(':');
+      var [loci1Start, loci1Stop] = loci1Range.split('-');
+      var [loci2Start, loci2Stop] = loci2Range.split('-');
 
       range1 = {
         chr: loci1Chr,
@@ -357,7 +351,7 @@
         });
       } else {
         // Multiple chromosomes
-        ranges = parseGenomicRawRanges(orthologs[0]);
+        ranges = parseGenomicRawRanges(orthologs[0][0]);
         chromosomesConfig = {}
         chromosomesConfig[org1] = [ranges[0].chr];
         chromosomesConfig[org2] = [ranges[1].chr];

--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -112,7 +112,7 @@
     async function handleOrganism(event) {
       var organism =
           event.target.value.split('(')[1].split(')')[0]
-          .replace(' ', '-').toLowerCase();
+          .replace(/ /g, '-').toLowerCase();
 
       urlParams[event.target.id] = organism;
 
@@ -205,8 +205,8 @@
         urlParams['backend'] = 'oma';
       }
 
-      org1 = urlParams['org'].replace('-', ' ');
-      org2 = urlParams['org2'].replace('-', ' ');
+      org1 = urlParams['org'].replace(/-/g, ' ');
+      org2 = urlParams['org2'].replace(/-/g, ' ');
 
       showBandLabels = 'band-labels' in urlParams;
 

--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -351,7 +351,7 @@
         });
       } else {
         // Multiple chromosomes
-        ranges = parseGenomicRawRanges(orthologs[0][0]);
+        ranges = parseGenomicRawRanges(orthologs[0]);
         chromosomesConfig = {}
         chromosomesConfig[org1] = [ranges[0].chr];
         chromosomesConfig[org2] = [ranges[1].chr];

--- a/src/js/annotations/synteny-collinear.js
+++ b/src/js/annotations/synteny-collinear.js
@@ -29,23 +29,20 @@ function getRegionsR1AndR2(regions, xOffset, ideo) {
   r1 = regions.r1;
   r2 = regions.r2;
 
-  var r1ChrLengthPx = r1.chr.bands.slice(-1)[0].px.stop;
-  var r2ChrLengthPx = r2.chr.bands.slice(-1)[0].px.stop;
-  var ratio = r2ChrLengthPx / r1ChrLengthPx;
+  // var r1ChrLengthPx = r1.chr.bands.slice(-1)[0].px.stop;
+  // var r2ChrLengthPx = r2.chr.bands.slice(-1)[0].px.stop;
+  // var ratio = r2ChrLengthPx / r1ChrLengthPx;
   var r1ChrDom = document.querySelector('#' + r1.chr.id + '-chromosome-set');
   var r1GenomeOffset = r1ChrDom.getCTM().f;
   var r2ChrDom = document.querySelector('#' + r2.chr.id + '-chromosome-set');
   // var r2GenomeOffset = r2ChrDom.getBoundingClientRect().top;
   var r2GenomeOffset = r2ChrDom.getCTM().f;
 
-  r1.startPx = ideo.convertBpToPx(r1.chr, r1.start) * ratio + r1GenomeOffset - 7;
-  r1.stopPx = ideo.convertBpToPx(r1.chr, r1.stop) * ratio + r1GenomeOffset - 7;
-  r2.startPx = ideo.convertBpToPx(r2.chr, r2.start) * ratio + r2GenomeOffset - 7;
-  r2.stopPx = ideo.convertBpToPx(r2.chr, r2.stop) * ratio + r2GenomeOffset - 7;
-  // r2.startPx = (ideo.convertBpToPx(r2.chr, r2.start) + xOffset) * ratio;
-  // r2.stopPx = (ideo.convertBpToPx(r2.chr, r2.stop) + xOffset) * ratio;
-  // r2.startPx = (ideo.convertBpToPx(r2.chr, r2.start) + xOffset) + r2GenomeOffset;
-  // r2.stopPx = (ideo.convertBpToPx(r2.chr, r2.stop) + xOffset) + r2GenomeOffset;
+  // r1.startPx = ideo.convertBpToPx(r1.chr, r1.start) * ratio + r1GenomeOffset - 7;
+  r1.startPx = ideo.convertBpToPx(r1.chr, r1.start) + r1GenomeOffset - 7;
+  r1.stopPx = ideo.convertBpToPx(r1.chr, r1.stop) + r1GenomeOffset - 7;
+  r2.startPx = ideo.convertBpToPx(r2.chr, r2.start) + r2GenomeOffset - 7;
+  r2.stopPx = ideo.convertBpToPx(r2.chr, r2.stop) + r2GenomeOffset - 7;
 
   return [r1, r2];
 }
@@ -100,8 +97,8 @@ function writeSyntenicRegions(syntenicRegions, syntenies, xOffset, ideo) {
     syntenicRegion = writeSyntenicRegion(syntenies, regionID, ideo);
 
     chrWidth = ideo.config.chrWidth;
-    x1 = ideo._layout.getChromosomeSetYTranslate(0) + 9;
-    x2 = ideo._layout.getChromosomeSetYTranslate(1) - chrWidth + 201;
+    x1 = chrWidth + 9;
+    x2 = chrWidth + 210; // Genomes are spaced ~200 pixels apart
 
     writeSyntenicRegionPolygons(syntenicRegion, x1, x2, r1, r2, regions);
     writeSyntenicRegionLines(syntenicRegion, x1, x2, r1, r2);

--- a/src/js/init/init.js
+++ b/src/js/init/init.js
@@ -14,7 +14,7 @@ function isHeterogameticChromosome(chrModel, chrIndex, ideo) {
   return (
     'sex' in ideo.config &&
       (
-        ploidy === 2 && ideo.sexChromosomes.index + 2 === chrIndex ||
+        ploidy === 2 && ideo.sexChromosomes.index + 1 === chrIndex ||
         ideo.config.sex === 'female' && chrModel.name === 'Y'
       )
   );

--- a/test/web-test.js
+++ b/test/web-test.js
@@ -563,12 +563,12 @@ describe('Ideogram', function() {
       line1 = document.querySelector(selector1 + ' .syntenyBorder');
       line3 = document.querySelector(selector3 + ' .syntenyBorder');
 
-      assert.equal(Math.round(line1.getAttribute('x1')), 23);
+      assert.equal(Math.round(line1.getAttribute('x1')), 19);
       assert.equal(Math.round(line1.getAttribute('x2')), 220);
-      assert.equal(Math.round(line1.getAttribute('y1')), 14);
+      assert.equal(Math.round(line1.getAttribute('y1')), 15);
 
-      assert.equal(Math.round(line3.getAttribute('y1')), 315);
-      assert.equal(Math.round(line3.getAttribute('y2')), 52);
+      assert.equal(Math.round(line3.getAttribute('y1')), 313);
+      assert.equal(Math.round(line3.getAttribute('y2')), 51);
       done();
     }
 


### PR DESCRIPTION
This irons out a few wrinkles for comparative genomics.  You can now:

* Compare genomes for species that have three-part names, like _Canis lupus familiaris_ (dog)
* Draw more accurate orthology annotations for genomes involving chromosomes of different size.  Multi-gene comparisons between human and fly (_Drosophila melanogaster_) -- like the new one below -- previously had glaring problems.

<img width="847" alt="ideogram_orthology_human_fly" src="https://user-images.githubusercontent.com/1334561/68499351-fc1d1a80-0226-11ea-81d9-15ec88704741.png">
