### PR TITLE
Tailor layout, improve filter and sort, support more organisms in "Differential expression"

### DIFF
--- a/examples/vanilla/differential-expression.html
+++ b/examples/vanilla/differential-expression.html
@@ -590,14 +590,18 @@
     fetch(annotationsPath)
       .then(response => response.json())
       .then(rawAnnots => {
+          const numChrs = rawAnnots.annots.length;
+          const ideoWidth = 1100;
+          const chrWidth = ideoWidth/(numChrs*4.5);
+          const chrMargin = ideoWidth/(numChrs*2.8);
           const config = {
             container: '#ideogram-container',
             orientation: 'vertical',
             organism: rawAnnots.metadata.organism, // This is why we need to fetch annots first
             assembly: rawAnnots.metadata.assembly,
-            chrHeight: 225,
-            chrWidth: 12,
-            chrMargin: 19,
+            chrHeight: 205,
+            chrWidth: chrWidth,
+            chrMargin: chrMargin,
             annotations: rawAnnots,
             annotationsLayout: 'histogram',
             barWidth: 3,
@@ -646,7 +650,11 @@
     'GLDS-168': {
       assay: 'rna_seq_ERCCnorm_differential_expression',
       studyTitle: 'RR-1 and RR-3 mouse liver transcriptomics with and without ERCC control RNA spike-ins'
-    }
+    },
+    'GLDS-188': {
+      assay: 'array_differential_expression',
+      studyTitle: 'Dynamic gene expression response to altered gravity in human T cells (sounding rocket flight)'
+    },
   }
 
   window.urlParams = parseUrlParams();

--- a/examples/vanilla/differential-expression.html
+++ b/examples/vanilla/differential-expression.html
@@ -547,11 +547,16 @@
     const table = `<table id="ideogram-annots-table" class="display">${head}</table>`;
     document.querySelector('#table-container').innerHTML = table;
 
+    // Show more rows in each page for larger screens
+    const pageLength = window.outerHeight >= 950 ? 20 : 10;
+
     $('#ideogram-annots-table').DataTable({
+      data: rows,
       dom: 'lBfrtip', // Docs: https://datatables.net/reference/option/dom
       buttons: [{extend: 'csv', text: 'Export'}],
-      data: rows,
       order: [[headers.indexOf(sortKey), 'desc']],
+      pageLength: pageLength,
+      lengthMenu: [10, 20, 50, 100, 500, 1000],
       deferRender: true,
       // columnDefs: [null, null, null, null, {render: }]
       columns: [
@@ -597,6 +602,13 @@
           const calcChrMargin = (ideoWidth/numChrs - chrWidth) - chrWidth*1.8;
           const maxChrMargin = 50;
           const chrMargin = calcChrMargin > maxChrMargin ? maxChrMargin : calcChrMargin;
+
+          // TODO: Make chromosome height responsive to larger screens
+          // const tableHeight = 490;
+          // const headerHeight = 120;
+          // const calcChrHeight = window.outerHeight - tableHeight - headerHeight;
+          // // const maxChrHeight = 225;
+          // // const chrHeight = calcChrHeight > maxChrHeight ? maxChrHeight : calcChrHeight;
 
           const config = {
             container: '#ideogram-container',

--- a/examples/vanilla/differential-expression.html
+++ b/examples/vanilla/differential-expression.html
@@ -83,7 +83,7 @@
     .noUi-marker-horizontal.noUi-marker-large {height: 12px;}
     .noUi-marker .noUi-marker-horizontal .noUi-marker-normal {height: 3px;}
     .noUi-horizontal .noUi-tooltip {bottom: 115%;}
-    .noUi-tooltip {padding-top: 2px; padding-bottom: 0px;}
+    .noUi-tooltip {padding-top: 2px; padding-bottom: 0px; font-size: 12px;}
 
     .inactive .noUi-connect {background: #AAA;}
     .inactive .noUi-tooltip {color: #AAA;}
@@ -149,15 +149,15 @@
       },
       'log2fc': {
         range: {
-          'min': [-4],
-          'max': 4
+          'min': [-1.5],
+          'max': 1.5
         },
-        start: [-4, -1, 1, 4],
-        sliderDecimals: 1,
-        pipDecimals: 0,
+        start: [-1.5, -0.26, 0.26, 1.5],
+        sliderDecimals: 2,
+        pipDecimals: 1,
         connect: [false, true, false, true, false],
-        values: [0, 12.5, 25, 37.5, 50, 62.5, 75, 87.5, 100],
-        density: 4
+        values: [0, 16.7, 34.4, 50, 66.7, 84.4, 100],
+        density: 3
       }
     };
   
@@ -198,7 +198,7 @@
     const metricLabel = metricLabels[metric];
     document.querySelector(`#${comparisonId}`).innerHTML += 
       `<div style="margin-bottom: 115px; margin-left: 15px;">
-        <div style="width: 200px; margin-left: -15px; z-index: 2;">
+        <div style="margin-left: -15px; z-index: 2;">
           <input type="checkbox" class="slider-checkbox" id="slider-checkbox-${sliderId}"/>
           <label for="slider-checkbox-${sliderId}">${metricLabel}</label>
         </div>
@@ -247,7 +247,7 @@
 
     document.querySelector('#facets').innerHTML += `
       <div class="comparison-dropdowns" id="${comparisonId}">
-        <div style="margin-bottom: 30px; width: 200px;"></div>
+        <div style="margin-bottom: 30px;"></div>
       <div>`;
 
     writeComparisonDropdowns();
@@ -450,8 +450,8 @@
 
       if (slider.id.includes('log2fc')) {
         range = range.map(v => {
-          if (v === -4) return -Infinity;
-          if (v === 4) return Infinity;
+          if (v === -1.5) return -Infinity;
+          if (v === 1.5) return Infinity;
           return v;
         })
       }
@@ -518,7 +518,7 @@
         } else if (header === 'gene-type') {
           cells.push(labels[header][value]);
         } else if (header.includes(metrics[1])) {
-          const dispVal = value === 0 ? '< 1e-18' : value;
+          const dispVal = value === 0 ? '< 10e-18' : value;
           cells.push({display: dispVal, sortVal: value})
         } else {
           cells.push(value);
@@ -577,7 +577,6 @@
     Object.assign(selections, rangeSelections);
 
     counts = ideogram.filterAnnots(selections);
-
     writeCounts(counts);
 
     writeTable(metrics, comparison);
@@ -592,16 +591,20 @@
       .then(rawAnnots => {
           const numChrs = rawAnnots.annots.length;
           const ideoWidth = 1100;
-          const chrWidth = ideoWidth/(numChrs*4.5);
-          const chrMargin = ideoWidth/(numChrs*2.8);
+
+          const maxChrWidth = ideoWidth/(numChrs*4.5);
+          const maxChrMargin = ideoWidth/(numChrs*2.8);
+          const chrWidth = maxChrWidth <= 13 ? maxChrWidth : 13;
+          const chrMargin = maxChrMargin <= 18 ? maxChrMargin : 18;
+
           const config = {
             container: '#ideogram-container',
             orientation: 'vertical',
             organism: rawAnnots.metadata.organism, // This is why we need to fetch annots first
             assembly: rawAnnots.metadata.assembly,
             chrHeight: 205,
-            chrWidth: chrWidth < 15 ? chrWidth : 15,
-            chrMargin: chrMargin < 25 ? chrMargin : 25,
+            chrWidth: chrWidth,
+            chrMargin: chrMargin,
             annotations: rawAnnots,
             annotationsLayout: 'histogram',
             barWidth: 3,

--- a/examples/vanilla/differential-expression.html
+++ b/examples/vanilla/differential-expression.html
@@ -270,7 +270,7 @@
     document.querySelector('#summary').innerHTML = 
       `Genomic distribution of differentially expressed <span id="organismName" style="font-style: italic">${metadata.organism}</span> 
       genes, viewed with <a href="https://github.com/eweitz/ideogram">Ideogram.js</a>.
-      Data: NASA GeneLab 
+      NASA GeneLab 
       <a href="https://genelab-data.ndc.nasa.gov/genelab/accession/${acc}/" target="_blank">${acc}</a>, 
       "${window.studyTitle}".`;
 
@@ -590,19 +590,19 @@
       .then(response => response.json())
       .then(rawAnnots => {
           const numChrs = rawAnnots.annots.length;
-          const ideoWidth = 1100;
+          const ideoWidth = window.outerWidth - 340;
 
           const maxChrWidth = ideoWidth/(numChrs*4.5);
           const maxChrMargin = ideoWidth/(numChrs*2.8);
           const chrWidth = maxChrWidth <= 13 ? maxChrWidth : 13;
-          const chrMargin = maxChrMargin <= 18 ? maxChrMargin : 18;
+          const chrMargin = maxChrMargin <= 24 ? maxChrMargin : 24;
 
           const config = {
             container: '#ideogram-container',
             orientation: 'vertical',
             organism: rawAnnots.metadata.organism, // This is why we need to fetch annots first
             assembly: rawAnnots.metadata.assembly,
-            chrHeight: 205,
+            chrHeight: 225,
             chrWidth: chrWidth,
             chrMargin: chrMargin,
             annotations: rawAnnots,
@@ -661,6 +661,10 @@
     'GLDS-37': {
       assay: 'rna_seq_differential_expression',
       studyTitle: 'Comparison of the spaceflight transcriptome of four commonly used Arabidopsis thaliana ecotypes'
+    },
+    'GLDS-42': {
+      assay: 'array_differential_expression',
+      studyTitle: 'Expression data from C. elegans'
     }
   }
 

--- a/examples/vanilla/differential-expression.html
+++ b/examples/vanilla/differential-expression.html
@@ -35,7 +35,7 @@
 
     #summary {margin-bottom: 20px;}
 
-    #ideogram-container {margin-top: -15px;}
+    #ideogram-container {margin-top: -20px;}
 
     li {padding: 2px 0;}
     li.hidden {display: none;}
@@ -94,6 +94,11 @@
       margin-left: 20px;
       top: -1px;
     }
+
+    #table-container .paginate_button {padding: 3px 9px;}
+    #table-container .dataTables_info {padding-top: 0.3em;}
+    #table-container .dataTables_paginate {margin-right: 10px;}
+    #table-container table.dataTable thead th {padding-top: 4px;}
   </style>
 </head>
 <body>
@@ -242,7 +247,7 @@
 
     document.querySelector('#facets').innerHTML += `
       <div class="comparison-dropdowns" id="${comparisonId}">
-        <div style="margin-bottom: 30px; width: 200px; margin-top: 5px;"></div>
+        <div style="margin-bottom: 30px; width: 200px;"></div>
       <div>`;
 
     writeComparisonDropdowns();
@@ -263,9 +268,9 @@
     const acc = window.accession;
 
     document.querySelector('#summary').innerHTML = 
-      `Genomic distribution of differentially expressed 
-      <span id="organismName" style="font-style: italic">${metadata.organism}</span> 
-      genes.  Data from NASA GeneLab 
+      `Genomic distribution of differentially expressed <span id="organismName" style="font-style: italic">${metadata.organism}</span> 
+      genes, viewed with <a href="https://github.com/eweitz/ideogram">Ideogram.js</a>.
+      Data: NASA GeneLab 
       <a href="https://genelab-data.ndc.nasa.gov/genelab/accession/${acc}/" target="_blank">${acc}</a>, 
       "${window.studyTitle}".`;
 
@@ -359,6 +364,12 @@
     let sliders = document.querySelectorAll('.ideogramSlider');
     sliders.forEach((slider, i) => {
       noUiSlider.create(slider, getSliderConfig(metrics[i]));
+      if (i === 0) {
+        let val1 = document.querySelector(`#${slider.id} .noUi-value:nth-child(2)`);
+        val1.innerHTML = '≤ ' + val1.innerHTML;
+        let val2 = document.querySelector(`#${slider.id} .noUi-value:last-child`);
+        val2.innerHTML = '≥ ' + val2.innerHTML;
+      }
       slider.noUiSlider.on('change', function(){filterGenes(metrics, comparison);});
     });
 
@@ -434,6 +445,14 @@
       if (checkbox.checked === false) return;
       
       var range = slider.noUiSlider.get().map(d => parseFloat(d));
+
+      if (slider.id.includes('log2fc')) {
+        range = range.map(v => {
+          if (v === -4) return -Infinity;
+          if (v === 4) return Infinity;
+          return v;
+        })
+      }
       selections[slider.id] = range;
     });
 
@@ -524,12 +543,12 @@
     document.querySelector('#table-container').innerHTML = table;
 
     $('#ideogram-annots-table').DataTable({
-      dom: 'lBfrtip', // Confused?  See https://datatables.net/reference/option/dom.
+      dom: 'lBfrtip', // Docs: https://datatables.net/reference/option/dom
       buttons: [{extend: 'csv', text: 'Export'}],
       data: rows,
       order: [[headers.indexOf(sortKey), 'desc']],
       deferRender: true,
-      columns: [{width: '50px'}, {width: '475px'}, {width: '125px'}, {width: '125px'}, {width: '100px'}]
+      columns: [{width: '50px'}, {width: '515px'}, {width: '120px'}, {width: '115px'}, {width: '80px'}]
     });
   }
 
@@ -564,9 +583,9 @@
             orientation: 'vertical',
             organism: rawAnnots.metadata.organism, // This is why we need to fetch annots first
             assembly: rawAnnots.metadata.assembly,
-            chrHeight: 200,
+            chrHeight: 225,
             chrWidth: 12,
-            chrMargin: 18,
+            chrMargin: 19,
             annotations: rawAnnots,
             annotationsLayout: 'histogram',
             barWidth: 3,
@@ -587,8 +606,8 @@
   // window.assay = 'array_differential_expression';
   // window.studyTitle = 'STS-135 Liver Transcriptomics';
 
-  // // window.accession = 'GLDS-242';
-  // // window.assay = 'rna_seq_ERCCnorm_differential_expression';
+  // window.accession = 'GLDS-242';
+  // window.assay = 'rna_seq_ERCCnorm_differential_expression';
   // window.studyTitle = 'Effect of spaceflight on liver from mice flown on the ISS for 33 days: transcriptional analysis';
   
   // window.accession = 'GLDS-168';

--- a/examples/vanilla/differential-expression.html
+++ b/examples/vanilla/differential-expression.html
@@ -346,14 +346,16 @@
     // Update annotations upon changing selection in either comparison dropdown
     document.querySelectorAll('.comparison-dropdown').forEach(dropdown => {
       dropdown.addEventListener('change', function() {
-        window.factor1 = slug(document.querySelector('#comparison-dropdown-1').value);
-        window.factor2 = slug(document.querySelector('#comparison-dropdown-2').value);
+        window.factor1 =
+          slug(document.querySelector('#comparison-dropdown-1').value).replace(/_/g, '-');
+        window.factor2 =
+          slug(document.querySelector('#comparison-dropdown-2').value).replace(/_/g, '-');
         if (factor1 === factor2) return;
         if (
           this.id === 'comparison-dropdown-1' ||
           factor1 !== ideogram.rawAnnots.metadata.deg.thisFactor
         ) {
-          initIdeogram(baseAnnotsPath + '_' + window.factor1 + '.json');
+          initIdeogram(baseAnnotsPath + '_' + window.factor1 + '.json?alt=media');
         } else {
           writeFacets();
         }
@@ -515,6 +517,9 @@
           cells.push(getRoughLocation(annot));
         } else if (header === 'gene-type') {
           cells.push(labels[header][value]);
+        } else if (header.includes(metrics[1]) && value === 0) {
+          // TODO: Update sort to handle < 1E-18 as 0
+          cells.push(1e-18)
         } else {
           cells.push(value);
         }
@@ -623,8 +628,12 @@
       assay: 'array_differential_expression',
       studyTitle: 'STS-135 Liver Transcriptomics'
     },
+    // 'GLDS-242': {
+    //   assay: 'rna_seq_ERCCnorm_differential_expression',
+    //   studyTitle: 'Effect of spaceflight on liver from mice flown on the ISS for 33 days: transcriptional analysis'
+    // },
     'GLDS-242': {
-      assay: 'rna_seq_ERCCnorm_differential_expression',
+      assay: 'rna_seq_differential_expression',
       studyTitle: 'Effect of spaceflight on liver from mice flown on the ISS for 33 days: transcriptional analysis'
     },
     'GLDS-168': {

--- a/examples/vanilla/differential-expression.html
+++ b/examples/vanilla/differential-expression.html
@@ -600,8 +600,8 @@
             organism: rawAnnots.metadata.organism, // This is why we need to fetch annots first
             assembly: rawAnnots.metadata.assembly,
             chrHeight: 205,
-            chrWidth: chrWidth,
-            chrMargin: chrMargin,
+            chrWidth: chrWidth < 15 ? chrWidth : 15,
+            chrMargin: chrMargin < 25 ? chrMargin : 25,
             annotations: rawAnnots,
             annotationsLayout: 'histogram',
             barWidth: 3,
@@ -655,6 +655,10 @@
       assay: 'array_differential_expression',
       studyTitle: 'Dynamic gene expression response to altered gravity in human T cells (sounding rocket flight)'
     },
+    'GLDS-37': {
+      assay: 'rna_seq_differential_expression',
+      studyTitle: 'Comparison of the spaceflight transcriptome of four commonly used Arabidopsis thaliana ecotypes'
+    }
   }
 
   window.urlParams = parseUrlParams();

--- a/examples/vanilla/differential-expression.html
+++ b/examples/vanilla/differential-expression.html
@@ -592,10 +592,11 @@
           const numChrs = rawAnnots.annots.length;
           const ideoWidth = window.outerWidth - 340;
 
-          const maxChrWidth = ideoWidth/(numChrs*4.5);
-          const maxChrMargin = ideoWidth/(numChrs*2.8);
-          const chrWidth = maxChrWidth <= 13 ? maxChrWidth : 13;
-          const chrMargin = maxChrMargin <= 24 ? maxChrMargin : 24;
+          const chrWidth = 11;
+
+          const calcChrMargin = (ideoWidth/numChrs - chrWidth) - chrWidth*1.8;
+          const maxChrMargin = 50;
+          const chrMargin = calcChrMargin > maxChrMargin ? maxChrMargin : calcChrMargin;
 
           const config = {
             container: '#ideogram-container',

--- a/examples/vanilla/differential-expression.html
+++ b/examples/vanilla/differential-expression.html
@@ -56,6 +56,11 @@
       background: #FFF;
     }
 
+    .comparison-dropdown {
+      max-width: 285px;
+    }
+
+    /* Vertically shortens the 2 in log2(fold change)*/
     sub {
       font-size: 0.83em;
       vertical-align: sub;
@@ -477,7 +482,7 @@
   }
 
   function slug(string) {
-    return string.toLowerCase().replace(/ /g, '-');
+    return string.toLowerCase().replace(/ /g, '-').replace(/\&/g, 'and');
   }
 
   function hyperlinkGene(annot) {
@@ -547,8 +552,21 @@
     const table = `<table id="ideogram-annots-table" class="display">${head}</table>`;
     document.querySelector('#table-container').innerHTML = table;
 
+
     // Show more rows in each page for larger screens
-    const pageLength = window.outerHeight >= 950 ? 20 : 10;
+    const screenIsTall = window.innerHeight >= 850;
+    const screenIsWide = window.innerWidth >= 1600;
+    const pageLength = screenIsTall ? 15 : 10;
+    const colWidths = {
+      symbol: 50,
+      geneName: 515,
+      log2fc: 120,
+      adjustedPValue: 115,
+      location: 80
+    }
+    if (screenIsWide) {
+      for (key in colWidths) {colWidths[key] += 50;}
+    }
 
     $('#ideogram-annots-table').DataTable({
       data: rows,
@@ -556,15 +574,15 @@
       buttons: [{extend: 'csv', text: 'Export'}],
       order: [[headers.indexOf(sortKey), 'desc']],
       pageLength: pageLength,
-      lengthMenu: [10, 20, 50, 100, 500, 1000],
+      lengthMenu: [10, 15, 25, 50, 100, 500, 1000],
       deferRender: true,
       // columnDefs: [null, null, null, null, {render: }]
       columns: [
-        {width: '50px'},
-        {width: '515px'},
-        {width: '120px'},
-        {width: '115px', render: {_: 'display', sort: 'sortVal'}},
-        {width: '80px', type: 'genomeorder'}
+        {width: colWidths.symbol},
+        {width: colWidths.geneName},
+        {width: colWidths.log2fc},
+        {width: colWidths.adjustedPValue, render: {_: 'display', sort: 'sortVal'}},
+        {width: colWidths.location, type: 'genomeorder'}
       ]
     });
   }
@@ -588,6 +606,28 @@
   }
 
   /**
+  * Returns chromosome margin value that best fits overall ideogram width
+  * 
+  * TODO: Merge this into Ideogram.js library
+  **/
+  function getChrMargin(ideoWidth, numChrs, chrWidth) {
+    var chrMargin;
+    const calcChrMargin = ideoWidth/numChrs - chrWidth - chrWidth * 1.8;
+    const maxChrMargin = 50;
+    const minChrMargin = 13;
+
+    if (minChrMargin <= calcChrMargin && calcChrMargin <= maxChrMargin) {
+      chrMargin = calcChrMargin;
+    } else if (minChrMargin > calcChrMargin) {
+      chrMargin = minChrMargin;
+    } else {
+      chrMargin = maxChrMargin;
+    }
+
+    return chrMargin
+  }
+
+  /**
   * Fetch annotations, then create Ideogram
   **/
   function initIdeogram(annotationsPath) {
@@ -599,10 +639,7 @@
 
           const chrWidth = 11;
 
-          const calcChrMargin = (ideoWidth/numChrs - chrWidth) - chrWidth*1.8;
-          const maxChrMargin = 50;
-          const chrMargin = calcChrMargin > maxChrMargin ? maxChrMargin : calcChrMargin;
-
+          const chrMargin = getChrMargin(ideoWidth, numChrs, chrWidth);
           // TODO: Make chromosome height responsive to larger screens
           // const tableHeight = 490;
           // const headerHeight = 120;
@@ -644,7 +681,7 @@
       return urlParams;
     }
 
-  window.basePath = 'https://www.googleapis.com/storage/v1/b/ideogram/o/nasa%2f';
+  window.basePath = 'https://www.googleapis.com/storage/v1/b/ideogram/o/nasa%2fannots%2f';
   
   window.datasets = {
     'GLDS-21': {
@@ -682,12 +719,29 @@
     'GLDS-3': {
       assay: 'array_differential_expression',
       studyTitle: 'Drosophila melanogaster gene expression changes after spaceflight'
+    },
+    'GLDS-19': {
+      assay: 'array_differential_expression',
+      studyTitle: 'Transcription profiling of rat to study the effect of hindlimb unloading on healing of medial collateral ligaments 3 weeks after injury'
     }
+  }
+
+  window.datasetsByOrganism = {
+    'mus-musculus': 'GLDS-21',
+    'homo-sapiens': 'GLDS-188',
+    'arabidopsis-thaliana': 'GLDS-37',
+    'rattus-norvegicus': 'GLDS-19'
   }
 
   window.urlParams = parseUrlParams();
 
-  window.accession = 'acc' in urlParams ? urlParams.acc : 'GLDS-21';
+  if ('acc' in urlParams) {
+    window.accession = urlParams.acc;
+  } else if ('org' in urlParams) {
+    window.accession = datasetsByOrganism[urlParams.org];
+  } else {
+    window.accession = 'GLDS-21';
+  }
   window.assay = datasets[accession].assay;
   window.studyTitle = datasets[accession].studyTitle;
 

--- a/examples/vanilla/differential-expression.html
+++ b/examples/vanilla/differential-expression.html
@@ -596,27 +596,52 @@
       });
   }
 
