### PR TITLE
Compare horizontal genomes

### DIFF
--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -14,11 +14,12 @@
     #ideogram-container {margin-left: 125px;}
     #search {width: 280px;}
 
-    #options {float: left;}
+    #options label {display: inline;}
+    /* .option {text-decoration: underline;} */
 
     ul {padding: 2px 10px 10px 10px;}
 
-    ul li {list-style-type: none; padding-inline-start: 20px;}
+    ul li {list-style-type: none;}
   </style>
   <script type="text/javascript" src="../../dist/js/ideogram.min.js"></script>
   <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/homology@0.4.0/dist/homology.min.js"></script>
@@ -83,39 +84,41 @@
       <option>Rice (Oryza sativa)</option>
       </select>
   </label>
-  <a href="#" id="advanced-toggle">Advanced</a>
-  <div id="advanced">
-    <ul id="options">
-      Chromosome scale
+  <div id="options">
+  <a href="#" id="options-toggle">Options</a>
+  <div id="settings">
+    <ul>
+      <span class="option">Chromosome scale</span>
       <li>
         <input type="radio" name="chromosome-scale" id="absolute" value="absolute" checked>
-        <label for="absolute" style="display: inline;">Absolute</label>
+        <label for="absolute">Absolute</label>
       </li>
       <li>
         <input type="radio" name="chromosome-scale" id="relative" value="relative">
-        <label for="relative" style="display: inline;">Relative</label>
+        <label for="relative">Relative</label>
       </li>
       <br/>
-      Orientation
+      <span class="option">Orientation</span>
       <li>
         <input type="radio" name="orientation" id="vertical" value="vertical" checked>
-        <label for="vertical" style="display: inline;">Vertical</label>
+        <label for="vertical">Vertical</label>
       </li>
       <li>
         <input type="radio" name="orientation" id="horizontal" value="horizontal">
-        <label for="horizontal" style="display: inline;">Horizontal</label>
+        <label for="horizontal">Horizontal</label>
       </li>
       <br/>
-      Orthology backend
+      <span class="option">Orthology backend</span>
       <li>
         <input type="radio" name="backend" id="orthodb" value="orthodb" checked>
-        <label for="orthodb" style="display: inline;">OrthoDB</label>
+        <label for="orthodb">OrthoDB</label>
       </li>
       <li>
         <input type="radio" name="backend" id="oma" value="oma">
-        <label for="oma" style="display: inline;">OMA Browser</label>
+        <label for="oma">OMA Browser</label>
       </li>
     </ul>
+  </div>
   </div>
   </div>
   <div id="ideogram-container"></div>

--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -84,41 +84,39 @@
       <option>Rice (Oryza sativa)</option>
       </select>
   </label>
