### PR TITLE
Label genomes when comparing gene lists

### DIFF
--- a/examples/vanilla/compare-whole-genomes.html
+++ b/examples/vanilla/compare-whole-genomes.html
@@ -66,80 +66,80 @@
 
   var initialized = false;
 
-  // function onIdeogramLoad() {
-  //     var chrs, humanChrs, mouseChrs, syntenicRegions, humanTaxid, mouseTaxid;
-
-  //     chrs = ideogram.chromosomes;
-  //     humanTaxid = ideogram.getTaxid('human');
-  //     mouseTaxid = ideogram.getTaxid('mouse');
-  //     humanChrs = chrs[humanTaxid];
-  //     mouseChrs = chrs[mouseTaxid];
-
-  //     syntenicRegions = [];
-
-  //     // MTOR gene
-  //     range1 = {chr: humanChrs['1'], start: 11106531, stop: 11262557};
-  //     range2 = {chr: mouseChrs['4'], start: 148448582, stop: 148557685};
-  //     syntenicRegions.push({'r1': range1, 'r2': range2});
-
-  //     // PTEN gene
-  //     range3 = {chr: humanChrs['10'], start: 87864470, stop: 87965472};
-  //     range4 = {chr: mouseChrs['19'], start: 32758445, stop: 32820028};
-  //     syntenicRegions.push({'r1': range3, 'r2': range4});
-
-  //     // GAD2 gene
-  //     range5 = {chr: humanChrs['10'], start: 26216810, stop: 26300961}
-  //     range6 = {chr: mouseChrs['2'], start: 22622663, stop: 22690346};
-  //     syntenicRegions.push({'r1': range5, 'r2': range6});
-
-  //     ideogram.drawSynteny(syntenicRegions);
-  //   }
-
-    function onIdeogramLoad() {
-      // These genes were fetched via the Orthologs example in Ideogram, e.g.:
-      // https://eweitz.github.io/ideogram/orthologs?gene=KDM5A&org=homo-sapiens&org2=arabidopsis-thaliana&backend=orthodb
-
-      var chrs, humanChrs, mouseChrs, syntenicRegions, humanTaxid, mouseTaxid,
-        range1, range2;
+  function onIdeogramLoad() {
+      var chrs, humanChrs, mouseChrs, syntenicRegions, humanTaxid, mouseTaxid;
 
       chrs = ideogram.chromosomes;
       humanTaxid = ideogram.getTaxid('human');
-      plantTaxid = ideogram.getTaxid('thale cress'); // Arabidopsis thaliana
-      // plantTaxid = ideogram.getTaxid('mus-musculus'); // Mouse
+      mouseTaxid = ideogram.getTaxid('mouse');
       humanChrs = chrs[humanTaxid];
-      plantChrs = chrs[plantTaxid];
+      mouseChrs = chrs[mouseTaxid];
 
       syntenicRegions = [];
 
-      // GTF2B gene
-      range1 = {chr: humanChrs['1'], start: 88853213, stop: 88891499};
-      range2 = {chr: plantChrs['3'], start: 3199907, stop: 3201642};
+      // MTOR gene
+      range1 = {chr: humanChrs['1'], start: 11106531, stop: 11262557};
+      range2 = {chr: mouseChrs['4'], start: 148448582, stop: 148557685};
       syntenicRegions.push({'r1': range1, 'r2': range2});
 
-      // E2F4 gene
-      range1 = {chr: humanChrs['16'], start: 67192154, stop: 67198917};
-      range2 = {chr: plantChrs['1'], start: 17634696, stop: 17637808};
-      syntenicRegions.push({'r1': range1, 'r2': range2});
+      // PTEN gene
+      range3 = {chr: humanChrs['10'], start: 87864470, stop: 87965472};
+      range4 = {chr: mouseChrs['19'], start: 32758445, stop: 32820028};
+      syntenicRegions.push({'r1': range3, 'r2': range4});
 
-      // Gtf2e2 gene
-      range1 = {chr: humanChrs['8'], start: 30658240, stop: 30578317};
-      range2 = {chr: plantChrs['4'], start: 10984520, stop: 10982516};
-      syntenicRegions.push({'r1': range1, 'r2': range2});
-
-      // NFYC gene
-      range1 = {chr: humanChrs['1'], start: 40691698, stop: 40771602};
-      range2 = {chr: plantChrs['1'], start: 20451082, stop: 20452670};
-      syntenicRegions.push({'r1': range1, 'r2': range2});
-
-      // KDM5A gene
-      range1 = {chr: humanChrs['12'], start: 389319, stop: 280056};
-      range2 = {chr: plantChrs['1'], start: 23553231, stop: 23544553};
-      syntenicRegions.push({'r1': range1, 'r2': range2});
+      // GAD2 gene
+      range5 = {chr: humanChrs['10'], start: 26216810, stop: 26300961}
+      range6 = {chr: mouseChrs['2'], start: 22622663, stop: 22690346};
+      syntenicRegions.push({'r1': range5, 'r2': range6});
 
       ideogram.drawSynteny(syntenicRegions);
-
-      document.querySelector('#_ideogram').setAttribute('width', 1000);
     }
+
+    // function onIdeogramLoad() {
+    //   // These genes were fetched via the Orthologs example in Ideogram, e.g.:
+    //   // https://eweitz.github.io/ideogram/orthologs?gene=KDM5A&org=homo-sapiens&org2=arabidopsis-thaliana&backend=orthodb
+
+    //   var chrs, humanChrs, mouseChrs, syntenicRegions, humanTaxid, mouseTaxid,
+    //     range1, range2;
+
+    //   chrs = ideogram.chromosomes;
+    //   humanTaxid = ideogram.getTaxid('human');
+    //   // plantTaxid = ideogram.getTaxid('thale cress'); // Arabidopsis thaliana
+    //   plantTaxid = ideogram.getTaxid('mus-musculus'); // Mouse
+    //   humanChrs = chrs[humanTaxid];
+    //   plantChrs = chrs[plantTaxid];
+
+    //   syntenicRegions = [];
+
+    //   // GTF2B gene
+    //   range1 = {chr: humanChrs['1'], start: 88853213, stop: 88891499};
+    //   range2 = {chr: plantChrs['3'], start: 3199907, stop: 3201642};
+    //   syntenicRegions.push({'r1': range1, 'r2': range2});
+
+    //   // E2F4 gene
+    //   range1 = {chr: humanChrs['16'], start: 67192154, stop: 67198917};
+    //   range2 = {chr: plantChrs['1'], start: 17634696, stop: 17637808};
+    //   syntenicRegions.push({'r1': range1, 'r2': range2});
+
+    //   // Gtf2e2 gene
+    //   range1 = {chr: humanChrs['8'], start: 30658240, stop: 30578317};
+    //   range2 = {chr: plantChrs['4'], start: 10984520, stop: 10982516};
+    //   syntenicRegions.push({'r1': range1, 'r2': range2});
+
+    //   // NFYC gene
+    //   range1 = {chr: humanChrs['1'], start: 40691698, stop: 40771602};
+    //   range2 = {chr: plantChrs['1'], start: 20451082, stop: 20452670};
+    //   syntenicRegions.push({'r1': range1, 'r2': range2});
+
+    //   // KDM5A gene
+    //   range1 = {chr: humanChrs['12'], start: 389319, stop: 280056};
+    //   range2 = {chr: plantChrs['1'], start: 23553231, stop: 23544553};
+    //   syntenicRegions.push({'r1': range1, 'r2': range2});
+
+    //   ideogram.drawSynteny(syntenicRegions);
+
+    //   document.querySelector('#_ideogram').setAttribute('width', 1000);
+    // }
 
     // Record app state in URL
     function updateUrl(params) {
@@ -198,8 +198,8 @@
       }
 
       config = {
-        organism: ['human', 'thale cress'],
-        // organism: ['human', 'mus musculus'],
+        // organism: ['human', 'thale cress'],
+        organism: ['human', 'mus musculus'],
         orientation: orientation,
         geometry: 'collinear',
         chromosomeScale: chromosomeScale,

--- a/examples/vanilla/homology-human-fly.html
+++ b/examples/vanilla/homology-human-fly.html
@@ -51,58 +51,58 @@
 
       range1 = {
         chr: chr1,
-        start: 11106530,
-        stop: 11262550,
+        start: 1,
+        stop: 1,
         orientation: 'reverse'
       };
       
 
       range17 = {
         chr: chr17,
-        start: 11106530,
-        stop: 11262550,
+        start: 1,
+        stop: 1,
         orientation: 'reverse'
       };
 
       range2 = {
         chr: chr2L,
         // chr: chr3,
-        start: 9484485,
-        stop: 9485576
+        start: 1,
+        stop: 1
       };
 
       range3 = {
         chr: chr2R,
         // chr: chr4,
-        start: 9484485,
-        stop: 9485576
+        start: 1,
+        stop: 1
       };
 
       range4 = {
         chr: chr3L,
         // chr: chr4,
-        start: 9484485,
-        stop: 9485576
+        start: 1,
+        stop: 1
       };
 
       range5 = {
         chr: chr3R,
         // chr: chr4,
-        start: 9484485,
-        stop: 9485576
+        start: 1,
+        stop: 1
       };
 
       range6 = {
         chr: chr4,
         // chr: chr4,
-        start: 9484,
-        stop: 9485
+        start: 1,
+        stop: 1
       };
 
       range7 = {
         chr: chrX,
-        start: 9484485,
-        stop: 9485576
+        start: 1,
+        stop: 1 
       };
 
       syntenicRegions.push({'r1': range1, 'r2': range2});

--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -66,8 +66,8 @@
   <label for="backend">
     Orthology backend:
     <select class="left-select backend-select" id="backend">
-      <option id="oma" selected>OMA Browser</option>
-      <option id="orthodb">OrthoDB</option>
+      <option id="orthodb" selected>OrthoDB</option>
+      <option id="oma">OMA Browser</option>
     </select>
   </label>
   </div>
@@ -190,7 +190,7 @@
         urlParams['genes'] = 'MTOR'
         urlParams['org'] = 'homo-sapiens';
         urlParams['org2'] = 'mus-musculus';
-        urlParams['backend'] = 'oma';
+        urlParams['backend'] = 'orthodb';
         // urlParams['loci'] = '1:11106531-11262557,4:148448582-148557685';
       }
 
@@ -201,7 +201,7 @@
       }
 
       if ('backend' in urlParams === false) {
-        urlParams['backend'] = 'oma';
+        urlParams['backend'] = 'orthodb';
       }
 
       org1 = urlParams['org'].replace(/-/g, ' ');