-  window.basePath = '../../data/annotations/';
-  
-  window.accession = 'GLDS-21';
-  window.assay = 'array_differential_expression';
-  window.studyTitle = 'Effects of spaceflight on murine skeletal muscle gene expression';
-  
-  // window.accession = 'GLDS-25';
-  // window.assay = 'array_differential_expression';
-  // window.studyTitle = 'STS-135 Liver Transcriptomics';
+  function parseUrlParams() {
+      var rawParams = document.location.search;
+      var urlParams = {};
+      var param, key, value;
+      if (rawParams !== '') {
+        rawParams = rawParams.split('?')[1].split('&');
+        rawParams.forEach(rawParam => {
+          param = rawParam.split('=');
+          key = param[0];
+          value = param[1];
+          urlParams[key] = value;
+        });
+      }
+      return urlParams;
+    }
 
-  // window.accession = 'GLDS-242';
-  // window.assay = 'rna_seq_ERCCnorm_differential_expression';
-  // window.studyTitle = 'Effect of spaceflight on liver from mice flown on the ISS for 33 days: transcriptional analysis';
+  window.basePath = 'https://www.googleapis.com/storage/v1/b/ideogram/o/nasa%2f';
   
-  // window.accession = 'GLDS-168';
-  // window.assay = 'rna_seq_ERCCnorm_differential_expression';
-  // window.studyTitle = 'RR-1 and RR-3 mouse liver transcriptomics with and without ERCC control RNA spike-ins';
+  window.datasets = {
+    'GLDS-21': {
+      assay: 'array_differential_expression',
+      studyTitle:  'Effects of spaceflight on murine skeletal muscle gene expression'
+    },
+    'GLDS-25': {
+      assay: 'array_differential_expression',
+      studyTitle: 'STS-135 Liver Transcriptomics'
+    },
+    'GLDS-242': {
+      assay: 'rna_seq_ERCCnorm_differential_expression',
+      studyTitle: 'Effect of spaceflight on liver from mice flown on the ISS for 33 days: transcriptional analysis'
+    },
+    'GLDS-168': {
+      assay: 'rna_seq_ERCCnorm_differential_expression',
+      studyTitle: 'RR-1 and RR-3 mouse liver transcriptomics with and without ERCC control RNA spike-ins'
+    }
+  }
+
+  window.urlParams = parseUrlParams();
+
+  window.accession = 'acc' in urlParams ? urlParams.acc : 'GLDS-21';
+  window.assay = datasets[accession].assay;
+  window.studyTitle = datasets[accession].studyTitle;
 
   window.factor = '';
   window.baseAnnotsPath = `${basePath}${accession}_${assay}_ideogram_annots`;
