### PR TITLE
Change CDN for better uptime and performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A [broader overview](https://speakerdeck.com/eweitz/ideogramjs-chromosome-visual
 
 To link directly to the latest release, copy this snippet:
 ```
-<script src="https://unpkg.com/ideogram@1.14.1/dist/js/ideogram.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/ideogram@1.14.1/dist/js/ideogram.min.js"></script>
 ```
 
 You can also easily use the library locally:
@@ -44,7 +44,7 @@ import Ideogram from 'ideogram';
 # Usage
 ```html
 <head>
-  <script src="https://unpkg.com/ideogram@1.14.1/dist/js/ideogram.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/ideogram@1.14.1/dist/js/ideogram.min.js"></script>
 </head>
 <body>
 <script>

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -72,7 +72,7 @@ function getDataDir() {
 
   if (host !== 'localhost' && host !== '127.0.0.1') {
     return (
-      'https://unpkg.com/ideogram@' + version + '/dist/data/bands/native/'
+      'https://cdn.jsdelivr.net/npm/ideogram@' + version + '/dist/data/bands/native/'
     );
   }
 


### PR DESCRIPTION
This changes the [content delivery network](https://en.wikipedia.org/wiki/Content_delivery_network) for Ideogram from https://unpkg.com to https://www.jsdelivr.com.

Unpkg is good, but has occasionally fails (e.g. #129).  However, JsDelivr has better reliability -- it's currently the best free CDN in terms of uptime and latency per https://www.cdnperf.com/.