--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -314,7 +314,7 @@
       var ideoContainer = document.querySelector('#ideogram-container');
       if (orthologs.length > 1) {
         document.querySelector('#_ideogram').setAttribute('width', 350);
-        ideoContainer.setAttribute('style', 'position: relative; top: -100px; left: 200px;');
+        ideoContainer.setAttribute('style', 'position: relative; top: -110px; left: 200px;');
       } else {
         ideoContainer.setAttribute('style', '');
       }

--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -313,7 +313,7 @@
 
       var ideoContainer = document.querySelector('#ideogram-container');
       if (orthologs.length > 1) {
-        document.querySelector('#_ideogram').setAttribute('width', 250);
+        document.querySelector('#_ideogram').setAttribute('width', 350);
         ideoContainer.setAttribute('style', 'position: relative; top: -100px; left: 200px;');
       } else {
         ideoContainer.setAttribute('style', '');

--- a/src/js/annotations/synteny-collinear.js
+++ b/src/js/annotations/synteny-collinear.js
@@ -97,8 +97,8 @@ function writeSyntenicRegions(syntenicRegions, syntenies, xOffset, ideo) {
     syntenicRegion = writeSyntenicRegion(syntenies, regionID, ideo);
 
     chrWidth = ideo.config.chrWidth;
-    x1 = chrWidth + 9;
-    x2 = chrWidth + 210; // Genomes are spaced ~200 pixels apart
+    x1 = chrWidth + 46;
+    x2 = chrWidth + 240; // Genomes are spaced ~200 pixels apart
 
     writeSyntenicRegionPolygons(syntenicRegion, x1, x2, r1, r2, regions);
     writeSyntenicRegionLines(syntenicRegion, x1, x2, r1, r2);

--- a/src/js/annotations/synteny-collinear.js
+++ b/src/js/annotations/synteny-collinear.js
@@ -29,20 +29,16 @@ function getRegionsR1AndR2(regions, ideo) {
   r1 = regions.r1;
   r2 = regions.r2;
 
-  // var r1ChrLengthPx = r1.chr.bands.slice(-1)[0].px.stop;
-  // var r2ChrLengthPx = r2.chr.bands.slice(-1)[0].px.stop;
-  // var ratio = r2ChrLengthPx / r1ChrLengthPx;
   var r1ChrDom = document.querySelector('#' + r1.chr.id + '-chromosome-set');
   var r1GenomeOffset = r1ChrDom.getCTM().f;
   var r2ChrDom = document.querySelector('#' + r2.chr.id + '-chromosome-set');
   // var r2GenomeOffset = r2ChrDom.getBoundingClientRect().top;
   var r2GenomeOffset = r2ChrDom.getCTM().f;
 
-  // r1.startPx = ideo.convertBpToPx(r1.chr, r1.start) * ratio + r1GenomeOffset - 7;
-  r1.startPx = ideo.convertBpToPx(r1.chr, r1.start) + r1GenomeOffset - 7;
-  r1.stopPx = ideo.convertBpToPx(r1.chr, r1.stop) + r1GenomeOffset - 7;
-  r2.startPx = ideo.convertBpToPx(r2.chr, r2.start) + r2GenomeOffset - 7;
-  r2.stopPx = ideo.convertBpToPx(r2.chr, r2.stop) + r2GenomeOffset - 7;
+  r1.startPx = ideo.convertBpToPx(r1.chr, r1.start) + r1GenomeOffset - 12;
+  r1.stopPx = ideo.convertBpToPx(r1.chr, r1.stop) + r1GenomeOffset - 12;
+  r2.startPx = ideo.convertBpToPx(r2.chr, r2.start) + r2GenomeOffset - 12;
+  r2.stopPx = ideo.convertBpToPx(r2.chr, r2.stop) + r2GenomeOffset - 12;
 
   return [r1, r2];
 }

--- a/src/js/collinear-vertical.js
+++ b/src/js/collinear-vertical.js
@@ -109,9 +109,9 @@ function collinearizeVerticalChromosomes(ideo) {
     yOffsets.forEach(d => {
       if (d > maxHeight) maxHeight = d;
     });
-    height = maxHeight + 20;
+    height = maxHeight + 30;
   } else {
-    height = xOffsets.slice(-1)[0] + 20;
+    height = xOffsets.slice(-1)[0] + 30;
   }
 
   d3.select(ideo.selector)

--- a/src/js/collinear-vertical.js
+++ b/src/js/collinear-vertical.js
@@ -101,7 +101,7 @@ function collinearizeVerticalChromosomes(ideo) {
   yOffsets = getyOffsets(chrSets, ideo);
   rearrangeChromosomes(chrSets, yOffsets, x, ideo);
 
-  width = Math.round(yOffsets.slice(-1)[0] + 20);
+  width = Math.round(yOffsets.slice(-1)[0] + 70);
 
   if (config.multiorganism) {
     height *= 8;

--- a/src/js/collinear-vertical.js
+++ b/src/js/collinear-vertical.js
@@ -14,7 +14,7 @@ function labelGenomes(ideo) {
     var scientificName = org.scientificName;
     d3.select(ideo.selector)
       .append('text')
-      .attr('class', 'genomeLabel')
+      .attr('class', 'genomeLabel italic')
       .attr('x', 50 + 200 * i)
       .attr('y', 10)
       .text(scientificName)

--- a/src/js/collinear-vertical.js
+++ b/src/js/collinear-vertical.js
@@ -6,6 +6,22 @@
 
 import {d3} from './lib';
 
+function labelGenomes(ideo) {
+
+  ideo.config.taxids.forEach((taxid, i) => {
+    var org = ideo.organisms[taxid];
+    // var commonName = slug(org.commonName);
+    var scientificName = org.scientificName;
+    d3.select(ideo.selector)
+      .append('text')
+      .attr('class', 'genomeLabel')
+      .attr('x', 50 + 200 * i)
+      .attr('y', 10)
+      .text(scientificName)
+      .attr('text-anchor', 'middle');
+  });
+}
+
 /**
 * Rearrange chromosomes from horizontal to collinear
 */
@@ -15,12 +31,12 @@ function rearrangeChromosomes(chrSets, yOffsets, x, ideo) {
 
   for (i = 0; i < chrSets.length; i++) {
     chrSet = chrSets[i];
-    y = yOffsets[i];
+    y = yOffsets[i] + 15;
 
     chr = ideo.chromosomesArray[i];
     taxid = chr.id.split('-')[1];
     orgIndex = ideo.config.taxids.indexOf(taxid);
-    adjustedX = x - orgIndex * 200;
+    adjustedX = x - orgIndex * 200 - 30;
     if (orgIndex === 0) {
       chrLabelX = -34;
       adjustedX += ideo.config.chrWidth * 2 - 16;
@@ -35,6 +51,8 @@ function rearrangeChromosomes(chrSets, yOffsets, x, ideo) {
     chrSet.setAttribute('transform', 'rotate(90) translate(' + y + ',' + adjustedX + ')');
     chrSet.querySelector('.chromosome').setAttribute('transform', 'translate(-13, 10)');
   }
+
+  labelGenomes(ideo);
 }
 
 /**

--- a/src/js/views/chromosome-model.js
+++ b/src/js/views/chromosome-model.js
@@ -140,7 +140,7 @@ function getCentromerePosition(hasBands, bands) {
  * bands, centromere position, etc.
  */
 function getChromosomeModel(bands, chrName, taxid, chrIndex) {
-  var hasBands, org, abbreviatedName, splitName,
+  var hasBands, org,
     chr = {},
     ideo = this;
 
@@ -153,10 +153,7 @@ function getChromosomeModel(bands, chrName, taxid, chrIndex) {
 
   if (ideo.config.fullChromosomeLabels === true) {
     org = this.organisms[taxid];
-    splitName = org.scientificName.split(' ');
-    abbreviatedName = splitName[0][0] + '. ' + splitName[1];
-
-    chr.name = abbreviatedName + ' chr' + chr.name;
+    chr.name = org.scientificName + ' chr' + chr.name;
   }
 
   chr.bands = bands;

--- a/test/web-test.js
+++ b/test/web-test.js
@@ -565,10 +565,10 @@ describe('Ideogram', function() {
 
       assert.equal(Math.round(line1.getAttribute('x1')), 56);
       assert.equal(Math.round(line1.getAttribute('x2')), 250);
-      assert.equal(Math.round(line1.getAttribute('y1')), 30);
+      assert.equal(Math.round(line1.getAttribute('y1')), 25);
 
-      assert.equal(Math.round(line3.getAttribute('y1')), 328);
-      assert.equal(Math.round(line3.getAttribute('y2')), 66);
+      assert.equal(Math.round(line3.getAttribute('y1')), 323);
+      assert.equal(Math.round(line3.getAttribute('y2')), 61);
       done();
     }
 

--- a/test/web-test.js
+++ b/test/web-test.js
@@ -563,12 +563,12 @@ describe('Ideogram', function() {
       line1 = document.querySelector(selector1 + ' .syntenyBorder');
       line3 = document.querySelector(selector3 + ' .syntenyBorder');
 
-      assert.equal(Math.round(line1.getAttribute('x1')), 19);
-      assert.equal(Math.round(line1.getAttribute('x2')), 220);
-      assert.equal(Math.round(line1.getAttribute('y1')), 15);
+      assert.equal(Math.round(line1.getAttribute('x1')), 56);
+      assert.equal(Math.round(line1.getAttribute('x2')), 250);
+      assert.equal(Math.round(line1.getAttribute('y1')), 30);
 
-      assert.equal(Math.round(line3.getAttribute('y1')), 313);
-      assert.equal(Math.round(line3.getAttribute('y2')), 51);
+      assert.equal(Math.round(line3.getAttribute('y1')), 328);
+      assert.equal(Math.round(line3.getAttribute('y2')), 66);
       done();
     }
 


### PR DESCRIPTION
This adds an organism name atop each genome when comparing multiple genes across species.

That enables users to better understand what they're looking at, without needing to consult a caption.

Example:
<img width="315" alt="ideogram_labeled_genomes_human_mouse_orthologs" src="https://user-images.githubusercontent.com/1334561/68939437-9f61b880-076e-11ea-91a6-70a7e6a06745.png">