-  window.annotsPath = `${baseAnnotsPath}${factor}.json`;
+  window.annotsPath = `${baseAnnotsPath}${factor}.json?alt=media`;
 
   initIdeogram(annotsPath);
   

--- a/examples/vanilla/differential-expression.html
+++ b/examples/vanilla/differential-expression.html
@@ -517,9 +517,9 @@
           cells.push(getRoughLocation(annot));
         } else if (header === 'gene-type') {
           cells.push(labels[header][value]);
-        } else if (header.includes(metrics[1]) && value === 0) {
-          // TODO: Update sort to handle < 1E-18 as 0
-          cells.push(1e-18)
+        } else if (header.includes(metrics[1])) {
+          const dispVal = value === 0 ? '< 1e-18' : value;
+          cells.push({display: dispVal, sortVal: value})
         } else {
           cells.push(value);
         }
@@ -553,7 +553,14 @@
       data: rows,
       order: [[headers.indexOf(sortKey), 'desc']],
       deferRender: true,
-      columns: [{width: '50px'}, {width: '515px'}, {width: '120px'}, {width: '115px'}, {width: '80px'}]
+      // columnDefs: [null, null, null, null, {render: }]
+      columns: [
+        {width: '50px'},
+        {width: '515px'},
+        {width: '120px'},
+        {width: '115px', render: {_: 'display', sort: 'sortVal'}},
+        {width: '80px', type: 'genomeorder'}
+      ]
     });
   }
 