-  <div id="options">
-  <a href="#" id="options-toggle">Options</a>
-  <div id="settings">
-    <ul>
-      <span class="option">Chromosome scale</span>
-      <li>
-        <input type="radio" name="chromosome-scale" id="absolute" value="absolute" checked>
-        <label for="absolute">Absolute</label>
-      </li>
-      <li>
-        <input type="radio" name="chromosome-scale" id="relative" value="relative">
-        <label for="relative">Relative</label>
-      </li>
-      <br/>
-      <span class="option">Orientation</span>
-      <li>
-        <input type="radio" name="orientation" id="vertical" value="vertical" checked>
-        <label for="vertical">Vertical</label>
-      </li>
-      <li>
-        <input type="radio" name="orientation" id="horizontal" value="horizontal">
-        <label for="horizontal">Horizontal</label>
-      </li>
-      <br/>
-      <span class="option">Orthology backend</span>
-      <li>
-        <input type="radio" name="backend" id="orthodb" value="orthodb" checked>
-        <label for="orthodb">OrthoDB</label>
-      </li>
-      <li>
-        <input type="radio" name="backend" id="oma" value="oma">
-        <label for="oma">OMA Browser</label>
-      </li>
-    </ul>
-  </div>
+    <a href="#" id="options-toggle">Options</a>
+    <div id="options" style="display: none">
+      <ul>
+        <span class="option">Chromosome scale</span>
+        <li>
+          <input type="radio" name="chromosome-scale" id="absolute" value="absolute" checked>
+          <label for="absolute">Absolute</label>
+        </li>
+        <li>
+          <input type="radio" name="chromosome-scale" id="relative" value="relative">
+          <label for="relative">Relative</label>
+        </li>
+        <br/>
+        <span class="option">Orientation</span>
+        <li>
+          <input type="radio" name="orientation" id="vertical" value="vertical" checked>
+          <label for="vertical">Vertical</label>
+        </li>
+        <li>
+          <input type="radio" name="orientation" id="horizontal" value="horizontal">
+          <label for="horizontal">Horizontal</label>
+        </li>
+        <br/>
+        <span class="option">Orthology backend</span>
+        <li>
+          <input type="radio" name="backend" id="orthodb" value="orthodb" checked>
+          <label for="orthodb">OrthoDB</label>
+        </li>
+        <li>
+          <input type="radio" name="backend" id="oma" value="oma">
+          <label for="oma">OMA Browser</label>
+        </li>
+      </ul>
   </div>
   </div>
   <div id="ideogram-container"></div>
@@ -576,6 +574,14 @@
     document.querySelector('#search').addEventListener('keyup', handleSearch);
     document.querySelectorAll('.org-select').forEach(select => {
       select.addEventListener('change', handleOrganism);
+    });
+    document.querySelector('#options-toggle').addEventListener('click', (event) => {
+      var options = document.querySelector('#options');
+      if (options.style.display === 'none') {
+        options.style.display = '';
+      } else {
+        options.style.display = 'none';
+      }
     });
 
     radioButtons = document.querySelectorAll('input[type=radio]');

--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -11,8 +11,10 @@
     .left-select {position: absolute; left: 150px;}
     #status-container {display: inline-block; margin-left: 86px;}
     #error-container {color: red;}
-    #ideogram-container {margin-left: 125px;}
+    #ideogram-container {margin-left: 125px; z-index: -1}
     #search {width: 280px;}
+
+    #options {z-index: 9999; background: white; border: 1px solid #DDD;}
 
     #options label {display: inline;}
     /* .option {text-decoration: underline;} */
