### PR TITLE
Horizontal genome labels

### DIFF
--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -622,6 +622,7 @@
         onLoad: onIdeogramLoad,
         orientation: orientation,
         chrHeight: chrHeight,
+        chrLabelSize: 11
       };
 
       if (org1 !== org2) {
@@ -639,7 +640,7 @@
         Object.assign(config, {
           chromosomeScale: scale,
           geometry: 'collinear',
-          chrMargin: 3
+          chrMargin: 6
         });
       } else {
         // For one chromosome in each genome

--- a/src/js/annotations/synteny-collinear-horizontal.js
+++ b/src/js/annotations/synteny-collinear-horizontal.js
@@ -6,15 +6,15 @@ import {
 function writeSyntenicRegionLines(syntenicRegion, y1, y2, r1, r2) {
   syntenicRegion.append('line')
     .attr('class', 'syntenyBorder')
-    .attr('x1', r1.startPx)
-    .attr('x2', r2.startPx)
+    .attr('x1', r1.startPx - 15)
+    .attr('x2', r2.startPx - 15)
     .attr('y1', y1)
     .attr('y2', y2);
 
   syntenicRegion.append('line')
     .attr('class', 'syntenyBorder')
-    .attr('x1', r1.stopPx)
-    .attr('x2', r2.stopPx)
+    .attr('x1', r1.stopPx - 15)
+    .attr('x2', r2.stopPx - 15)
     .attr('y1', y1)
     .attr('y2', y2);
 }
@@ -37,7 +37,7 @@ function writeSyntenicRegions(syntenicRegions, syntenies, ideo) {
 
     chrWidth = ideo.config.chrWidth;
     y1 = chrWidth + 31;
-    y2 = chrWidth + 201; // Genomes are spaced ~200 pixels apart
+    y2 = chrWidth + 191; // Genomes are spaced ~200 pixels apart
 
     writeSyntenicRegionPolygonsHorizontal(syntenicRegion, y1, y2, r1, r2, regions);
     writeSyntenicRegionLines(syntenicRegion, y1, y2, r1, r2);

--- a/src/js/annotations/synteny-collinear-horizontal.js
+++ b/src/js/annotations/synteny-collinear-horizontal.js
@@ -36,8 +36,8 @@ function writeSyntenicRegions(syntenicRegions, syntenies, ideo) {
     syntenicRegion = writeSyntenicRegion(syntenies, regionID, ideo);
 
     chrWidth = ideo.config.chrWidth;
-    y1 = chrWidth + 21;
-    y2 = chrWidth + 191; // Genomes are spaced ~200 pixels apart
+    y1 = chrWidth + 31;
+    y2 = chrWidth + 201; // Genomes are spaced ~200 pixels apart
 
     writeSyntenicRegionPolygonsHorizontal(syntenicRegion, y1, y2, r1, r2, regions);
     writeSyntenicRegionLines(syntenicRegion, y1, y2, r1, r2);

--- a/src/js/collinear-vertical.js
+++ b/src/js/collinear-vertical.js
@@ -35,11 +35,12 @@ function labelGenomes(ideo) {
 */
 function rearrangeChromosomes(chrSets, yOffsets, x, ideo) {
   var i, chrSet, y, chrLabelX, adjustedX, chr, taxid, orgIndex,
-    config = ideo.config;
+    config = ideo.config,
+    chrLabelSize = config.chrLabelSize;
 
   for (i = 0; i < chrSets.length; i++) {
     chrSet = chrSets[i];
-    y = yOffsets[i] + 15;
+    y = yOffsets[i] + 23 - chrLabelSize;
 
     chr = ideo.chromosomesArray[i];
     taxid = chr.id.split('-')[1];
@@ -53,7 +54,9 @@ function rearrangeChromosomes(chrSets, yOffsets, x, ideo) {
     }
 
     if (config.showChromosomeLabels) {
-      chrSet.querySelector('.chrLabel > tspan').setAttribute('x', chrLabelX);
+      let labelSpan = chrSet.querySelector('.chrLabel > tspan');
+      labelSpan.setAttribute('x', chrLabelX);
+      labelSpan.setAttribute('dy', chrLabelSize - 8);
       chrSet.querySelector('.chrLabel').setAttribute('text-anchor', 'start');
     }
     chrSet.setAttribute('transform', 'rotate(90) translate(' + y + ',' + adjustedX + ')');

--- a/src/js/collinear.js
+++ b/src/js/collinear.js
@@ -11,13 +11,14 @@ function labelGenomes(ideo) {
 
   ideo.config.taxids.forEach((taxid, i) => {
     var org = ideo.organisms[taxid];
+    var config = ideo.config;
     // var commonName = slug(org.commonName);
     var scientificName = org.scientificName;
     d3.select(ideo.selector)
       .append('text')
       .attr('class', 'genomeLabel italic')
       .attr('x', 5)
-      .attr('y', 10 + 240 * i)
+      .attr('y', config.chrLabelSize + (200 + (3 * config.chrWidth)) * i)
       .text(scientificName);
   });
 }
@@ -49,9 +50,9 @@ function rearrangeChromosomes(chrSets, xOffsets, y, ideo) {
     adjustedY = y + orgIndex * 200;
     if (orgIndex === 0 && ideo.config.multiorganism) {
       chrLabelY = chrLabelSize - 4;
-      adjustedY += chrWidth * 2;
+      adjustedY += chrWidth * 2 + chrLabelSize;
     } else {
-      chrLabelY = chrWidth * 2 + chrLabelSize;
+      chrLabelY = chrWidth * 2 + chrLabelSize + 2;
     }
 
     if (ideo.config.showChromosomeLabels) {
@@ -62,7 +63,9 @@ function rearrangeChromosomes(chrSets, xOffsets, y, ideo) {
     chrSet.querySelector('.chromosome').setAttribute('transform', 'translate(-13, 10)');
   }
 
-  labelGenomes(ideo);
+  if (config.multiorganism) {
+    labelGenomes(ideo);
+  }
 }
 
 /**
@@ -153,7 +156,7 @@ function collinearizeChromosomes(ideo) {
 
   y = (
     (config.numAnnotTracks * (annotHeight + annotLabelHeight + 4)) -
-    config.chrWidth + 1 + 10
+    config.chrWidth + 1
   );
 
   xOffsets = getXOffsets(chrSets, ideo);

--- a/src/js/collinear.js
+++ b/src/js/collinear.js
@@ -7,6 +7,21 @@
 import {d3} from './lib';
 import collinearizeVerticalChromosomes from './collinear-vertical';
 
+function labelGenomes(ideo) {
+
+  ideo.config.taxids.forEach((taxid, i) => {
+    var org = ideo.organisms[taxid];
+    // var commonName = slug(org.commonName);
+    var scientificName = org.scientificName;
+    d3.select(ideo.selector)
+      .append('text')
+      .attr('class', 'genomeLabel italic')
+      .attr('x', 5)
+      .attr('y', 10 + 240 * i)
+      .text(scientificName);
+  });
+}
+
 /**
 * Rearrange chromosomes from parallel horizontal to collinear horizontal
 *
@@ -19,7 +34,10 @@ import collinearizeVerticalChromosomes from './collinear-vertical';
 *     --- --- ---
 */
 function rearrangeChromosomes(chrSets, xOffsets, y, ideo) {
-  var i, chr, chrSet, taxid, x, adjustedY, orgIndex, chrLabelY;
+  var i, chr, chrSet, taxid, x, adjustedY, orgIndex, chrLabelY,
+    config = ideo.config,
+    chrWidth = config.chrWidth,
+    chrLabelSize = config.chrLabelSize;
 
   for (i = 0; i < chrSets.length; i++) {
     chrSet = chrSets[i];
@@ -27,13 +45,13 @@ function rearrangeChromosomes(chrSets, xOffsets, y, ideo) {
 
     chr = ideo.chromosomesArray[i];
     taxid = chr.id.split('-')[1];
-    orgIndex = ideo.config.taxids.indexOf(taxid);
+    orgIndex = config.taxids.indexOf(taxid);
     adjustedY = y + orgIndex * 200;
     if (orgIndex === 0 && ideo.config.multiorganism) {
-      chrLabelY = 6;
-      adjustedY += ideo.config.chrWidth * 2;
+      chrLabelY = chrLabelSize - 4;
+      adjustedY += chrWidth * 2;
     } else {
-      chrLabelY = ideo.config.chrWidth * 2 + 10;
+      chrLabelY = chrWidth * 2 + chrLabelSize;
     }
 
     if (ideo.config.showChromosomeLabels) {
@@ -43,6 +61,8 @@ function rearrangeChromosomes(chrSets, xOffsets, y, ideo) {
     chrSet.setAttribute('transform', 'translate(' + x + ',' + adjustedY + ')');
     chrSet.querySelector('.chromosome').setAttribute('transform', 'translate(-13, 10)');
   }
+
+  labelGenomes(ideo);
 }
 
 /**
@@ -133,7 +153,7 @@ function collinearizeChromosomes(ideo) {
 
   y = (
     (config.numAnnotTracks * (annotHeight + annotLabelHeight + 4)) -
-    config.chrWidth + 1
+    config.chrWidth + 1 + 10
   );
 
   xOffsets = getXOffsets(chrSets, ideo);

--- a/src/js/init/configure.js
+++ b/src/js/init/configure.js
@@ -146,7 +146,10 @@ function configureBands(ideo) {
 
 let configuredCss = staticCss;
 function configureTextStyle(ideo) {
-  if (!ideo.config.chrLabelSize) return;
+  if (!ideo.config.chrLabelSize) {
+    ideo.config.chrLabelSize = 9;
+    return;
+  }
 
   const size = ideo.config.chrLabelSize;
   configuredCss += `#_ideogram text {font-size: ${size}px}`;

--- a/test/web-test.js
+++ b/test/web-test.js
@@ -565,10 +565,10 @@ describe('Ideogram', function() {
 
       assert.equal(Math.round(line1.getAttribute('x1')), 56);
       assert.equal(Math.round(line1.getAttribute('x2')), 250);
-      assert.equal(Math.round(line1.getAttribute('y1')), 25);
+      assert.equal(Math.round(line1.getAttribute('y1')), 24);
 
-      assert.equal(Math.round(line3.getAttribute('y1')), 323);
-      assert.equal(Math.round(line3.getAttribute('y2')), 61);
+      assert.equal(Math.round(line3.getAttribute('y1')), 322);
+      assert.equal(Math.round(line3.getAttribute('y2')), 60);
       done();
     }
 
@@ -659,8 +659,8 @@ describe('Ideogram', function() {
 
       assert.equal(Math.round(line1.getAttribute('x1')), 22);
       assert.equal(Math.round(line1.getAttribute('x2')), 139);
-      assert.equal(Math.round(line1.getAttribute('y1')), 31);
-      assert.equal(Math.round(line1.getAttribute('y2')), 201);
+      assert.equal(Math.round(line1.getAttribute('y1')), 41);
+      assert.equal(Math.round(line1.getAttribute('y2')), 211);
 
       assert.equal(Math.round(line3.getAttribute('x1')), 320);
       assert.equal(Math.round(line3.getAttribute('x2')), 58);
@@ -726,8 +726,8 @@ describe('Ideogram', function() {
 
       assert.equal(Math.round(line1.getAttribute('x1')), 56);
       assert.equal(Math.round(line1.getAttribute('x2')), 250);
-      assert.equal(Math.round(line1.getAttribute('y2')), 23);
-      assert.equal(Math.round(line2.getAttribute('y2')), 59);
+      assert.equal(Math.round(line1.getAttribute('y2')), 22);
+      assert.equal(Math.round(line2.getAttribute('y2')), 58);
 
       done();
 
@@ -2497,7 +2497,7 @@ describe('Ideogram', function() {
       assert.equal(chr2CanvasBox.x, 111);
 
       assert.equal(labelX, '-8');
-      assert.equal(labelY, '30');
+      assert.equal(labelY, '31');
 
       done();
     }

--- a/test/web-test.js
+++ b/test/web-test.js
@@ -657,13 +657,13 @@ describe('Ideogram', function() {
       line1 = document.querySelector(selector1 + ' .syntenyBorder');
       line3 = document.querySelector(selector3 + ' .syntenyBorder');
 
-      assert.equal(Math.round(line1.getAttribute('x1')), 22);
-      assert.equal(Math.round(line1.getAttribute('x2')), 139);
+      assert.equal(Math.round(line1.getAttribute('x1')), 7);
+      assert.equal(Math.round(line1.getAttribute('x2')), 124);
       assert.equal(Math.round(line1.getAttribute('y1')), 41);
-      assert.equal(Math.round(line1.getAttribute('y2')), 211);
+      assert.equal(Math.round(line1.getAttribute('y2')), 201);
 
-      assert.equal(Math.round(line3.getAttribute('x1')), 320);
-      assert.equal(Math.round(line3.getAttribute('x2')), 58);
+      assert.equal(Math.round(line3.getAttribute('x1')), 305);
+      assert.equal(Math.round(line3.getAttribute('x2')), 43);
 
       done();
     }


### PR DESCRIPTION
This adds organism labels to horizontal genomes, enables setting such labels' size, and fixes a bug with pixel offsets in horizontal syntenic regions.

For example, see the labels "_Homo sapiens_" and "_Canis lupus familiaris_" beside the genomes below:
<img width="1376" alt="horizontal_genome_labels_ideogram" src="https://user-images.githubusercontent.com/1334561/79921026-63a6db00-83ff-11ea-8c91-daf5632e60bc.png">
