### PR TITLE
Enable configuring chromosome label size

### DIFF
--- a/api.md
+++ b/api.md
@@ -37,6 +37,7 @@ var ideogram = new Ideogram({
 * [chrHeight](#chrheight)
 * [chrMargin](#chrmargin)
 * [chrWidth](#chrwidth)
+* [chrLabelSize](#chrlabelsize)
 * [chromosomes](#chromosomes)
 * [chromosomeScale](#chromosomescale)
 * [container](#container)
@@ -133,6 +134,9 @@ Number.  Optional.  Default: 10.  The pixel space of the margin between each chr
 
 ## chrWidth
 Number.  Optional.  Default: 10.  The pixel width of each chromosome.  Example in [Annotations, tracks](https://eweitz.github.io/ideogram/annotations-tracks).
+
+## chrLabelSize
+Number.  Optional.  Default: 9.  The pixel font size of chromosome labels.  Example in [Differential expression of genes](https://eweitz.github.io/ideogram/differential-expression).
 
 ## chromosomes
 Array.  Optional.  Default: all chromosomes in assembly.  A list of the names of chromosomes to display.  Useful for depicting a subset of the chromosomes in the genome, e.g. a single chromosome.  Example in [Annotations, basic](https://eweitz.github.io/ideogram/annotations-basic).

--- a/examples/vanilla/differential-expression.html
+++ b/examples/vanilla/differential-expression.html
@@ -664,6 +664,7 @@
             annotations: rawAnnots,
             annotationsLayout: 'histogram',
             barWidth: 3,
+            chrLabelSize: 12,
             filterable: true,
             onLoad: writeFacets
           };

--- a/src/js/bands/draw.js
+++ b/src/js/bands/draw.js
@@ -5,7 +5,8 @@
 
 import {d3} from '../lib';
 import {hideUnshownBandLabels, setBandsToShow} from './show';
-import {staticColors, staticCss, staticGradients} from './styles';
+import {staticColors, staticGradients} from './styles';
+import {configuredCss} from './../init/configure';
 
 /**
  * Draws text of cytoband label
@@ -159,7 +160,7 @@ function getBandColorGradients() {
 
   gradients = getGradients(staticColors);
 
-  css = staticCss;
+  css = `<style>${configuredCss}</style>`;
 
   gradients += staticGradients;
   gradients = "<defs>" + gradients + "</defs>";

--- a/src/js/bands/styles.js
+++ b/src/js/bands/styles.js
@@ -13,7 +13,6 @@ staticColors = [
 ];
 
 staticCss =
-  '<style>' +
   '#_ideogram {padding-left: 5px;} ' +
   '#_ideogram .labeled {padding-left: 15px;} ' +
   '#_ideogram.labeledLeft {padding-left: 15px; padding-top: 15px;} ' +
@@ -71,8 +70,7 @@ staticCss =
   '#_ideogram .stalk {fill: url("#stalk")} ' +
   '#_ideogram .gvar {fill: url("#gvar")} ' +
   '#_ideogram .noBands {fill: url("#noBands")} ' +
-  '#_ideogram .chromosome {fill: url("#noBands")} ' +
-  '</style>';
+  '#_ideogram .chromosome {fill: url("#noBands")} ';
 
 staticGradients =
   '<pattern id="stalk" width="2" height="1" patternUnits="userSpaceOnUse" ' +

--- a/src/js/init/configure.js
+++ b/src/js/init/configure.js
@@ -158,6 +158,8 @@ function configureTextStyle(ideo) {
  * High-level helper method for Ideogram constructor.
  *
  * @param config Configuration object.  Enables setting Ideogram properties.
+ *
+ * Docs: https://github.com/eweitz/ideogram/blob/master/api.md
  */
 function configure(config) {
 

--- a/src/js/init/configure.js
+++ b/src/js/init/configure.js
@@ -1,4 +1,5 @@
 import {organismMetadata} from './organism-metadata';
+import {staticCss} from './../bands/styles';
 
 function configurePloidy(ideo) {
   if (!ideo.config.ploidy) ideo.config.ploidy = 1;
@@ -145,6 +146,14 @@ function configureBands(ideo) {
   ideo.bandData = {};
 }
 
+let configuredCss = staticCss;
+function configureTextStyle(ideo) {
+  if (!ideo.config.chrLabelSize) return;
+
+  const size = ideo.config.chrLabelSize;
+  configuredCss += `#_ideogram text {font-size: ${size}px}`;
+}
+
 /**
  * High-level helper method for Ideogram constructor.
  *
@@ -166,6 +175,7 @@ function configure(config) {
   configureOrganisms(this);
   configureBump(this);
   configureSingleChromosome(config, this);
+  configureTextStyle(this);
   this.initAnnotSettings();
   if ('geometry' in this.config === false) {
     this.config.chrMargin += this.config.chrWidth;
@@ -178,4 +188,4 @@ function configure(config) {
   this.init();
 }
 
-export {configure};
+export {configure, configuredCss};


### PR DESCRIPTION
This adds an option named `chrLabelSize` to the Ideogram configuration API.  This option can be used to enlarge or shrink text font size for chromosome labels, which can enhance readability for users.