### PR TITLE
Specify orthologs via URL

### DIFF
--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -16,8 +16,8 @@
   </style>
   <script type="text/javascript" src="../../dist/js/ideogram.min.js"></script>
   <!-- <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/homology@0.4.0/dist/homology.min.js"></script> -->
-  <!-- <script type="text/javascript" src="https://eweitz.github.io/homology/dist/homology.min.js"></script> -->
-  <script type="text/javascript" src="http://localhost/homology/dist/homology.min.js"></script>
+  <script type="text/javascript" src="https://eweitz.github.io/homology/dist/homology.min.js"></script>
+  <!-- <script type="text/javascript" src="http://localhost/homology/dist/homology.min.js"></script> -->
 <link rel="icon" type="image/x-icon" href="img/ideogram_favicon.ico">
 </head>
 <body>
@@ -179,7 +179,7 @@
     }
 
     async function processUrl() {
-      var genesList;
+      var genesList, hasGenes, hasLoci;
 
       document.querySelector('#ideogram-container').innerHTML = '';
       document.querySelector('#status-container').innerHTML = 'Loading...';
@@ -191,9 +191,15 @@
         delete urlParams['gene'];
       }
 
+      hasGenes = 'genes' in urlParams;
+      hasLoci = 'loci' in urlParams;
+
       // Set default parameters if none are provided.
       if ('org' in urlParams === false) {
-        urlParams['genes'] = 'MTOR'
+        if (!hasLoci) {
+          urlParams['genes'] = 'MTOR'
+          hasGenes = true
+        }
         urlParams['org'] = 'homo-sapiens';
         urlParams['org2'] = 'mus-musculus';
         urlParams['backend'] = 'orthodb';
@@ -218,18 +224,28 @@
       updateOrganismMenu('org', org1);
       updateOrganismMenu('org2', org2);
 
-      genes = urlParams['genes'];
-      document.querySelector('#genes').value = genes.replace('%20', ' ');
+      if (hasGenes) {
+        genes = urlParams['genes'];
+        document.querySelector('#genes').value = genes.replace('%20', ' ');
+        updateGenesParams(genes);
+      }
 
       backend = urlParams['backend'];
       document.querySelector('#backend #' + backend).selected = true;
 
-      updateGenesParams(genes);
-
       if (shouldUpdateState()) {
         try {
-          genesList = splitList(genes);
-          orthologs = await fetchOrthologs(genesList, org1, [org2], backend);
+          if (hasGenes) {
+            genesList = splitList(genes);
+            orthologs = await fetchOrthologs(genesList, org1, [org2], backend);
+          } else {
+            orthologs = urlParams['loci'].split(';').map(ortholog => {
+              return ortholog.split(',').map(locus => {
+                return {location: locus, gene: ''}
+              })
+            })
+            console.log(orthologs)
+          }
         } catch (error) {
           document.querySelector('#status-container').innerHTML =
             `<span id="error-container">${error}</span>`;
@@ -238,7 +254,7 @@
       };
       prevState = Object.assign({}, urlParams);
 
-      
+
     }
 
     function parseGenomicRawRanges(ortholog) {

--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -240,11 +240,20 @@
             orthologs = await fetchOrthologs(genesList, org1, [org2], backend);
           } else {
             orthologs = urlParams['loci'].split(';').map(ortholog => {
-              return ortholog.split(',').map(locus => {
-                return {location: locus, gene: ''}
+              return ortholog.split(',').map(loc => {
+                const entries = loc.split('|')
+                locus = {location: entries[0]}
+                if (entries.length > 1) {
+                  entries.splice(1).map(entry => {
+                    const [key, value] = entry.split(':')
+                    locus[key] = value
+                  })
+                }
+                if ('gene' in locus === false) locus['gene'] = ''
+                console.log(locus)
+                return locus
               })
             })
-            console.log(orthologs)
           }
         } catch (error) {
           document.querySelector('#status-container').innerHTML =

--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -184,10 +184,10 @@
     * Examples:
     *
     * Single ortholog:
-    * https://eweitz.github.io/ideogram/orthologs?loci=1:11106531-11262557|gene:MTOR,4:148448582-148557685|gene:Mtor&org=homo-sapiens&org2=mus-musculus
+    * https://eweitz.github.io/ideogram/orthologs?loci=1:11106531-11262557|name:MTOR,4:148448582-148557685|name:Mtor&org=homo-sapiens&org2=mus-musculus
     *
     * Multiple orthologs:
-    * https://eweitz.github.io/ideogram/orthologs?loci=1:11106531-11262557|gene:MTOR,4:148448582-148557685|gene:Mtor;10:11106531-11262557|gene:FOO,X:148448582-148557685|gene:Foo&org=homo-sapiens&org2=mus-musculus
+    * https://eweitz.github.io/ideogram/orthologs?loci=1:11106531-11262557|name:MTOR,4:148448582-148557685|name:Mtor;10:11106531-11262557|name:FOO,X:148448582-148557685|name:Foo&org=homo-sapiens&org2=mus-musculus
     */
     function parseRawOrthologs(rawOrthologs) {
       return rawOrthologs.split(';').map(ortholog => {
@@ -200,7 +200,7 @@
               locus[key] = value
             })
           }
-          if ('gene' in locus === false) locus['gene'] = ''
+          if ('name' in locus === false) locus['name'] = ''
           return locus
         })
       })
