### PR TITLE
Use URL to set color, width, and name for interchromosomal features

### DIFF
--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -225,16 +225,23 @@
     * Single ortholog:
     * https://eweitz.github.io/ideogram/orthologs?loci=1:11106531-11262557!name:MTOR,4:148448582-148557685!name:Mtor&org=homo-sapiens&org2=mus-musculus
     *
+    * Single ortholog with custom color and width:
+    * https://eweitz.github.io/ideogram/orthologs?loci=6:40611225-77560424,1:111464150-67465953!!color:pink&org=canis-lupus-familiaris&org2=homo-sapiens
+    *
     * Multiple orthologs:
     * https://eweitz.github.io/ideogram/orthologs?loci=1:11106531-11262557!name:MTOR,4:148448582-148557685!name:Mtor;10:11106531-11262557!name:FOO,X:148448582-148557685!name:Foo&org=homo-sapiens&org2=mus-musculus
+    *
+    * Synteny block:
+    * https://eweitz.github.io/ideogram/orthologs?loci=6:40611225-77560424,1:111464150-67465953!!color:pink&org=canis-lupus-familiaris&org2=homo-sapiens
     */
     function parseLociParam(lociParam) {
       return lociParam.split(';').map(ortholog => {
         let region = {}
 
-        // Two exclamation points ("!!") demarcate ranges from props
+        // Two exclamation points ("!!") demarcate a pair of two ranges from its props
         let [rawRanges, regionProps] = ortholog.split('!!')
         ranges = rawRanges.split(',').map(loc => {
+          // One exclamation point ("!") demarcates one range from its props
           const entries = loc.split('!')
           locus = {location: entries[0].trim()}
           if (entries.length > 1) {

--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -238,7 +238,7 @@
       return lociParam.split(';').map(ortholog => {
         let region = {}
 
-        // Two exclamation points ("!!") demarcate a pair of two ranges from its props
+        // Two exclamation points ("!!") demarcate a pair of ranges from its props
         let [rawRanges, regionProps] = ortholog.split('!!')
         ranges = rawRanges.split(',').map(loc => {
           // One exclamation point ("!") demarcates one range from its props

--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -35,8 +35,8 @@
   </label>
   <div style="font-size: 12px; position: relative; top: -7px;">
     Examples:
-    <a href="?genes=MTOR&org=homo-sapiens&org2=mus-musculus&backend=orthodb">MTOR</a> |
-    <a href="?genes=MTOR,BRCA1&org=homo-sapiens&org2=mus-musculus&backend=orthodb">MTOR, BRCA1</a> |
+    <a href="?genes=MTOR&org=homo-sapiens&org2=mus-musculus&backend=oma">MTOR</a> |
+    <a href="?genes=MTOR,BRCA1&org=homo-sapiens&org2=mus-musculus&backend=oma">MTOR, BRCA1</a> |
     <a href="?loci=2:150000000,5:20000000&org=homo-sapiens&org2=mus-musculus">2:150000000, 5:200000000</a>
   </div>
   <label for="org">
@@ -80,8 +80,8 @@
   <label for="backend">
     Orthology backend:
     <select class="left-select backend-select" id="backend">
-      <option id="orthodb" selected>OrthoDB</option>
-      <option id="oma">OMA Browser</option>
+      <option id="oma" selected>OMA Browser</option>
+      <option id="orthodb">OrthoDB</option>
     </select>
   </label>
   </div>
@@ -286,7 +286,7 @@
         }
         urlParams['org'] = 'homo-sapiens';
         urlParams['org2'] = 'mus-musculus';
-        urlParams['backend'] = 'orthodb';
+        urlParams['backend'] = 'oma';
         // urlParams['loci'] = '1:11106531-11262557,4:148448582-148557685';
       }
 
@@ -297,7 +297,7 @@
       }
 
       if ('backend' in urlParams === false) {
-        urlParams['backend'] = 'orthodb';
+        urlParams['backend'] = 'oma';
       }
 
       org1 = urlParams['org'].replace(/-/g, ' ');

--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -219,6 +219,7 @@
       return rawOrthologs.split(';').map(ortholog => {
         let region = {}
 
+        // Two exclamation points ("!!") demarcate ranges from props
         let [rawRanges, regionProps] = ortholog.split('!!')
         ranges = rawRanges.split(',').map(loc => {
           const entries = loc.split('!')
@@ -232,16 +233,18 @@
           if ('name' in locus === false) locus['name'] = ''
           return locus
         })
-        // region['ranges'] = ranges
 
         if (regionProps) {
           regionProps.split(',').map(prop => {
             const [key, value] = prop.split(':').map(v => v.trim())
             region[key] = value
           })
+
+          // TODO: Refactor orthologs code to enable specifying arbitrary props
+          if ('color' in region) ranges.push(region.color)
+          if ('width' in region) ranges.push(region.width)
         }
 
-        // return region
         return ranges
       })
     }
@@ -323,7 +326,7 @@
 
     function parseSyntenicRegion(ortholog) {
 
-      var [loci1, loci2, color] = ortholog;
+      var [loci1, loci2, color, width] = ortholog;
 
       var [loci1Chr, loci1Range] = loci1.location.split(':');
       var [loci2Chr, loci2Range] = loci2.location.split(':');
@@ -359,6 +362,7 @@
 
       let region = {r1, r2};
       if (typeof color !== 'undefined') region.color = color
+      if (typeof width !== 'undefined') region.width = width
 
       return region;
     }

--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -118,7 +118,6 @@
 
       var searchInput = event.target.value.trim();
 
-      console.log(searchInput)
       if (isGenomicLocation(searchInput)) {
         updateLociParams(searchInput)
       } else {
@@ -148,6 +147,20 @@
         .replace(/%20/g, '')
         .replace(/^\s+|\s+$/g, '')
         .split(',');
+    }
+
+    /** Returns [geneList, genePropList] */
+    function parseGenesParam(genesParam) {
+      let geneList = []
+      let genePropList = []
+      splitList(genesParam).map(rawValue => {
+        const splitValue = rawValue.split('!')
+        geneList.push(splitValue[0])
+        if (splitValue.length > 1) {
+          genePropList.push(splitValue[1])
+        }
+      });
+      return [geneList, genePropList]
     }
 
     /**
@@ -205,7 +218,7 @@
     }
 
     /**
-    * Parses orthologs specifies via "loci" URL parameter
+    * Parses orthologs specified via "loci" URL parameter
     *
     * Examples:
     *
@@ -215,8 +228,8 @@
     * Multiple orthologs:
     * https://eweitz.github.io/ideogram/orthologs?loci=1:11106531-11262557!name:MTOR,4:148448582-148557685!name:Mtor;10:11106531-11262557!name:FOO,X:148448582-148557685!name:Foo&org=homo-sapiens&org2=mus-musculus
     */
-    function parseRawOrthologs(rawOrthologs) {
-      return rawOrthologs.split(';').map(ortholog => {
+    function parseLociParam(lociParam) {
+      return lociParam.split(';').map(ortholog => {
         let region = {}
 
         // Two exclamation points ("!!") demarcate ranges from props
@@ -250,7 +263,7 @@
     }
 
     async function processUrl() {
-      var genesList, hasGenes, hasLoci, loci;
+      var geneList, genePropList, hasGenes, hasLoci, loci;
 
       document.querySelector('#ideogram-container').innerHTML = '';
       document.querySelector('#status-container').innerHTML = 'Loading...';
@@ -296,8 +309,9 @@
       updateOrganismMenu('org2', org2);
 
       if (hasGenes) {
-        genes = urlParams['genes'];
-        document.querySelector('#search').value = genes.replace('%20', ' ');
+        [geneList, genePropList] = parseGenesParam(urlParams['genes']);
+        genes = geneList.toString()
+        document.querySelector('#search').value = genes
         updateGenesParams(genes);
       } else {
         loci = urlParams['loci'].replace(/%20/g, ' ')
@@ -310,10 +324,18 @@
       if (shouldUpdateState()) {
         try {
           if (hasGenes) {
-            genesList = splitList(genes);
-            orthologs = await fetchOrthologs(genesList, org1, [org2], backend);
+            rawOrthologs = await fetchOrthologs(geneList, org1, [org2], backend);
+            orthologs = rawOrthologs.map((rawOrtholog, i) => {
+              if (genePropList.length === 0) return rawOrtholog
+
+              const propVals = genePropList[i].split(',').map(prop => {
+                return prop.split(':')[1]
+              })
+
+              return rawOrtholog.concat(propVals)
+            })
           } else {
-            orthologs = parseRawOrthologs(loci)
+            orthologs = parseLociParam(loci)
           }
         } catch (error) {
           document.querySelector('#status-container').innerHTML =

--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -15,8 +15,8 @@
     #search {width: 280px;}
   </style>
   <script type="text/javascript" src="../../dist/js/ideogram.min.js"></script>
-  <!-- <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/homology@0.4.0/dist/homology.min.js"></script> -->
-  <script type="text/javascript" src="https://eweitz.github.io/homology/dist/homology.min.js"></script>
+  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/homology@0.4.0/dist/homology.min.js"></script>
+  <!-- <script type="text/javascript" src="https://eweitz.github.io/homology/dist/homology.min.js"></script> -->
   <!-- <script type="text/javascript" src="http://localhost/homology/dist/homology.min.js"></script> -->
 <link rel="icon" type="image/x-icon" href="img/ideogram_favicon.ico">
 </head>
@@ -217,7 +217,10 @@
     */
     function parseRawOrthologs(rawOrthologs) {
       return rawOrthologs.split(';').map(ortholog => {
-        return ortholog.split(',').map(loc => {
+        let region = {}
+
+        let [rawRanges, regionProps] = ortholog.split('!!')
+        ranges = rawRanges.split(',').map(loc => {
           const entries = loc.split('!')
           locus = {location: entries[0].trim()}
           if (entries.length > 1) {
@@ -229,6 +232,17 @@
           if ('name' in locus === false) locus['name'] = ''
           return locus
         })
+        // region['ranges'] = ranges
+
+        if (regionProps) {
+          regionProps.split(',').map(prop => {
+            const [key, value] = prop.split(':').map(v => v.trim())
+            region[key] = value
+          })
+        }
+
+        // return region
+        return ranges
       })
     }
 
@@ -307,9 +321,9 @@
       prevState = Object.assign({}, urlParams);
     }
 
-    function parseGenomicRawRanges(ortholog) {
+    function parseSyntenicRegion(ortholog) {
 
-      var [loci1, loci2] = ortholog;
+      var [loci1, loci2, color] = ortholog;
 
       var [loci1Chr, loci1Range] = loci1.location.split(':');
       var [loci2Chr, loci2Range] = loci2.location.split(':');
@@ -329,21 +343,24 @@
         delete loci2.gene
       }
 
-      range1 = {
+      r1 = {
         chr: loci1Chr,
         start: loci1Start,
         stop: loci1Stop,
         name: loci1.name
       };
 
-      range2 = {
+      r2 = {
         chr: loci2Chr,
         start: loci2Start,
         stop: loci2Stop,
         name: loci2.name
       };
 
-      return [range1, range2];
+      let region = {r1, r2};
+      if (typeof color !== 'undefined') region.color = color
+
+      return region;
     }
 
     function drawSynteny() {
@@ -353,19 +370,10 @@
       document.querySelector('#status-container').innerHTML = '';
 
       chrs = ideogram.chromosomes;
-      org1Taxid = ideogram.getTaxid(org1);
-      org2Taxid = ideogram.getTaxid(org2);
 
       for (i = 0; i < orthologs.length; i++) {
-        [rawRange1, rawRange2] = parseGenomicRawRanges(orthologs[i]);
-
-        range1 = rawRange1
-        range1.chr = chrs[org1Taxid][rawRange1.chr]
-
-        range2 = rawRange2
-        range2.chr = chrs[org2Taxid][rawRange2.chr]
-
-        syntenicRegions.push({'r1': range1, 'r2': range2});
+        const region = parseSyntenicRegion(orthologs[i]);
+        syntenicRegions.push(region);
       }
 
       ideogram.drawSynteny(syntenicRegions);
@@ -419,10 +427,10 @@
         });
       } else {
         // For one chromosome in each genome
-        ranges = parseGenomicRawRanges(orthologs[0]);
+        region = parseSyntenicRegion(orthologs[0]);
         chromosomesConfig = {}
-        chromosomesConfig[org1] = [ranges[0].chr];
-        chromosomesConfig[org2] = [ranges[1].chr];
+        chromosomesConfig[org1] = [region.r1.chr];
+        chromosomesConfig[org2] = [region.r2.chr];
         Object.assign(config, {
           chromosomes: chromosomesConfig,
           chrHeight: 400,

--- a/src/js/annotations/synteny-collinear.js
+++ b/src/js/annotations/synteny-collinear.js
@@ -1,45 +1,7 @@
 import {d3} from '../lib';
-import {getRegionsR1AndR2} from './synteny-lib';
-
-function writeSyntenicRegion(syntenies, regionID, ideo) {
-  return syntenies.append('g')
-    .attr('class', 'syntenicRegion')
-    .attr('id', regionID)
-    .on('click', function() {
-      var activeRegion = this;
-      var others = d3.selectAll(ideo.selector + ' .syntenicRegion')
-        .filter(function() { return (this !== activeRegion); });
-
-      others.classed('hidden', !others.classed('hidden'));
-    })
-    .on('mouseover', function() {
-      var activeRegion = this;
-      d3.selectAll(ideo.selector + ' .syntenicRegion')
-        .filter(function() { return (this !== activeRegion); })
-        .classed('ghost', true);
-    })
-    .on('mouseout', function() {
-      d3.selectAll(ideo.selector + ' .syntenicRegion')
-        .classed('ghost', false);
-    });
-}
-
-function writeSyntenicRegionPolygons(syntenicRegion, x1, x2, r1, r2, regions) {
-  var color, opacity;
-
-  color = ('color' in regions) ? regions.color : '#CFC';
-  opacity = ('opacity' in regions) ? regions.opacity : 1;
-
-  syntenicRegion.append('polygon')
-    .attr('points',
-      x1 + ', ' + r1.startPx + ' ' +
-      x1 + ', ' + r1.stopPx + ' ' +
-      x2 + ', ' + r2.stopPx + ' ' +
-      x2 + ', ' + r2.startPx
-    )
-    .style('fill', color)
-    .style('fill-opacity', opacity);
-}
+import {
+  getRegionsR1AndR2, writeSyntenicRegionPolygons, writeSyntenicRegion
+} from './synteny-lib';
 
 function writeSyntenicRegionLines(syntenicRegion, x1, x2, r1, r2) {
   syntenicRegion.append('line')

--- a/src/js/annotations/synteny-collinear.js
+++ b/src/js/annotations/synteny-collinear.js
@@ -1,4 +1,5 @@
 import {d3} from '../lib';
+import {getRegionsR1AndR2} from './synteny-lib';
 
 function writeSyntenicRegion(syntenies, regionID, ideo) {
   return syntenies.append('g')
@@ -21,26 +22,6 @@ function writeSyntenicRegion(syntenies, regionID, ideo) {
       d3.selectAll(ideo.selector + ' .syntenicRegion')
         .classed('ghost', false);
     });
-}
-
-function getRegionsR1AndR2(regions, ideo) {
-  var r1, r2;
-
-  r1 = regions.r1;
-  r2 = regions.r2;
-
-  var r1ChrDom = document.querySelector('#' + r1.chr.id + '-chromosome-set');
-  var r1GenomeOffset = r1ChrDom.getCTM().f;
-  var r2ChrDom = document.querySelector('#' + r2.chr.id + '-chromosome-set');
-  // var r2GenomeOffset = r2ChrDom.getBoundingClientRect().top;
-  var r2GenomeOffset = r2ChrDom.getCTM().f;
-
-  r1.startPx = ideo.convertBpToPx(r1.chr, r1.start) + r1GenomeOffset - 12;
-  r1.stopPx = ideo.convertBpToPx(r1.chr, r1.stop) + r1GenomeOffset - 12;
-  r2.startPx = ideo.convertBpToPx(r2.chr, r2.start) + r2GenomeOffset - 12;
-  r2.stopPx = ideo.convertBpToPx(r2.chr, r2.stop) + r2GenomeOffset - 12;
-
-  return [r1, r2];
 }
 
 function writeSyntenicRegionPolygons(syntenicRegion, x1, x2, r1, r2, regions) {

--- a/src/js/annotations/synteny-lib.js
+++ b/src/js/annotations/synteny-lib.js
@@ -1,3 +1,5 @@
+import {d3} from '../lib';
+
 export function writeSyntenicRegion(syntenies, regionID, ideo) {
   return syntenies.append('g')
     .attr('class', 'syntenicRegion')

--- a/src/js/annotations/synteny-lib.js
+++ b/src/js/annotations/synteny-lib.js
@@ -1,3 +1,43 @@
+export function writeSyntenicRegion(syntenies, regionID, ideo) {
+  return syntenies.append('g')
+    .attr('class', 'syntenicRegion')
+    .attr('id', regionID)
+    .on('click', function() {
+      var activeRegion = this;
+      var others = d3.selectAll(ideo.selector + ' .syntenicRegion')
+        .filter(function() { return (this !== activeRegion); });
+
+      others.classed('hidden', !others.classed('hidden'));
+    })
+    .on('mouseover', function() {
+      var activeRegion = this;
+      d3.selectAll(ideo.selector + ' .syntenicRegion')
+        .filter(function() { return (this !== activeRegion); })
+        .classed('ghost', true);
+    })
+    .on('mouseout', function() {
+      d3.selectAll(ideo.selector + ' .syntenicRegion')
+        .classed('ghost', false);
+    });
+}
+
+export function writeSyntenicRegionPolygons(syntenicRegion, x1, x2, r1, r2, regions) {
+  var color, opacity;
+
+  color = ('color' in regions) ? regions.color : '#CFC';
+  opacity = ('opacity' in regions) ? regions.opacity : 1;
+
+  syntenicRegion.append('polygon')
+    .attr('points',
+      x1 + ', ' + r1.startPx + ' ' +
+      x1 + ', ' + r1.stopPx + ' ' +
+      x2 + ', ' + r2.stopPx + ' ' +
+      x2 + ', ' + r2.startPx
+    )
+    .style('fill', color)
+    .style('fill-opacity', opacity);
+}
+
 export function getRegionsR1AndR2(regions, ideo, xOffset = null) {
   var r1, r2,
     r1Offset, r2Offset;

--- a/src/js/annotations/synteny-lib.js
+++ b/src/js/annotations/synteny-lib.js
@@ -1,0 +1,41 @@
+export function getRegionsR1AndR2(regions, ideo, xOffset = null) {
+  var r1, r2,
+    r1Offset, r2Offset;
+
+  r1 = regions.r1;
+  r2 = regions.r2;
+
+  if (typeof r1.chr === 'string') {
+    const taxids = ideo.config.taxids;
+    if (ideo.config.multiorganism) {
+      r1.chr = ideo.chromosomes[taxids[0]][r1.chr];
+      r2.chr = ideo.chromosomes[taxids[1]][r2.chr];
+    } else {
+      r1.chr = ideo.chromosomes[taxids[0]][r1.chr];
+      r2.chr = ideo.chromosomes[taxids[0]][r2.chr];
+    }
+  }
+
+  var r1ChrDom = document.querySelector('#' + r1.chr.id + '-chromosome-set');
+  var r1GenomeOffset = r1ChrDom.getCTM().f;
+  var r2ChrDom = document.querySelector('#' + r2.chr.id + '-chromosome-set');
+  // var r2GenomeOffset = r2ChrDom.getBoundingClientRect().top;
+  var r2GenomeOffset = r2ChrDom.getCTM().f;
+
+  if (xOffset === null) {
+    // When collinear
+    r1Offset = r1GenomeOffset - 12;
+    r2Offset = r2GenomeOffset - 12;
+  } else {
+    // When parallel
+    r1Offset = xOffset;
+    r2Offset = xOffset;
+  }
+
+  r1.startPx = ideo.convertBpToPx(r1.chr, r1.start) + r1Offset;
+  r1.stopPx = ideo.convertBpToPx(r1.chr, r1.stop) + r1Offset;
+  r2.startPx = ideo.convertBpToPx(r2.chr, r2.start) + r2Offset;
+  r2.stopPx = ideo.convertBpToPx(r2.chr, r2.stop) + r2Offset;
+
+  return [r1, r2];
+}

--- a/src/js/annotations/synteny.js
+++ b/src/js/annotations/synteny.js
@@ -1,46 +1,8 @@
 import {d3} from '../lib';
 import {drawSyntenyCollinear} from './synteny-collinear';
-import {getRegionsR1AndR2} from './synteny-lib';
-
-function writeSyntenicRegion(syntenies, regionID, ideo) {
-  return syntenies.append('g')
-    .attr('class', 'syntenicRegion')
-    .attr('id', regionID)
-    .on('click', function() {
-      var activeRegion = this;
-      var others = d3.selectAll(ideo.selector + ' .syntenicRegion')
-        .filter(function() { return (this !== activeRegion); });
-
-      others.classed('hidden', !others.classed('hidden'));
-    })
-    .on('mouseover', function() {
-      var activeRegion = this;
-      d3.selectAll(ideo.selector + ' .syntenicRegion')
-        .filter(function() { return (this !== activeRegion); })
-        .classed('ghost', true);
-    })
-    .on('mouseout', function() {
-      d3.selectAll(ideo.selector + ' .syntenicRegion')
-        .classed('ghost', false);
-    });
-}
-
-function writeSyntenicRegionPolygons(syntenicRegion, x1, x2, r1, r2, regions) {
-  var color, opacity;
-
-  color = ('color' in regions) ? regions.color : '#CFC';
-  opacity = ('opacity' in regions) ? regions.opacity : 1;
-
-  syntenicRegion.append('polygon')
-    .attr('points',
-      x1 + ', ' + r1.startPx + ' ' +
-      x1 + ', ' + r1.stopPx + ' ' +
-      x2 + ', ' + r2.stopPx + ' ' +
-      x2 + ', ' + r2.startPx
-    )
-    .style('fill', color)
-    .style('fill-opacity', opacity);
-}
+import {
+  getRegionsR1AndR2, writeSyntenicRegionPolygons, writeSyntenicRegion
+} from './synteny-lib';
 
 function writeSyntenicRegionLines(syntenicRegion, x1, x2, r1, r2, regions) {
 

--- a/src/js/annotations/synteny.js
+++ b/src/js/annotations/synteny.js
@@ -66,20 +66,37 @@ function writeSyntenicRegionPolygons(syntenicRegion, x1, x2, r1, r2, regions) {
     .style('fill-opacity', opacity);
 }
 
-function writeSyntenicRegionLines(syntenicRegion, x1, x2, r1, r2) {
+function writeSyntenicRegionLines(syntenicRegion, x1, x2, r1, r2, regions) {
+
+  var stroke, width;
+  if (
+    Math.abs(r1.startPx - r1.startPx) < 2 &&
+    Math.abs(r1.stopPx - r1.stopPx) < 2
+  ) {
+    stroke = regions.color;
+    width = regions.width;
+  } else {
+    stroke = '';
+    width = '';
+  }
+
   syntenicRegion.append('line')
     .attr('class', 'syntenyBorder')
     .attr('x1', x1)
     .attr('x2', x2)
     .attr('y1', r1.startPx)
-    .attr('y2', r2.startPx);
+    .attr('y2', r2.startPx)
+    .style('stroke', stroke)
+    .style('stroke-width', width);
 
   syntenicRegion.append('line')
     .attr('class', 'syntenyBorder')
     .attr('x1', x1)
     .attr('x2', x2)
     .attr('y1', r1.stopPx)
-    .attr('y2', r2.stopPx);
+    .attr('y2', r2.stopPx)
+    .style('stroke', stroke)
+    .style('stroke-width', stroke);
 }
 
 function writeSyntenicRegionLabels(syntenicRegion, x1, x2, r1, r2, regionId) {
@@ -124,7 +141,7 @@ function writeSyntenicRegions(syntenicRegions, syntenies, xOffset, ideo) {
     x2 = ideo._layout.getChromosomeSetYTranslate(1) - chrWidth;
 
     writeSyntenicRegionPolygons(syntenicRegion, x1, x2, r1, r2, regions);
-    writeSyntenicRegionLines(syntenicRegion, x1, x2, r1, r2);
+    writeSyntenicRegionLines(syntenicRegion, x1, x2, r1, r2, regions);
     writeSyntenicRegionLabels(syntenicRegion, x1, x2, r1, r2, regionID);
   }
 }

--- a/src/js/annotations/synteny.js
+++ b/src/js/annotations/synteny.js
@@ -30,6 +30,17 @@ function getRegionsR1AndR2(regions, xOffset, ideo) {
   r1 = regions.r1;
   r2 = regions.r2;
 
+  if (typeof r1.chr === 'string') {
+    const taxids = ideo.config.taxids;
+    if (ideo.config.multiorganism) {
+      r1.chr = ideo.chromosomes[taxids[0]][r1.chr];
+      r2.chr = ideo.chromosomes[taxids[1]][r2.chr];
+    } else {
+      r1.chr = ideo.chromosomes[taxids[0]][r1.chr];
+      r2.chr = ideo.chromosomes[taxids[0]][r2.chr];
+    }
+  }
+
   r1.startPx = ideo.convertBpToPx(r1.chr, r1.start) + xOffset;
   r1.stopPx = ideo.convertBpToPx(r1.chr, r1.stop) + xOffset;
   r2.startPx = ideo.convertBpToPx(r2.chr, r2.start) + xOffset;

--- a/src/js/annotations/synteny.js
+++ b/src/js/annotations/synteny.js
@@ -1,5 +1,6 @@
 import {d3} from '../lib';
 import {drawSyntenyCollinear} from './synteny-collinear';
+import {getRegionsR1AndR2} from './synteny-lib';
 
 function writeSyntenicRegion(syntenies, regionID, ideo) {
   return syntenies.append('g')
@@ -22,31 +23,6 @@ function writeSyntenicRegion(syntenies, regionID, ideo) {
       d3.selectAll(ideo.selector + ' .syntenicRegion')
         .classed('ghost', false);
     });
-}
-
-function getRegionsR1AndR2(regions, xOffset, ideo) {
-  var r1, r2;
-
-  r1 = regions.r1;
-  r2 = regions.r2;
-
-  if (typeof r1.chr === 'string') {
-    const taxids = ideo.config.taxids;
-    if (ideo.config.multiorganism) {
-      r1.chr = ideo.chromosomes[taxids[0]][r1.chr];
-      r2.chr = ideo.chromosomes[taxids[1]][r2.chr];
-    } else {
-      r1.chr = ideo.chromosomes[taxids[0]][r1.chr];
-      r2.chr = ideo.chromosomes[taxids[0]][r2.chr];
-    }
-  }
-
-  r1.startPx = ideo.convertBpToPx(r1.chr, r1.start) + xOffset;
-  r1.stopPx = ideo.convertBpToPx(r1.chr, r1.stop) + xOffset;
-  r2.startPx = ideo.convertBpToPx(r2.chr, r2.start) + xOffset;
-  r2.stopPx = ideo.convertBpToPx(r2.chr, r2.stop) + xOffset;
-
-  return [r1, r2];
 }
 
 function writeSyntenicRegionPolygons(syntenicRegion, x1, x2, r1, r2, regions) {
@@ -126,7 +102,7 @@ function writeSyntenicRegions(syntenicRegions, syntenies, xOffset, ideo) {
   for (i = 0; i < syntenicRegions.length; i++) {
     regions = syntenicRegions[i];
 
-    [r1, r2] = getRegionsR1AndR2(regions, xOffset, ideo);
+    [r1, r2] = getRegionsR1AndR2(regions, ideo, xOffset);
 
     regionID = (
       r1.chr.id + '_' + r1.start + '_' + r1.stop + '_' +


### PR DESCRIPTION
This provides experimental support for specifying the color, width, and name of interchromosomal features (e.g. orthologs and syntenic regions) by URL.  

### Use case
This gives users richer control of ortholog rendering in Ideogram.  [Recent work](https://github.com/eweitz/ideogram/pull/194) enabled you to pass your own coordinates for instant and robust ortholog rendering in Ideogram.  Now you can control the displayed label, color and width of those orthologs.  Color can also be defined for synteny blocks.

Being able to specify these things by URL makes it possible to make custom comparative genomics visualizations through simple links -- no development environment needed.

### How to
Color, width, and name can be specified in the `loci` URL parameter.  The `loci` parameter takes two ranges (or two positions, or a range and position) separated by a comma.  

* Two exclamation points ("!!") define properties for a _pair_ of loci (e.g. color, width)
* One exclamation point ("!") defines properties for a _single_  locus (e.g. name)

Examples below demonstrate the experimental syntax.

Ortholog colored red, with width (line thickness) of 3 pixels:
https://eweitz.github.io/ideogram/orthologs?loci=1:12647785-12675741!name:PIK3CA,3:179198826-179234364!name:PIK3CA!!color:red,width:3&org=canis-lupus-familiaris&org2=homo-sapiens
<img width="300" alt="color_and_width_set_via_url_ortholog_ideogram" src="https://user-images.githubusercontent.com/1334561/79058472-9fda7e80-7c3c-11ea-837e-eae5e0749424.png">


Synteny block:
https://eweitz.github.io/ideogram/orthologs?loci=6:40611225-77560424,1:111464150-67465953!!color:pink&org=canis-lupus-familiaris&org2=homo-sapiens
<img width="289" alt="inverted_synteny_dog_human_defined_via_url_ideogram" src="https://user-images.githubusercontent.com/1334561/79058581-ccdb6100-7c3d-11ea-9f5d-34a8271ce78e.png">


### Work in progress ###
This experimental syntax for nested URL parameters is more compact, human-readable, and extensible than conventional approaches like percent-encoding JSON.  But the syntax is incomplete and will likely require breaking changes to support important features.

Another syntax like [JSURL](https://github.com/Sage/jsurl) might be better.  See [comparison](https://jsfiddle.net/1g5xoc8p/3/).