@@ -653,6 +660,25 @@
   window.annotsPath = `${baseAnnotsPath}${factor}.json?alt=media`;
 
   initIdeogram(annotsPath);
+
+  function orderByGenomicPosition(a, b) {
+    const splitA = a.split(':');
+    const splitB = b.split(':');
+    const chrNameA = splitA[0].slice(3);
+    const chrNameB = splitB[0].slice(3);
+    if (chrNameA === chrNameB) {
+      const posA = parseFloat(splitA[1].slice(0, -1));
+      const posB = parseFloat(splitB[1].slice(0, -1));
+      return (posA < posB) ? -1 : (posA > posB) ? 1 : 0;
+    } else {
+      return chrNameA.localeCompare(chrNameB, undefined, {numeric: true, sensitivity: 'base'})
+    }
+  }
+
+  jQuery.extend(jQuery.fn.dataTable.ext.type.order, {
+    'genomeorder-asc': function(a, b) {return orderByGenomicPosition(a, b);},
+    'genomeorder-desc': function(a, b) {return -1 * orderByGenomicPosition(a, b)}
+  });
   
   </script>
 </body>

--- a/examples/vanilla/differential-expression.html
+++ b/examples/vanilla/differential-expression.html
@@ -665,6 +665,10 @@
     'GLDS-42': {
       assay: 'array_differential_expression',
       studyTitle: 'Expression data from C. elegans'
+    },
+    'GLDS-3': {
+      assay: 'array_differential_expression',
+      studyTitle: 'Drosophila melanogaster gene expression changes after spaceflight'
     }
   }
 