@@ -289,18 +289,28 @@
       var [loci1Start, loci1Stop] = loci1Range.split('-');
       var [loci2Start, loci2Stop] = loci2Range.split('-');
 
+      if ('gene' in loci1) {
+        loci1.name = loci1.gene
+        delete loci1.gene
+      }
+
+      if ('gene' in loci2) {
+        loci2.name = loci2.gene
+        delete loci2.gene
+      }
+
       range1 = {
         chr: loci1Chr,
         start: loci1Start,
         stop: loci1Stop,
-        name: loci1.gene
+        name: loci1.name
       };
 
       range2 = {
         chr: loci2Chr,
         start: loci2Start,
         stop: loci2Stop,
-        name: loci2.gene
+        name: loci2.name
       };
 
       return [range1, range2];

--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -178,6 +178,34 @@
       }
     }
 
+    /**
+    * Parses orthologs specifies via "loci" URL parameter
+    *
+    * Examples:
+    *
+    * Single ortholog:
+    * https://eweitz.github.io/ideogram/orthologs?loci=1:11106531-11262557|gene:MTOR,4:148448582-148557685|gene:Mtor&org=homo-sapiens&org2=mus-musculus
+    *
+    * Multiple orthologs:
+    * https://eweitz.github.io/ideogram/orthologs?loci=1:11106531-11262557|gene:MTOR,4:148448582-148557685|gene:Mtor;10:11106531-11262557|gene:FOO,X:148448582-148557685|gene:Foo&org=homo-sapiens&org2=mus-musculus
+    */
+    function parseRawOrthologs(rawOrthologs) {
+      return rawOrthologs.split(';').map(ortholog => {
+        return ortholog.split(',').map(loc => {
+          const entries = loc.split('|')
+          locus = {location: entries[0]}
+          if (entries.length > 1) {
+            entries.splice(1).map(entry => {
+              const [key, value] = entry.split(':')
+              locus[key] = value
+            })
+          }
+          if ('gene' in locus === false) locus['gene'] = ''
+          return locus
+        })
+      })
+    }
+
     async function processUrl() {
       var genesList, hasGenes, hasLoci;
 
@@ -239,21 +267,7 @@
             genesList = splitList(genes);
             orthologs = await fetchOrthologs(genesList, org1, [org2], backend);
           } else {
-            orthologs = urlParams['loci'].split(';').map(ortholog => {
-              return ortholog.split(',').map(loc => {
-                const entries = loc.split('|')
-                locus = {location: entries[0]}
-                if (entries.length > 1) {
-                  entries.splice(1).map(entry => {
-                    const [key, value] = entry.split(':')
-                    locus[key] = value
-                  })
-                }
-                if ('gene' in locus === false) locus['gene'] = ''
-                console.log(locus)
-                return locus
-              })
-            })
+            orthologs = parseRawOrthologs(urlParams['loci'])
           }
         } catch (error) {
           document.querySelector('#status-container').innerHTML =

--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -184,15 +184,15 @@
     * Examples:
     *
     * Single ortholog:
-    * https://eweitz.github.io/ideogram/orthologs?loci=1:11106531-11262557|name:MTOR,4:148448582-148557685|name:Mtor&org=homo-sapiens&org2=mus-musculus
+    * https://eweitz.github.io/ideogram/orthologs?loci=1:11106531-11262557!name:MTOR,4:148448582-148557685!name:Mtor&org=homo-sapiens&org2=mus-musculus
     *
     * Multiple orthologs:
-    * https://eweitz.github.io/ideogram/orthologs?loci=1:11106531-11262557|name:MTOR,4:148448582-148557685|name:Mtor;10:11106531-11262557|name:FOO,X:148448582-148557685|name:Foo&org=homo-sapiens&org2=mus-musculus
+    * https://eweitz.github.io/ideogram/orthologs?loci=1:11106531-11262557!name:MTOR,4:148448582-148557685!name:Mtor;10:11106531-11262557!name:FOO,X:148448582-148557685!name:Foo&org=homo-sapiens&org2=mus-musculus
     */
     function parseRawOrthologs(rawOrthologs) {
       return rawOrthologs.split(';').map(ortholog => {
         return ortholog.split(',').map(loc => {
-          const entries = loc.split('|')
+          const entries = loc.split('!')
           locus = {location: entries[0]}
           if (entries.length > 1) {
             entries.splice(1).map(entry => {


### PR DESCRIPTION
This enables orthologs to be specified via URL using a "loci" URL parameter, e.g.:

* Single ortholog:
https://eweitz.github.io/ideogram/orthologs?loci=1:11106531-11262557!name:MTOR,4:148448582-148557685!name:Mtor&org=homo-sapiens&org2=mus-musculus
 
* Multiple orthologs:
https://eweitz.github.io/ideogram/orthologs?loci=1:11106531-11262557!name:MTOR,4:148448582-148557685!name:Mtor;10:11106531-11262557!name:FOO,X:148448582-148557685!name:Foo&org=homo-sapiens&org2=mus-musculus

This helps quickly and reliably plot orthologs, assuming their coordinates are already known.

[<img width="1186" alt="orthologs_via_loci_url_param_ideogram_2020-03-11" src="https://user-images.githubusercontent.com/1334561/76475356-f1d97b80-63d4-11ea-860c-58b2542bbda3.png">](https://eweitz.github.io/ideogram/orthologs?loci=1:11106531-11262557!name:MTOR,4:148448582-148557685!name:Mtor&org=homo-sapiens&org2=mus-musculus)
