### PR TITLE
Label annotations for comparative genomics

### DIFF
--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -239,22 +239,27 @@
 
       var [loci1, loci2] = ortholog;
 
-      var [loci1Chr, loci1Range] = loci1.split(':');
-      var [loci2Chr, loci2Range] = loci2.split(':');
+      var [loci1Chr, loci1Range] = loci1.location.split(':');
+      var [loci2Chr, loci2Range] = loci2.location.split(':');
       var [loci1Start, loci1Stop] = loci1Range.split('-');
       var [loci2Start, loci2Stop] = loci2Range.split('-');
 
       range1 = {
         chr: loci1Chr,
         start: loci1Start,
-        stop: loci1Stop
+        stop: loci1Stop,
+        name: loci1.gene
       };
 
       range2 = {
         chr: loci2Chr,
         start: loci2Start,
-        stop: loci2Stop
+        stop: loci2Stop,
+        name: loci2.gene
       };
+
+      console.log('range1')
+      console.log(range1)
 
       return [range1, range2];
     }
@@ -290,13 +295,15 @@
         range1 = {
           chr: org1ChrObj,
           start: rawRanges[0].start,
-          stop: rawRanges[0].stop
+          stop: rawRanges[0].stop,
+          name: rawRanges[0].name
         };
 
         range2 = {
           chr: org2ChrObj,
           start: rawRanges[1].start,
-          stop: rawRanges[1].stop
+          stop: rawRanges[1].stop,
+          name: rawRanges[1].name
         };
 
         syntenicRegions.push({'r1': range1, 'r2': range2});

--- a/src/js/annotations/synteny-collinear.js
+++ b/src/js/annotations/synteny-collinear.js
@@ -23,7 +23,7 @@ function writeSyntenicRegion(syntenies, regionID, ideo) {
     });
 }
 
-function getRegionsR1AndR2(regions, xOffset, ideo) {
+function getRegionsR1AndR2(regions, ideo) {
   var r1, r2;
 
   r1 = regions.r1;
@@ -86,7 +86,7 @@ function writeSyntenicRegions(syntenicRegions, syntenies, xOffset, ideo) {
   for (i = 0; i < syntenicRegions.length; i++) {
     regions = syntenicRegions[i];
 
-    [r1, r2] = getRegionsR1AndR2(regions, xOffset, ideo);
+    [r1, r2] = getRegionsR1AndR2(regions, ideo);
 
     regionID = (
       r1.chr.id + '_' + r1.start + '_' + r1.stop + '_' +

--- a/src/js/annotations/synteny.js
+++ b/src/js/annotations/synteny.js
@@ -71,6 +71,27 @@ function writeSyntenicRegionLines(syntenicRegion, x1, x2, r1, r2) {
     .attr('y2', r2.stopPx);
 }
 
+function writeSyntenicRegionLabels(syntenicRegion, x1, x2, r1, r2, regionId) {
+  var rangeIds = regionId.split('__').map(d => 'label_' + d);
+  if ('name' in r1) {
+    syntenicRegion.append('text')
+      .attr('id', rangeIds[0])
+      .attr('y', r1.startPx + 3)
+      .text(r1.name);
+    var r1Width =
+      document.querySelector('#' + rangeIds[0]).getBoundingClientRect().width;
+    d3.select('#' + rangeIds[0]).attr('x', x1 - 15 - r1Width);
+  }
+  if ('name' in r2) {
+    syntenicRegion.append('text')
+      .attr('id', rangeIds[1])
+      .text(r2.name)
+      .attr('x', x2 + 15)
+      .attr('y', r2.startPx + 3)
+      .text(r2.name);
+  }
+}
+
 function writeSyntenicRegions(syntenicRegions, syntenies, xOffset, ideo) {
   var i, regions, r1, r2, regionID, syntenicRegion, chrWidth, x1, x2;
 
@@ -93,6 +114,7 @@ function writeSyntenicRegions(syntenicRegions, syntenies, xOffset, ideo) {
 
     writeSyntenicRegionPolygons(syntenicRegion, x1, x2, r1, r2, regions);
     writeSyntenicRegionLines(syntenicRegion, x1, x2, r1, r2);
+    writeSyntenicRegionLabels(syntenicRegion, x1, x2, r1, r2, regionID);
   }
 }
 

--- a/src/js/views/chromosome-model.js
+++ b/src/js/views/chromosome-model.js
@@ -153,7 +153,6 @@ function getChromosomeModel(bands, chrName, taxid, chrIndex) {
 
   if (ideo.config.fullChromosomeLabels === true) {
     org = this.organisms[taxid];
-    console.log(org.scientificName);
     splitName = org.scientificName.split(' ');
     abbreviatedName = splitName[0][0] + '. ' + splitName[1];
 


### PR DESCRIPTION
This enables labeling annotations used for comparative genomics.  It also updates the Orthologs example to use related upstream enhancements in [Homology.js](https://github.com/eweitz/homology).

For example, when plotting orthology of MTOR gene, new labels make it clearer what is being shown:

<img width="357" alt="ideogram_ortholog_labels_human_mouse_mtor" src="https://user-images.githubusercontent.com/1334561/68851233-8c35e680-06a3-11ea-9ff8-e42957ebb55f.png">