--- a/scripts/python/deg_to_ideogram.py
+++ b/scripts/python/deg_to_ideogram.py
@@ -127,8 +127,11 @@ def parse_deg_matrix(deg_matrix_path):
             for factor in comparisons_by_factor:
                 comparison_indices = comparisons_by_factor[factor]['indices']
                 gene_stats[factor][gene_symbol] = [row[i] for i in comparison_indices]
+
+    metadata_labels = get_key_labels(metadata_keys)
+    metadata_list = list(metadata_labels.keys())
     
-    return [gene_metadata, metadata_keys, gene_stats, comparisons_by_factor]
+    return [gene_metadata, metadata_list, gene_stats, comparisons_by_factor]
 
 def get_annots_by_chr(gene_coordinates, gene_expressions, gene_types, gene_metadata):
     """Merge coordinates and expressions, return Ideogram annotations
@@ -230,7 +233,9 @@ def get_metadata(gene_pos_metadata, sorted_gene_types, key_labels):
     return metadata
 
 
-def get_deg_metadata(factor, factors):
+def get_deg_metadata(factor, annots_by_chr_by_factor):
+
+    factors = list(annots_by_chr_by_factor.keys())
 
     split_factor = factor.split('-')
 
@@ -238,11 +243,14 @@ def get_deg_metadata(factor, factors):
         suffix = ''
         other_factor = 'ground-control'
     elif 'flt' in factor and 'rr' not in factor.lower():
-        # Seen in GLDS-168 (e.g. "FLT")
         suffix = ''
-        other_factor = 'bsl-' + split_factor[1]
+        if len(split_factor) > 2:
+            other_factor = '-'.join(split_factor[:2]) + '-gc'
+        else:
+            # Seen in GLDS-242 (e.g. "FLT-C1")
+            other_factor = 'bsl-' + split_factor[1]
     elif factor == 'rr1-flt-wercc':
-        # Seen in GLDS-242 (e.g. "RR1_FLT_wERCC")
+        # Seen in GLDS-168
         other_factor = 'rr1-bsl-wercc'
         suffix = ''
     else:
@@ -264,38 +272,56 @@ def get_deg_metadata(factor, factors):
 
 
 coordinates, gene_types, gene_pos_metadata = get_gene_coordinates(gene_pos_path)
-metadata, metadata_keys, expressions, comparisons_by_factor = parse_deg_matrix(deg_path)
-
-metadata_labels = get_key_labels(metadata_keys)
-metadata_list = list(metadata_labels.keys())
+metadata, metadata_list, expressions, comparisons_by_factor = parse_deg_matrix(deg_path)
 
 [annots_by_chr_by_factor, sorted_gene_types] =\
     get_annots_by_chr(coordinates, expressions, gene_types, metadata)
 
+content_by_suffix = {}
+
 for i, factor in enumerate(annots_by_chr_by_factor):
     annots_by_chr = annots_by_chr_by_factor[factor]
+    annots_list = list(annots_by_chr.values())
 
     comparisons = comparisons_by_factor[factor]['comparisons']
     comparison_labels = get_key_labels(comparisons)
     comparison_list = list(comparison_labels.keys())
 
     keys = ['name', 'start', 'length', 'gene-type'] + metadata_list + comparison_list
-    annots_list = list(annots_by_chr.values())
+
     metadata = get_metadata(gene_pos_metadata, sorted_gene_types, comparison_labels)
     for factor2 in annots_by_chr_by_factor:
         factor_label = comparisons_by_factor[factor2]['label']
         metadata['labels'][factor2] = factor_label
 
-    factors = list(annots_by_chr_by_factor.keys())
+    deg_metadata, suffix = get_deg_metadata(factor, annots_by_chr_by_factor)
 
-    deg_metadata, suffix = get_deg_metadata(factor, factors)
-
-    metadata['deg'] = get_deg_metadata(factor, factor)
+    metadata['deg'] = deg_metadata
 
     annots = {'keys': keys, 'annots': annots_list, 'metadata': metadata}
 
     annots_json = json.dumps(annots)
+    content_by_suffix[suffix] = annots_json
 
+# Ensure we have a default suffix (indicated by '') so Ideogram can load
+# annotations data given only an accession
+if '' not in content_by_suffix:
+    default_suffix = None
+    print(content_by_suffix.keys())
+    for suffix in content_by_suffix:
+        if 'control' not in suffix:
+            # Try to find a suffix indicating strongest treatment factor
+            default_suffix = suffix
+            break
+    if default_suffix is None:
+        # Fallback; just use the first suffix as default if none found yet
+        first_suffix = list(content_by_suffix.keys())[0]
+        default_suffix = first_suffix
+    content_by_suffix[''] = content_by_suffix[default_suffix]
+    del content_by_suffix[default_suffix]
+
+for suffix in content_by_suffix:
+    annots_json = content_by_suffix[suffix]
     output_filename = deg_path.split('/')[-1].replace('.csv', '') + \
         '_ideogram_annots' + suffix + '.json'
 

--- a/scripts/python/deg_to_ideogram.py
+++ b/scripts/python/deg_to_ideogram.py
@@ -207,7 +207,8 @@ def slug(value):
         .replace(')', '')\
         .replace(' ', '-')\
         .replace('.', '-')\
-        .replace('_', '-')
+        .replace('_', '-')\
+        .replace('&', 'and')
 
 def get_key_labels(keys):
     key_labels = {}

--- a/scripts/python/reduce_gtf.py
+++ b/scripts/python/reduce_gtf.py
@@ -1,7 +1,7 @@
 '''Reduce a GTF file to a simpler gene position TSV file.
 
 This CLI converts a GTF genome annotation file from GENCODE, Ensembl, or NCBI
-into a smaller, simpler, and more metadata-rich TSV gene position ("gene pos")
+into a smaller, simpler, and more metadata-rich TSV gene position ("gen_pos")
 file.  The purpose is to speed up, simplify, and enrich downstream pipelines
 that require only data on genes, and not e.g. transcripts or exons.
 
@@ -17,6 +17,10 @@ ftp://ftp.ensemblgenomes.org/pub/release-45/plants/gtf/arabidopsis_thaliana/Arab
 
 * Worm (Caenorhabditis elegans), from Ensembl:
 ftp://ftp.ensemblgenomes.org/pub/release-45/metazoa/gtf/caenorhabditis_elegans/Caenorhabditis_elegans.WBcel235.45.gtf.gz
+
+
+* Rat (Rattus norvegicus), from Ensembl:
+ftp://ftp.ensembl.org/pub/release-98/gtf/rattus_norvegicus/Rattus_norvegicus.Rnor_6.0.98.chr.gtf.gz
 
 PREREQUISITES
 * GTF file, local and unzipped


### PR DESCRIPTION
This refines the UI in the "[Differential expression](https://eweitz.github.io/ideogram/differential-expression)" example.  These changes will:

* Tailor layout of ideogram and annotation table to be more responsive to larger screens
* Unbound outer ends of the log<sub>2</sub>(fold change) range filter, so extreme values are included
* Sort location genomically, not lexicographically, so e.g. chr2:1M-2M comes before chr10:1M-2M
* Add support for [human](https://eweitz.github.io/ideogram/differential-expression?org=homo-sapiens), [Arabidopsis](https://eweitz.github.io/ideogram/differential-expression?org=arabidopsis-thaliana), and [rat](https://eweitz.github.io/ideogram/differential-expression?org=rattus-norvegicus)

[![ideogram_refine_deg_ui_2020-01-03](https://user-images.githubusercontent.com/1334561/71724030-cc405c80-2dfc-11ea-8b69-c0be05cc5625.gif)](https://eweitz.github.io/ideogram/differential-expression)