@@ -131,11 +133,13 @@
     }
 
     function updateGenesParams(geneNames) {
-      if (typeof geneNames === 'undefined') {
-        geneNames = genes;
+      if (typeof genes !== 'undefined') {
+        if (typeof geneNames === 'undefined') {
+          geneNames = genes;
+        }
+        delete urlParams['loci']
+        urlParams['genes'] = geneNames;
       }
-      delete urlParams['loci']
-      urlParams['genes'] = geneNames;
       updateUrl();
     }
 
@@ -498,9 +502,9 @@
           left = 200
           topPx = -110
         } else {
-          width = 1350
-          left = 0
-          topPx = 0
+          width = 2000
+          left = -350
+          topPx = 150
         }
         document.querySelector('#_ideogram').setAttribute('width', width);
         ideoContainer.setAttribute(
@@ -544,8 +548,22 @@
 
       if (orthologs.length > 1) {
         // For (likely) multiple chromosomes in each genome
+        organism = config.organism;
+        if (
+          (
+            organism.includes('canis lupus familiaris') ||
+            organism.includes('danio rerio')
+          ) &&
+          orientation === 'horizontal'
+        ) {
+          chrHeight = 65;
+        } else if (orientation === 'horizontal') {
+          chrHeight = 90;
+        } else {
+          chrHeight = 45;
+        }
         Object.assign(config, {
-          chrHeight: orientation === 'vertical' ? 45 : 70,
+          chrHeight: chrHeight,
           chrMargin: 3,
           chromosomeScale: scale,
           geometry: 'collinear'

--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -13,6 +13,12 @@
     #error-container {color: red;}
     #ideogram-container {margin-left: 125px;}
     #search {width: 280px;}
+
+    #options {float: left;}
+
+    ul {padding: 2px 10px 10px 10px;}
+
+    ul li {list-style-type: none; padding-inline-start: 20px;}
   </style>
   <script type="text/javascript" src="../../dist/js/ideogram.min.js"></script>
   <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/homology@0.4.0/dist/homology.min.js"></script>
@@ -77,13 +83,40 @@
       <option>Rice (Oryza sativa)</option>
       </select>
   </label>
-  <label for="backend">
-    Orthology backend:
-    <select class="left-select backend-select" id="backend">
-      <option id="orthodb" selected>OrthoDB</option>
-      <option id="oma">OMA Browser</option>
-    </select>
-  </label>
+  <a href="#" id="advanced-toggle">Advanced</a>
+  <div id="advanced">
+    <ul id="options">
+      Chromosome scale
+      <li>
+        <input type="radio" name="chromosome-scale" id="absolute" value="absolute" checked>
+        <label for="absolute" style="display: inline;">Absolute</label>
+      </li>
+      <li>
+        <input type="radio" name="chromosome-scale" id="relative" value="relative">
+        <label for="relative" style="display: inline;">Relative</label>
+      </li>
+      <br/>
+      Orientation
+      <li>
+        <input type="radio" name="orientation" id="vertical" value="vertical" checked>
+        <label for="vertical" style="display: inline;">Vertical</label>
+      </li>
+      <li>
+        <input type="radio" name="orientation" id="horizontal" value="horizontal">
+        <label for="horizontal" style="display: inline;">Horizontal</label>
+      </li>
+      <br/>
+      Orthology backend
+      <li>
+        <input type="radio" name="backend" id="orthodb" value="orthodb" checked>
+        <label for="orthodb" style="display: inline;">OrthoDB</label>
+      </li>
+      <li>
+        <input type="radio" name="backend" id="oma" value="oma">
+        <label for="oma" style="display: inline;">OMA Browser</label>
+      </li>
+    </ul>
+  </div>
   </div>
   <div id="ideogram-container"></div>
   <div id="status-container"></div>
@@ -170,11 +203,41 @@
       return value.includes(':')
     }
 
-    // Process selections in "Orthology source" drop-down menu
+    // Process selections in "Orthology backend" drop-down menu
     async function handleBackend(event) {
-      var menu = document.querySelector('#backend');
+      var backend = document.querySelector('input[name=backend]:checked').id;
 
-      urlParams['backend'] = menu.options[menu.selectedIndex].id;
+      urlParams['backend'] = backend;
+
+      updateGenesParams();
+      createIdeogram();
+    }
+
+    // Process selections in "Orthology source" radio inputs
+    async function handleBackend(event) {
+      var backend = document.querySelector('input[name=backend]:checked').id;
+
+      urlParams['backend'] = backend;
+
+      updateGenesParams();
+      createIdeogram();
+    }
+
+    // Process selections in "Orientation" radio inputs
+    async function handleOrientation(event) {
+      var orientation = document.querySelector('input[name=orientation]:checked').id;
+
+      urlParams['orientation'] = orientation;
+
+      updateGenesParams();
+      createIdeogram();
+    }
+
+    // Process selections in "Orientation" radio inputs
+    async function handleChromosomeScale(event) {
+      var scale = document.querySelector('input[name=chromosome-scale]:checked').id;
+
+      urlParams['chromosome-scale'] = scale;
 
       updateGenesParams();
       createIdeogram();
@@ -307,6 +370,14 @@
         urlParams['backend'] = 'orthodb';
       }
 
+      if ('orientation' in urlParams === false) {
+        urlParams['orientation'] = 'vertical';
+      }
+
+      if ('chromosome-scale' in urlParams === false) {
+        urlParams['chromosome-scale'] = 'relative';
+      }
+
       org1 = urlParams['org'].replace(/-/g, ' ');
       org2 = urlParams['org2'].replace(/-/g, ' ');
 
@@ -326,7 +397,13 @@
       }
 
       backend = urlParams['backend'];
-      document.querySelector('#backend #' + backend).selected = true;
+      document.querySelector('input[name=backend]#' + backend).checked = true;
+
+      scale = urlParams['chromosome-scale'];
+      document.querySelector('input[name=chromosome-scale]#' + scale).checked = true;
+
+      orientation = urlParams['orientation'];
+      document.querySelector('input[name=orientation]#' + orientation).checked = true;
 
       if (shouldUpdateState()) {
         try {
@@ -415,8 +492,20 @@
       // to account for whole-genome rendering
       ideoContainer = document.querySelector('#ideogram-container');
       if (orthologs.length > 1) {
-        document.querySelector('#_ideogram').setAttribute('width', 350);
-        ideoContainer.setAttribute('style', 'position: relative; top: -110px; left: 200px;');
+        if (orientation === 'vertical') {
+          width = 700
+          left = 200
+          topPx = -110
+        } else {
+          width = 1350
+          left = 0
+          topPx = 0
+        }
+        document.querySelector('#_ideogram').setAttribute('width', width);
+        ideoContainer.setAttribute(
+          'style',
+          'position: relative; top: ' + topPx + 'px; left: ' + left + 'px; width: ' + width + 'px;'
+        );
       } else {
         ideoContainer.setAttribute('style', '');
       }
@@ -433,12 +522,14 @@
       if (document.querySelector('#error-container') !== null) {
         return;
       }
-
+      console.log('orientation')
+      console.log(orientation)
       var config = {
         container: '#ideogram-container',
         showBandLabels: showBandLabels,
         rotatable: false,
-        onLoad: onIdeogramLoad
+        onLoad: onIdeogramLoad,
+        orientation: orientation
       };
 
       if (org1 !== org2) {
@@ -453,9 +544,9 @@
       if (orthologs.length > 1) {
         // For (likely) multiple chromosomes in each genome
         Object.assign(config, {
-          chrHeight: 45,
+          chrHeight: orientation === 'vertical' ? 45 : 70,
           chrMargin: 3,
-          chromosomeScale: 'relative',
+          chromosomeScale: scale,
           geometry: 'collinear'
         });
       } else {
@@ -466,7 +557,7 @@
         chromosomesConfig[org2] = [region.r2.chr];
         Object.assign(config, {
           chromosomes: chromosomesConfig,
-          chrHeight: 400,
+          chrHeight: orientation === 'vertical' ? 350 : 700,
           chrMargin: 50,
           fullChromosomeLabels: true,
           perspective: 'comparative'
@@ -483,8 +574,19 @@
     document.querySelectorAll('.org-select').forEach(select => {
       select.addEventListener('change', handleOrganism);
     });
-    document.querySelectorAll('.backend-select').forEach(select => {
-      select.addEventListener('change', handleBackend);
+
+    radioButtons = document.querySelectorAll('input[type=radio]');
+    radioButtons.forEach(function(radioButton) {
+      radioButton.addEventListener('click', function(event) {
+        var name = event.target.name;
+        if (name === 'backend') {
+          handleBackend(event);
+        } else if (name === 'orientation') {
+          handleOrientation(event);
+        } else if (name === 'chromosome-scale') {
+          handleChromosomeScale(event);
+        }
+      });
     });
 
     createIdeogram();

--- a/src/js/annotations/synteny-collinear-horizontal.js
+++ b/src/js/annotations/synteny-collinear-horizontal.js
@@ -1,0 +1,72 @@
+import {d3} from '../lib';
+import {
+  getRegionsR1AndR2, writeSyntenicRegionPolygonsHorizontal, writeSyntenicRegion
+} from './synteny-lib';
+
+function writeSyntenicRegionLines(syntenicRegion, y1, y2, r1, r2) {
+  syntenicRegion.append('line')
+    .attr('class', 'syntenyBorder')
+    .attr('x1', r1.startPx)
+    .attr('x2', r2.startPx)
+    .attr('y1', y1)
+    .attr('y2', y2);
+
+  syntenicRegion.append('line')
+    .attr('class', 'syntenyBorder')
+    .attr('x1', r1.stopPx)
+    .attr('x2', r2.stopPx)
+    .attr('y1', y1)
+    .attr('y2', y2);
+}
+
+function writeSyntenicRegions(syntenicRegions, syntenies, ideo) {
+  var i, regions, r1, r2, regionID, syntenicRegion, chrWidth, y1, y2;
+
+  for (i = 0; i < syntenicRegions.length; i++) {
+    regions = syntenicRegions[i];
+
+    [r1, r2] = getRegionsR1AndR2(regions, ideo);
+
+    regionID = (
+      r1.chr.id + '_' + r1.start + '_' + r1.stop + '_' +
+      '__' +
+      r2.chr.id + '_' + r2.start + '_' + r2.stop
+    );
+
+    syntenicRegion = writeSyntenicRegion(syntenies, regionID, ideo);
+
+    chrWidth = ideo.config.chrWidth;
+    y1 = chrWidth + 21;
+    y2 = chrWidth + 191; // Genomes are spaced ~200 pixels apart
+
+    writeSyntenicRegionPolygonsHorizontal(syntenicRegion, y1, y2, r1, r2, regions);
+    writeSyntenicRegionLines(syntenicRegion, y1, y2, r1, r2);
+  }
+}
+
+function reportPerformance(t0, ideo) {
+  var t1 = new Date().getTime();
+  if (ideo.config.debug) {
+    console.log('Time in drawSyntenicRegions: ' + (t1 - t0) + ' ms');
+  }
+}
+
+/**
+ * Draws a trapezoid connecting a genomic range on
+ * one chromosome to a genomic range on another chromosome;
+ * a syntenic region.
+ */
+function drawSyntenyCollinearHorizontal(syntenicRegions, ideo) {
+  var syntenies,
+    t0 = new Date().getTime();
+
+  syntenies = d3.select(ideo.selector)
+    .insert('g', ':first-child')
+    .attr('class', 'synteny');
+
+  writeSyntenicRegions(syntenicRegions, syntenies, ideo);
+
+  reportPerformance(t0, ideo);
+}
+
+export {drawSyntenyCollinearHorizontal};

--- a/src/js/annotations/synteny-collinear.js
+++ b/src/js/annotations/synteny-collinear.js
@@ -19,7 +19,7 @@ function writeSyntenicRegionLines(syntenicRegion, x1, x2, r1, r2) {
     .attr('y2', r2.stopPx);
 }
 
-function writeSyntenicRegions(syntenicRegions, syntenies, xOffset, ideo) {
+function writeSyntenicRegions(syntenicRegions, syntenies, ideo) {
   var i, regions, r1, r2, regionID, syntenicRegion, chrWidth, x1, x2;
 
   for (i = 0; i < syntenicRegions.length; i++) {
@@ -57,16 +57,14 @@ function reportPerformance(t0, ideo) {
  * a syntenic region.
  */
 function drawSyntenyCollinear(syntenicRegions, ideo) {
-  var syntenies, xOffset,
+  var syntenies,
     t0 = new Date().getTime();
 
   syntenies = d3.select(ideo.selector)
     .insert('g', ':first-child')
     .attr('class', 'synteny');
 
-  xOffset = ideo._layout.margin.left;
-
-  writeSyntenicRegions(syntenicRegions, syntenies, xOffset, ideo);
+  writeSyntenicRegions(syntenicRegions, syntenies, ideo);
 
   reportPerformance(t0, ideo);
 }

--- a/src/js/annotations/synteny-lib.js
+++ b/src/js/annotations/synteny-lib.js
@@ -40,6 +40,23 @@ export function writeSyntenicRegionPolygons(syntenicRegion, x1, x2, r1, r2, regi
     .style('fill-opacity', opacity);
 }
 
+export function writeSyntenicRegionPolygonsHorizontal(syntenicRegion, y1, y2, r1, r2, regions) {
+  var color, opacity;
+
+  color = ('color' in regions) ? regions.color : '#CFC';
+  opacity = ('opacity' in regions) ? regions.opacity : 1;
+
+  syntenicRegion.append('polygon')
+    .attr('points',
+      r1.startPx + ', ' + y1 + ' ' +
+      r1.stopPx + ', ' + y1 + ' ' +
+      r2.stopPx + ', ' + y2 + ' ' +
+      r2.startPx + ', ' + y2
+    )
+    .style('fill', color)
+    .style('fill-opacity', opacity);
+}
+
 export function getRegionsR1AndR2(regions, ideo, xOffset = null) {
   var r1, r2,
     r1Offset, r2Offset;
@@ -59,17 +76,27 @@ export function getRegionsR1AndR2(regions, ideo, xOffset = null) {
   }
 
   var r1ChrDom = document.querySelector('#' + r1.chr.id + '-chromosome-set');
-  var r1GenomeOffset = r1ChrDom.getCTM().f;
+  var r1GenomeHorizontalXOffset = r1ChrDom.getCTM().e;
+  var r1GenomeVerticalXOffset = r1ChrDom.getCTM().f;
   var r2ChrDom = document.querySelector('#' + r2.chr.id + '-chromosome-set');
   // var r2GenomeOffset = r2ChrDom.getBoundingClientRect().top;
-  var r2GenomeOffset = r2ChrDom.getCTM().f;
+  var r2GenomeHorizontalXOffset = r2ChrDom.getCTM().e;
+  var r2GenomeVerticalXOffset = r2ChrDom.getCTM().f;
 
   if (xOffset === null) {
-    // When collinear
-    r1Offset = r1GenomeOffset - 12;
-    r2Offset = r2GenomeOffset - 12;
+    if (ideo.config.orientation === 'vertical') {
+      // When vertical collinear
+      // http://localhost:8080/examples/vanilla/compare-whole-genomes?chromosome-scale=absolute&orientation=vertical
+      r1Offset = r1GenomeVerticalXOffset - 12;
+      r2Offset = r2GenomeVerticalXOffset - 12;
+    } else {
+      // When horizontal collinear, e.g.
+      // http://localhost:8080/examples/vanilla/compare-whole-genomes?chromosome-scale=absolute&orientation=horizontal
+      r1Offset = r1GenomeHorizontalXOffset;
+      r2Offset = r2GenomeHorizontalXOffset;
+    }
   } else {
-    // When parallel
+    // When horizontal parallel
     r1Offset = xOffset;
     r2Offset = xOffset;
   }

--- a/src/js/annotations/synteny.js
+++ b/src/js/annotations/synteny.js
@@ -1,5 +1,6 @@
 import {d3} from '../lib';
 import {drawSyntenyCollinear} from './synteny-collinear';
+import {drawSyntenyCollinearHorizontal} from './synteny-collinear-horizontal';
 import {
   getRegionsR1AndR2, writeSyntenicRegionPolygons, writeSyntenicRegion
 } from './synteny-lib';
@@ -99,14 +100,18 @@ function reportPerformance(t0, ideo) {
 function drawSynteny(syntenicRegions) {
   var syntenies, xOffset,
     t0 = new Date().getTime(),
-    ideo = this;
+    ideo = this,
+    config = ideo.config;
 
   if (
-    ideo.config.multiorganism &&
-    ideo.config.geometry === 'collinear' &&
-    ideo.config.orientation === 'vertical'
+    config.multiorganism &&
+    config.geometry === 'collinear'
   ) {
-    return drawSyntenyCollinear(syntenicRegions, ideo);
+    if (config.orientation === 'vertical') {
+      return drawSyntenyCollinear(syntenicRegions, ideo);
+    } else {
+      return drawSyntenyCollinearHorizontal(syntenicRegions, ideo);
+    }
   }
 
   syntenies = d3.select(ideo.selector)

--- a/src/js/collinear-vertical.js
+++ b/src/js/collinear-vertical.js
@@ -23,7 +23,15 @@ function labelGenomes(ideo) {
 }
 
 /**
-* Rearrange chromosomes from horizontal to collinear
+* Rearrange chromosomes from parallel vertical to collinear vertical
+*
+* Parallel vertical (as in https://eweitz.github.io/ideogram/human)
+* | | |
+*
+* Collinear vertical (as in https://eweitz.github.io/ideogram/orthologs?loci=2:150000000,5:20000000;3:100000000,10:80000000&org=homo-sapiens&org2=mus-musculus)
+* |
+* |
+* |
 */
 function rearrangeChromosomes(chrSets, yOffsets, x, ideo) {
   var i, chrSet, y, chrLabelX, adjustedX, chr, taxid, orgIndex,

--- a/src/js/collinear.js
+++ b/src/js/collinear.js
@@ -8,7 +8,15 @@ import {d3} from './lib';
 import collinearizeVerticalChromosomes from './collinear-vertical';
 
 /**
-* Rearrange chromosomes from horizontal to collinear
+* Rearrange chromosomes from parallel horizontal to collinear horizontal
+*
+* Parallel horizontal (as in https://eweitz.github.io/ideogram/mouse)
+*     ---
+*     ---
+*     ---
+*
+* Collinear horizontal (as in https://eweitz.github.io/ideogram/geometry-collinear):
+*     --- --- ---
 */
 function rearrangeChromosomes(chrSets, xOffsets, y, ideo) {
   var i, chr, chrSet, taxid, x, adjustedY, orgIndex, chrLabelY;

--- a/src/js/collinear.js
+++ b/src/js/collinear.js
@@ -48,7 +48,7 @@ function rearrangeChromosomes(chrSets, xOffsets, y, ideo) {
 /**
 * Get pixel coordinates to use for rearrangement
 */
-function getxOffsets(chrSets, ideo) {
+function getXOffsets(chrSets, ideo) {
   var xOffsets, i, index, chr, prevChr, x, prevWidth, prevX, xBump, taxid,
     seenTaxids = {};
 
@@ -136,7 +136,7 @@ function collinearizeChromosomes(ideo) {
     config.chrWidth + 1
   );
 
-  xOffsets = getxOffsets(chrSets, ideo);
+  xOffsets = getXOffsets(chrSets, ideo);
   rearrangeChromosomes(chrSets, xOffsets, y, ideo);
 
   height = y + config.chrWidth * 2 + 20;

--- a/test/web-test.js
+++ b/test/web-test.js
@@ -586,6 +586,102 @@ describe('Ideogram', function() {
     ideogram = new Ideogram(config);
   });
 
+  it('should show 3 syntenic regions in collinear horizontal genomes', function(done) {
+    // Tests use case from ../examples/vanilla/compare-whole-genomes
+    // Used for comparing multiple whole genomes
+
+    function onIdeogramLoad() {
+      var chrs, chr1, chr4, humanTaxid, mouseTaxid;
+
+      humanTaxid = ideogram.getTaxid('human');
+      mouseTaxid = ideogram.getTaxid('mouse');
+
+      chrs = ideogram.chromosomes;
+      chr1 = chrs[humanTaxid]['1'];
+      chr4 = chrs[mouseTaxid]['4'];
+      chr19 = chrs[mouseTaxid]['19'];
+      syntenicRegions = [];
+
+      range1 = {
+        chr: chr1,
+        start: 11106531,
+        stop: 11262557,
+        orientation: 'reverse'
+      };
+
+      range2 = {
+        chr: chr4,
+        start: 148448582,
+        stop: 148557685
+      };
+      // range2 = {
+      //   chr: chr19,
+      //   start: 61431564,
+      //   stop: 61431565 // end of mouse chr19
+      // };
+
+      syntenicRegions.push({r1: range1, r2: range2});
+
+      var chr10 = chrs[humanTaxid]['10'];
+      var range3 = {
+        chr: chr10,
+        start: 87864470,
+        stop: 87965472
+      };
+      var range4 = {
+        chr: chr19,
+        start: 32758445,
+        stop: 32820028
+      };
+      syntenicRegions.push({r1: range3, r2: range4});
+
+      var range5 = {
+        chr: chr10,
+        start: 26216810,
+        stop: 26300961
+      };
+      var range6 = {
+        chr: chrs[mouseTaxid]['2'],
+        start: 22622663,
+        stop: 22690346
+      };
+      syntenicRegions.push({r1: range5, r2: range6});
+
+      ideogram.drawSynteny(syntenicRegions);
+
+      var selector1, selector3, line1, line3;
+
+      selector1 = '#chr1-9606_11106531_11262557___chr4-10090_148448582_148557685';
+      selector3 = '#chr10-9606_26216810_26300961___chr2-10090_22622663_22690346';
+
+      line1 = document.querySelector(selector1 + ' .syntenyBorder');
+      line3 = document.querySelector(selector3 + ' .syntenyBorder');
+
+      assert.equal(Math.round(line1.getAttribute('x1')), 22);
+      assert.equal(Math.round(line1.getAttribute('x2')), 139);
+      assert.equal(Math.round(line1.getAttribute('y1')), 31);
+      assert.equal(Math.round(line1.getAttribute('y2')), 201);
+
+      assert.equal(Math.round(line3.getAttribute('x1')), 320);
+      assert.equal(Math.round(line3.getAttribute('x2')), 58);
+
+      done();
+    }
+
+    config = {
+      organism: ['human', 'mouse'],
+      orientation: 'horizontal',
+      geometry: 'collinear',
+      chromosomeScale: 'absolute',
+      chrHeight: 40,
+      chrMargin: 3,
+      dataDir: '/dist/data/bands/native/',
+      onLoad: onIdeogramLoad
+    };
+
+    ideogram = new Ideogram(config);
+  });
+
   it('should plot accurate synteny in relative collinear vertical genomes', function(done) {
     // Tests use case from ../examples/vanilla/compare-whole-genomes
     // Used for comparing multiple whole genomes


### PR DESCRIPTION
This enables comparing genomes with a horizontal orientation.  

Laptop and desktop screens are usually more wide than tall, so this allows more chromosomes to fit in view.  You can now compare genomes involving an organism with many chromosomes -- e.g. dog -- at higher detail without scrolling.

More technically, this enables comparing whole genomes where the layout has a collinear geometry (chromosomes are lined end-to-end) and horizontal orientation (laid flat).  

Also, options for [orientation](https://github.com/eweitz/ideogram/blob/master/api.md#orientation) and [chromosome scale](https://github.com/eweitz/ideogram/blob/master/api.md#chromosomescale) have been made adjustable in the [Orthologs example](https://eweitz.github.io/ideogram/orthologs) UI -- making it easy to experiment with layout and configure views as desired.

Compare positions of BRCA1 and MTOR genes in horizontal genomes for human and dog:
<img width="1420" alt="compare_horizontal_genomes_human_dog_ideogram" src="https://user-images.githubusercontent.com/1334561/79669752-e162b080-818b-11ea-8220-a8dccf571c09.png">
