### PR TITLE
Enhance tooltips, refine UX in "Related genes"

### DIFF
--- a/examples/vanilla/orthologs.html
+++ b/examples/vanilla/orthologs.html
@@ -70,7 +70,7 @@
   <a href="homology-basic">Next</a> |
   <a href="https://github.com/eweitz/ideogram/blob/gh-pages/orthologs.html" target="_blank">Source</a>
   <p>
-    Compare gene locations across organisms.  See also <a href="paralogs">Paralogs</a>.
+    Compare gene locations across organisms.  See also <a href="related-genes">Related genes</a>.
   </p>
   <div style="float: left; width: 350px;">
   <label for="search" id="search-container">Search:

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -122,9 +122,9 @@
     // Start example-specific handling
     ///
 
-    var urlParams = parseUrlParams();
+    const urlParams = parseUrlParams();
 
-    var organism = 'org' in urlParams ? urlParams.org : 'homo-sapiens';
+    const organism = 'org' in urlParams ? urlParams.org : 'homo-sapiens';
 
     document.querySelector(`[value="${organism}"]`).selected = true;
     document.querySelector('select').addEventListener('change', handleOrganism);
@@ -136,11 +136,11 @@
     document.querySelector('#search-button').addEventListener('click', handleSearch);
     document.querySelector('#search-genes').addEventListener('keyup', handleSearch);
 
-    var ideogramFirstLoad = true;
+    let ideogramFirstLoad = true;
 
     function parseUrlParams() {
-      var rawParams = document.location.search;
-      var urlParams = {};
+      let rawParams = document.location.search;
+      const urlParams = {};
       var param, key, value;
       if (rawParams !== '') {
         rawParams = rawParams.split('?')[1].split('&');
@@ -156,7 +156,7 @@
 
     // Record app state in URL
     function updateUrl() {
-      var params = Object.keys(urlParams).map(key => {
+      const params = Object.keys(urlParams).map(key => {
         return key + '=' + urlParams[key];
       }).join('&');
       history.pushState(null, null, '?' + params);
@@ -164,7 +164,7 @@
 
     function handleOrganism() {
       document.querySelector('#search-genes').value = '';
-      var selectedOrg = document.querySelector('option:checked').text;
+      const selectedOrg = document.querySelector('option:checked').text;
       selectedOrg =
         selectedOrg.split('(')[1].split(')')[0]
         .replace(/ /g, '-').toLowerCase();
@@ -173,7 +173,7 @@
       updateUrl();
 
       config.organism = selectedOrg;
-      // var banded = !['homo sapiens', 'mus musculus'].includes(selectedOrg);
+      // const banded = !['homo sapiens', 'mus musculus'].includes(selectedOrg);
       // config.showFullyBanded = banded;
       ideogram = new Ideogram(config);
     }
@@ -183,21 +183,22 @@
       // Ignore non-"Enter" keyups
       if (event.type === 'keyup' && event.keyCode !== 13) return;
 
-      var searchInput = event.target.value.trim();
+      const searchInput = event.target.value.trim();
 
       // Handles "BRCA1,BRCA2", "BRCA1 BRCA2", and "BRCA1, BRCA2"
-      let geneSymbols = searchInput.split(/[, ]/).filter(d => d !== '')
+      const geneSymbols = searchInput.split(/[, ]/).filter(d => d !== '')
+      const geneSymbol = geneSymbols[0];
 
-      urlParams['q'] = geneSymbols;
+      urlParams['q'] = geneSymbol;
       updateUrl();
 
-      plotRelatedGenes(geneSymbols);
+      plotRelatedGenes(geneSymbol);
     }
 
     function plotGeneFromUrl() {
       if (ideogramFirstLoad && 'q' in urlParams) {
         ideogramFirstLoad = false;
-        plotRelatedGenes([urlParams['q']]);
+        plotRelatedGenes(urlParams['q']);
       }
     }
 
@@ -212,7 +213,8 @@
     annotDescriptions = {}
 
     function onClickAnnot(annot) {
-      plotRelatedGenes([annot.name]);
+      document.querySelector('#search-genes').value = annot.name;
+      plotRelatedGenes(annot.name);
     }
 
     /**
@@ -348,7 +350,7 @@
 
         const ixns = interactions[gene.symbol];
 
-        description = describeInteractions(ixns)
+        const description = describeInteractions(gene, ixns);
 
         annotDescriptions[gene.symbol] = description;
       })
@@ -441,7 +443,7 @@
       // Fetch positon of searched gene
       const taxid = ideogram.config.taxid;
       const queryString =
-        `?q=symbol:${geneSymbols[0]}&species=${taxid}&fields=symbol,genomic_pos,name`;
+        `?q=symbol:${geneSymbol}&species=${taxid}&fields=symbol,genomic_pos,name`;
       let data = await fetchMyGeneInfo(queryString)
 
       const gene = data.hits[0]
@@ -466,10 +468,10 @@
     }
 
     function decorateGene(annot) {
-      var org = ideogram.getScientificName(ideogram.config.taxid);
-      var term = `(${annot.name}[gene])+AND+(${org}[orgn])`;
-      var url = `https://ncbi.nlm.nih.gov/gene/?term=${term}`;
-      var description = annotDescriptions[annot.name].split(' [')[0];
+      const org = ideogram.getScientificName(ideogram.config.taxid);
+      const term = `(${annot.name}[gene])+AND+(${org}[orgn])`;
+      const url = `https://ncbi.nlm.nih.gov/gene/?term=${term}`;
+      const description = annotDescriptions[annot.name].split(' [')[0];
       annot.displayName =
         `<a target="_blank" href="${url}">${annot.name}</a>
         <br/>
@@ -480,7 +482,7 @@
 
     const shape = 'triangle';
 
-    var legend = [{
+    const legend = [{
       name: '<b>Click gene to search</b>',
       rows: [
         {name: 'Interacting gene', color: 'purple', shape: shape},
@@ -504,7 +506,7 @@
 
     config.onLoad = plotGeneFromUrl;
 
-    var ideogram = new Ideogram(config);
+    const ideogram = new Ideogram(config);
   </script>
 </body>
 </html>

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -228,6 +228,7 @@
       return (
         ixn !== '' &&
         !ixn.includes(' ') &&
+        !ixn.includes('/') && // e.g. Akt/PKB
         ixn.toLowerCase() !== gene.name.toLowerCase()
       );
     }
@@ -330,7 +331,9 @@
 
       if (geneList.length === 0) return annots
 
-      const ixnParam = geneList.map(ixn => `symbol:${ixn}`).join(' OR ')
+      const ixnParam = geneList.map(ixn => {
+        return `symbol:${ixn.trim()}`
+      }).join(' OR ')
 
       const taxid = ideogram.config.taxid;
       const queryString =
@@ -379,6 +382,10 @@
 
       Object.entries(ensemblHomologGenes).map((idGene, i) => {
         let gene = idGene[1]
+
+        // Seen in related genes for SIRT2 in Pan troglodytes
+        if ('display_name' in gene === false) return;
+
         const annot = {
           name: gene.display_name,
           chr: gene.seq_region_name,
@@ -387,6 +394,7 @@
           id: gene.id,
           color: 'pink'
         };
+
         // Add to start of array, so searched gene gets top z-index
         annots.unshift(annot);
         ideogram.annotDescriptions[annot.name] = gene.description;

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -301,13 +301,33 @@
     }
 
     /**
+     * Summarizes interactions for a gene
+     *
+     * This comprises most of the content for tooltips for interacting genes.
+     */
+    function describeInteractions(gene, ixns) {
+      const pathwaysBase = 'https://www.wikipathways.org/index.php/Pathway:';
+
+      const links = ixns.map(ixn => {
+          const url = `${pathwaysBase}${ixn.pathwayId}`
+          return `<a href="${url}" target="_blank">${ixn.name}</a>`;
+        }).join('<br/>')
+
+      const description = `
+        ${gene.name}<br/><br/>
+        Interacts in pathways:<br/>
+        ${links}`;
+
+      return description
+    }
+
+    /**
      * Retrieves position and other data on interacting genes from MyGene.info
      */
     async function fetchInteractingGeneAnnots(interactions) {
 
       let annots = [];
       const geneList = Object.keys(interactions);
-      const pathwaysBase = 'https://www.wikipathways.org/index.php/Pathway:';
 
       if (geneList.length === 0) return annots
 
@@ -328,15 +348,7 @@
 
         const ixns = interactions[gene.symbol];
 
-        const links = ixns.map(ixn => {
-          const url = `${pathwaysBase}${ixn.pathwayId}`
-          return `<a href="${url}" target="_blank">${ixn.name}</a>`;
-        }).join('<br/>')
-
-        const description = `
-          ${gene.name}<br/><br/>
-          Interacts in pathways:<br/>
-          ${links}`;
+        description = describeInteractions(ixns)
 
         annotDescriptions[gene.symbol] = description;
       })

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -197,8 +197,6 @@
     function plotGeneFromUrl() {
       if (ideogramFirstLoad && 'q' in urlParams) {
         ideogramFirstLoad = false;
-        console.log('ideogram')
-        console.log(ideogram)
         plotRelatedGenes([urlParams['q']]);
       }
     }
@@ -289,17 +287,17 @@
     async function fetchInteractingGeneAnnots(interactions) {
 
       let annots = [];
-      let geneList = Object.keys(interactions);
+      const geneList = Object.keys(interactions);
       const pathwaysBase = 'https://www.wikipathways.org/index.php/Pathway:';
 
       if (geneList.length === 0) return annots
 
-      ixnParam = geneList.map(ixn => `symbol:${ixn}`).join(' OR ')
+      const ixnParam = geneList.map(ixn => `symbol:${ixn}`).join(' OR ')
 
       const taxid = ideogram.config.taxid;
       const queryString =
         `?q=${ixnParam}&species=${taxid}&fields=symbol,genomic_pos,name`;
-      let data = await fetchMyGeneInfo(queryString)
+      const data = await fetchMyGeneInfo(queryString)
 
       data.hits.forEach(hit => {
 
@@ -397,12 +395,21 @@
 
       let annots = [];
 
+      // Filters out placements on alternative loci scaffolds, an advanced
+      // genome assembly feature we are not concerned with in ideograms.
+      //
+      // Example:
+      // https://mygene.info/v3/query?q=symbol:PTPRC&species=9606&fields=symbol,genomic_pos,name
+      const genomic_pos = gene.genomic_pos.filter(pos => {
+        return pos.chr in ideogram.chromosomes[ideogram.config.taxid]
+      })[0]
+
       let annot = {
         name: gene.symbol,
-        chr: gene.genomic_pos.chr,
-        start: gene.genomic_pos.start,
-        stop: gene.genomic_pos.end,
-        id: gene.genomic_pos.ensemblgene,
+        chr: genomic_pos.chr,
+        start: genomic_pos.start,
+        stop: genomic_pos.end,
+        id: genomic_pos.ensemblgene,
         color: 'red'
       };
       annots.push(annot)

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -256,6 +256,7 @@
 
       let annots = [];
       let geneList = Object.keys(interactions);
+      const pathwaysBase = 'https://www.wikipathways.org/index.php/Pathway:';
 
       if (geneList.length === 0) return annots
 
@@ -276,7 +277,20 @@
           color: 'purple'
         }
         annots.push(annot)
-        annotDescriptions[hit.symbol] = hit.name;
+
+        const ixns = interactions[hit.symbol];
+
+        const links = ixns.map(ixn => {
+          const url = `${pathwaysBase}${ixn.pathwayId}`
+          return `<a href="${url}" target="_blank">${ixn.name}</a>`;
+        }).join('<br/>')
+
+        const description = `
+          ${hit.name}<br/><br/>
+          Interacts in pathways:<br/>
+          ${links}`;
+
+        annotDescriptions[hit.symbol] = description;
       })
 
       return annots;

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -126,10 +126,17 @@
 
     var organism = 'org' in urlParams ? urlParams.org : 'homo-sapiens';
 
+    document.querySelector(`[value="${organism}"]`).selected = true;
+    document.querySelector('select').addEventListener('change', handleOrganism);
+
+    if ('q' in urlParams) {
+      document.querySelector('#search-genes').value = urlParams['q']
+    }
+
     document.querySelector('#search-button').addEventListener('click', handleSearch);
     document.querySelector('#search-genes').addEventListener('keyup', handleSearch);
 
-    document.querySelector('select').addEventListener('change', handleOrganism);
+    var ideogramFirstLoad = true;
 
     function parseUrlParams() {
       var rawParams = document.location.search;
@@ -147,10 +154,24 @@
       return urlParams;
     }
 
+    // Record app state in URL
+    function updateUrl() {
+      var params = Object.keys(urlParams).map(key => {
+        return key + '=' + urlParams[key];
+      }).join('&');
+      history.pushState(null, null, '?' + params);
+    }
+
     function handleOrganism() {
       document.querySelector('#search-genes').value = '';
       var selectedOrg = document.querySelector('option:checked').text;
-      selectedOrg = selectedOrg.split('(')[1].split(')')[0].toLowerCase();
+      selectedOrg =
+        selectedOrg.split('(')[1].split(')')[0]
+        .replace(/ /g, '-').toLowerCase();
+
+      urlParams['org'] = selectedOrg;
+      updateUrl();
+
       config.organism = selectedOrg;
       // var banded = !['homo sapiens', 'mus musculus'].includes(selectedOrg);
       // config.showFullyBanded = banded;
@@ -166,7 +187,20 @@
 
       // Handles "BRCA1,BRCA2", "BRCA1 BRCA2", and "BRCA1, BRCA2"
       let geneSymbols = searchInput.split(/[, ]/).filter(d => d !== '')
-      searchGenes(geneSymbols);
+
+      urlParams['q'] = geneSymbols;
+      updateUrl();
+
+      plotRelatedGenes(geneSymbols);
+    }
+
+    function plotGeneFromUrl() {
+      if (ideogramFirstLoad && 'q' in urlParams) {
+        ideogramFirstLoad = false;
+        console.log('ideogram')
+        console.log(ideogram)
+        plotRelatedGenes([urlParams['q']]);
+      }
     }
 
     ////
@@ -268,6 +302,10 @@
       let data = await fetchMyGeneInfo(queryString)
 
       data.hits.forEach(hit => {
+
+        // If hit lacks position, skip processing
+        if ('genomic_pos' in hit === false) return;
+
         annot = {
           name: hit.symbol,
           chr: hit.genomic_pos.chr,
@@ -336,7 +374,7 @@
       return annots;
     }
 
-    async function searchGenes(geneSymbols) {
+    async function plotRelatedGenes(geneSymbols) {
 
       // Refine style
       document.querySelectorAll('.chromosome').forEach(chromosome => {
@@ -383,7 +421,7 @@
     }
 
     function onClickAnnot(annot) {
-      searchGenes([annot.name]);
+      plotRelatedGenes([annot.name]);
     }
 
     function decorateGene(annot) {
@@ -422,6 +460,9 @@
       onClickAnnot: onClickAnnot,
       onWillShowAnnotTooltip: decorateGene
     }
+
+    config.onLoad = plotGeneFromUrl;
+
     var ideogram = new Ideogram(config);
   </script>
 </body>

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -136,8 +136,6 @@
     document.querySelector('#search-button').addEventListener('click', handleSearch);
     document.querySelector('#search-genes').addEventListener('keyup', handleSearch);
 
-    let ideogramFirstLoad = true;
-
     function parseUrlParams() {
       let rawParams = document.location.search;
       const urlParams = {};
@@ -163,7 +161,6 @@
     }
 
     function handleOrganism() {
-      document.querySelector('#search-genes').value = '';
       const selectedOrg =
         document.querySelector('option:checked').text
           .split('(')[1].split(')')[0]
@@ -175,7 +172,9 @@
       config.organism = selectedOrg;
       // const banded = !['homo sapiens', 'mus musculus'].includes(selectedOrg);
       // config.showFullyBanded = banded;
+      delete ideogram;
       ideogram = new Ideogram(config);
+
     }
 
     // Process text input for the "Search" field.
@@ -185,7 +184,7 @@
 
       const searchInput = event.target.value.trim();
 
-      // Handles "BRCA1,BRCA2", "BRCA1 BRCA2", and "BRCA1, BRCA2"
+      // Handles e.g. "BRCA1,BRCA2", "BRCA1 BRCA2", and "BRCA1, BRCA2"
       const geneSymbols = searchInput.split(/[, ]/).filter(d => d !== '')
       const geneSymbol = geneSymbols[0];
 
@@ -196,8 +195,7 @@
     }
 
     function plotGeneFromUrl() {
-      if (ideogramFirstLoad && 'q' in urlParams) {
-        ideogramFirstLoad = false;
+      if ('q' in urlParams) {
         plotRelatedGenes(urlParams['q']);
       }
     }
@@ -209,8 +207,6 @@
     ////
 
     fetchEnsembl = Ideogram.fetchEnsembl;
-
-    annotDescriptions = {}
 
     function onClickAnnot(annot) {
       document.querySelector('#search-genes').value = annot.name;
@@ -247,10 +243,10 @@
      * https://webservice.wikipathways.org/findInteractions?query=ACE2&format=json
      * https://webservice.wikipathways.org/findInteractions?query=RAD51&format=json
      */
-    async function fetchInteractingGenes(gene, organism) {
+    async function fetchInteractingGenes(gene) {
       let ixns = {};
       let seenNameIds = {}
-      const orgNameSimple = organism.replace(/-/g, ' ');
+      const orgNameSimple = ideogram.config.organism.replace(/-/g, ' ');
       const queryString = `?query=${gene.name}&format=json`
       const url =
         `https://webservice.wikipathways.org/findInteractions${queryString}`;
@@ -311,7 +307,6 @@
      */
     function describeInteractions(gene, ixns) {
       const pathwaysBase = 'https://www.wikipathways.org/index.php/Pathway:';
-
       const links = ixns.map(ixn => {
           const url = `${pathwaysBase}${ixn.pathwayId}`
           return `<a href="${url}" target="_blank">${ixn.name}</a>`;
@@ -347,14 +342,14 @@
         // If hit lacks position, skip processing
         if ('genomic_pos' in gene === false) return;
 
-        annot = parseAnnotFromMgiGene(gene, 'purple')
+        const annot = parseAnnotFromMgiGene(gene, 'purple')
         annots.push(annot)
 
         const ixns = interactions[gene.symbol];
 
         const description = describeInteractions(gene, ixns);
 
-        annotDescriptions[gene.symbol] = description;
+        ideogram.annotDescriptions[gene.symbol] = description;
       })
 
       return annots;
@@ -376,15 +371,15 @@
       homologIds = homologs.map(homolog => homolog.id)
       path = '/lookup/id/' + orgUnderscored;
       let body = {
-        'ids': homologIds,
-        'species': orgUnderscored,
-        'object_type': 'gene'
+        ids: homologIds,
+        species: orgUnderscored,
+        object_type: 'gene'
       }
       const ensemblHomologGenes = await fetchEnsembl(path, body, 'POST');
 
       Object.entries(ensemblHomologGenes).map((idGene, i) => {
         let gene = idGene[1]
-        annot = {
+        const annot = {
           name: gene.display_name,
           chr: gene.seq_region_name,
           start: gene.start,
@@ -394,7 +389,7 @@
         };
         // Add to start of array, so searched gene gets top z-index
         annots.unshift(annot);
-        annotDescriptions[annot.name] = gene.description;
+        ideogram.annotDescriptions[annot.name] = gene.description;
       })
 
       return annots;
@@ -418,7 +413,7 @@
         genomic_pos = gene.genomic_pos;
       }
 
-      let annot = {
+      const annot = {
         name: gene.symbol,
         chr: genomic_pos.chr,
         start: genomic_pos.start,
@@ -430,7 +425,15 @@
       return annot
     }
 
+    /**
+     * For given gene, finds and draws interacting genes and paralogs
+     *
+     * @param geneSymbol {String} Gene symbol, e.g. RAD51
+     */
     async function plotRelatedGenes(geneSymbol) {
+
+      ideogram.annotDescriptions = {}
+
       const ideoSel = ideogram.selector
       const annotSel = ideoSel + ' .annot';
       document.querySelectorAll(annotSel).forEach(el => el.remove());
@@ -454,14 +457,14 @@
       let data = await fetchMyGeneInfo(queryString)
 
       const gene = data.hits[0]
-      annotDescriptions[gene.symbol] = gene.name;
+      ideogram.annotDescriptions[gene.symbol] = gene.name;
 
       let annots = [];
 
-      annot = parseAnnotFromMgiGene(gene);
+      const annot = parseAnnotFromMgiGene(gene);
       annots.push(annot)
 
-      interactions = await fetchInteractingGenes(annot, organism);
+      interactions = await fetchInteractingGenes(annot);
       interactingAnnots = await fetchInteractingGeneAnnots(interactions)
       annots = annots.concat(interactingAnnots)
 
@@ -474,11 +477,14 @@
       document.querySelector('#_ideogramLegend').style = style;
     }
 
+    /**
+     * Enhance tooltip shown on hovering over gene annotation
+     */
     function decorateGene(annot) {
       const org = ideogram.getScientificName(ideogram.config.taxid);
       const term = `(${annot.name}[gene])+AND+(${org}[orgn])`;
       const url = `https://ncbi.nlm.nih.gov/gene/?term=${term}`;
-      const description = annotDescriptions[annot.name].split(' [')[0];
+      const description = ideogram.annotDescriptions[annot.name].split(' [')[0];
       annot.displayName =
         `<a target="_blank" href="${url}">${annot.name}</a>
         <br/>
@@ -500,6 +506,7 @@
 
     config = {
       organism: organism,
+      container: '#ideogram-container',
       chrWidth: 8,
       chrHeight: 90,
       chrLabelSize: 10,
@@ -513,7 +520,7 @@
 
     config.onLoad = plotGeneFromUrl;
 
-    const ideogram = new Ideogram(config);
+    let ideogram = new Ideogram(config);
   </script>
 </body>
 </html>

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -164,10 +164,10 @@
 
     function handleOrganism() {
       document.querySelector('#search-genes').value = '';
-      const selectedOrg = document.querySelector('option:checked').text;
-      selectedOrg =
-        selectedOrg.split('(')[1].split(')')[0]
-        .replace(/ /g, '-').toLowerCase();
+      const selectedOrg =
+        document.querySelector('option:checked').text
+          .split('(')[1].split(')')[0]
+          .replace(/ /g, '-').toLowerCase();
 
       urlParams['org'] = selectedOrg;
       updateUrl();
@@ -214,6 +214,8 @@
 
     function onClickAnnot(annot) {
       document.querySelector('#search-genes').value = annot.name;
+      urlParams['q'] = annot.name
+      updateUrl();
       plotRelatedGenes(annot.name);
     }
 
@@ -429,6 +431,11 @@
     }
 
     async function plotRelatedGenes(geneSymbol) {
+      const ideoSel = ideogram.selector
+      const annotSel = ideoSel + ' .annot';
+      document.querySelectorAll(annotSel).forEach(el => el.remove());
+
+      ideogram.startHideAnnotTooltipTimeout();
 
       // Refine style
       document.querySelectorAll('.chromosome').forEach(chromosome => {

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -211,6 +211,19 @@
 
     annotDescriptions = {}
 
+    function onClickAnnot(annot) {
+      plotRelatedGenes([annot.name]);
+    }
+
+    /**
+     * Determines if interaction node might be a gene
+     *
+     * Some interaction nodes are biological processes; this filters out many.
+     * Filtering these out makes downstream queries faster.
+     *
+     * ixn {Object} Interaction from WikiPathways
+     * gene {Object} Gene from MyGene.info
+     */
     function maybeGeneSymbol(ixn, gene) {
       return (
         ixn !== '' &&
@@ -233,28 +246,31 @@
     async function fetchInteractingGenes(gene, organism) {
       let ixns = {};
       let seenNameIds = {}
-      let orgNameSimple = organism.replace(/-/g, ' ');
+      const orgNameSimple = organism.replace(/-/g, ' ');
       const queryString = `?query=${gene.name}&format=json`
       const url =
         `https://webservice.wikipathways.org/findInteractions${queryString}`;
+
       response = await fetch(url)
       data = await response.json()
+
+      // For each interaction, get nodes immediately upstream and downstream.
+      // Filter out pathway nodes that are definitely not gene symbols, then
+      // group pathways by (likely) gene symbol. Each interacting gene can have
+      // multiple pathways.
       data.result.forEach(interaction => {
         if (interaction.species.toLowerCase() === orgNameSimple) {
-          var right = interaction.fields.right.values;
-          var left = interaction.fields.left.values;
-          var rawIxns = right.concat(left)
-          var name = interaction.name;
-          var id = interaction.id;
+          const right = interaction.fields.right.values;
+          const left = interaction.fields.left.values;
+          const rawIxns = right.concat(left)
+          const name = interaction.name;
+          const id = interaction.id;
 
           rawIxns.forEach(rawIxn => {
-            let nameId = name + id;
-            if (
-              maybeGeneSymbol(rawIxn, gene) &&
-              !(nameId in seenNameIds)
-            ) {
+            const nameId = name + id;
+            if (maybeGeneSymbol(rawIxn, gene) && !(nameId in seenNameIds)) {
               seenNameIds[nameId] = 1;
-              let ixn = {name: name, pathwayId: id}
+              const ixn = {name: name, pathwayId: id}
               if (rawIxn in ixns) {
                 ixns[rawIxn].push(ixn)
               } else {
@@ -285,7 +301,7 @@
     }
 
     /**
-     * Retrieves positions of interacting genes from MyGene.info
+     * Retrieves position and other data on interacting genes from MyGene.info
      */
     async function fetchInteractingGeneAnnots(interactions) {
 
@@ -302,22 +318,15 @@
         `?q=${ixnParam}&species=${taxid}&fields=symbol,genomic_pos,name`;
       const data = await fetchMyGeneInfo(queryString)
 
-      data.hits.forEach(hit => {
+      data.hits.forEach(gene => {
 
         // If hit lacks position, skip processing
-        if ('genomic_pos' in hit === false) return;
+        if ('genomic_pos' in gene === false) return;
 
-        annot = {
-          name: hit.symbol,
-          chr: hit.genomic_pos.chr,
-          start: hit.genomic_pos.start,
-          stop: hit.genomic_pos.end,
-          id: hit.genomic_pos.ensemblgene,
-          color: 'purple'
-        }
+        annot = parseAnnotFromMgiGene(gene, 'purple')
         annots.push(annot)
 
-        const ixns = interactions[hit.symbol];
+        const ixns = interactions[gene.symbol];
 
         const links = ixns.map(ixn => {
           const url = `${pathwaysBase}${ixn.pathwayId}`
@@ -325,11 +334,11 @@
         }).join('<br/>')
 
         const description = `
-          ${hit.name}<br/><br/>
+          ${gene.name}<br/><br/>
           Interacts in pathways:<br/>
           ${links}`;
 
-        annotDescriptions[hit.symbol] = description;
+        annotDescriptions[gene.symbol] = description;
       })
 
       return annots;
@@ -375,7 +384,37 @@
       return annots;
     }
 
-    async function plotRelatedGenes(geneSymbols) {
+    /**
+     * Transforms MyGene.info (MGI) gene into Ideogram annotation
+     */
+    function parseAnnotFromMgiGene(gene, color='red') {
+      // Filters out placements on alternative loci scaffolds, an advanced
+      // genome assembly feature we are not concerned with in ideograms.
+      //
+      // Example:
+      // https://mygene.info/v3/query?q=symbol:PTPRC&species=9606&fields=symbol,genomic_pos,name
+      let genomic_pos = null;
+      if (Array.isArray(gene.genomic_pos)) {
+        genomic_pos = gene.genomic_pos.filter(pos => {
+          return pos.chr in ideogram.chromosomes[ideogram.config.taxid]
+        })[0];
+      } else {
+        genomic_pos = gene.genomic_pos;
+      }
+
+      let annot = {
+        name: gene.symbol,
+        chr: genomic_pos.chr,
+        start: genomic_pos.start,
+        stop: genomic_pos.end,
+        id: genomic_pos.ensemblgene,
+        color: color
+      };
+
+      return annot
+    }
+
+    async function plotRelatedGenes(geneSymbol) {
 
       // Refine style
       document.querySelectorAll('.chromosome').forEach(chromosome => {
@@ -398,23 +437,7 @@
 
       let annots = [];
 
-      // Filters out placements on alternative loci scaffolds, an advanced
-      // genome assembly feature we are not concerned with in ideograms.
-      //
-      // Example:
-      // https://mygene.info/v3/query?q=symbol:PTPRC&species=9606&fields=symbol,genomic_pos,name
-      const genomic_pos = gene.genomic_pos.filter(pos => {
-        return pos.chr in ideogram.chromosomes[ideogram.config.taxid]
-      })[0]
-
-      let annot = {
-        name: gene.symbol,
-        chr: genomic_pos.chr,
-        start: genomic_pos.start,
-        stop: genomic_pos.end,
-        id: genomic_pos.ensemblgene,
-        color: 'red'
-      };
+      annot = parseAnnotFromMgiGene(gene);
       annots.push(annot)
 
       interactions = await fetchInteractingGenes(annot, organism);
@@ -428,10 +451,6 @@
       ideogram.drawAnnots(annots);
 
       document.querySelector('#_ideogramLegend').style = style;
-    }
-
-    function onClickAnnot(annot) {
-      plotRelatedGenes([annot.name]);
     }
 
     function decorateGene(annot) {

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -307,16 +307,25 @@
      * This comprises most of the content for tooltips for interacting genes.
      */
     function describeInteractions(gene, ixns) {
-      const pathwaysBase = 'https://www.wikipathways.org/index.php/Pathway:';
-      const links = ixns.map(ixn => {
-          const url = `${pathwaysBase}${ixn.pathwayId}`
-          return `<a href="${url}" target="_blank">${ixn.name}</a>`;
-        }).join('<br/>')
 
-      const description = `
-        ${gene.name}<br/><br/>
-        Interacts in pathways:<br/>
-        ${links}`;
+      let description = gene.name;
+
+      if (typeof ixns !== 'undefined') {
+        // ixns is undefined when querying e.g. CDKN1B in human
+        const pathwaysBase = 'https://www.wikipathways.org/index.php/Pathway:';
+        const links = ixns.map(ixn => {
+            const url = `${pathwaysBase}${ixn.pathwayId}`
+            return `<a href="${url}" target="_blank">${ixn.name}</a>`;
+          }).join('<br/>')
+
+        let pathwayText = 'pathway'
+        if (ixns.length > 1) pathwayText += 's'
+
+        description += `
+          <br/><br/>
+          Interacts in ${pathwayText}:<br/>
+          ${links}`;
+      }
 
       return description
     }

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -86,7 +86,7 @@
         <option value="macaca-fascicularis">Crab-eating macaque (Macaca fascicularis)</option>
         <option value="felis-catus">Cat (Felis catus)</option>
         <option value="canis-lupus-familiaris">Dog (Canis lupus familiaris)</option>
-        <option value="equus-caballus">Horse (Horse)</option>
+        <option value="equus-caballus">Horse (Equus caballus)</option>
         <option value="bos-taurus">Cow (Bos taurus)</option>
         <option value="sus-scrofa">Pig (Sus scrofa)</option>
         <!-- <option value="petromyzon-marinus">Lamprey (Petromyzon marinus)</option> -->
@@ -118,9 +118,18 @@
   <div id="ideogram-container"></div>
   <script type="text/javascript">
 
-    fetchEnsembl = Ideogram.fetchEnsembl;
+    ////
+    // Start example-specific handling
+    ///
 
-    annotDescriptions = {}
+    var urlParams = parseUrlParams();
+
+    var organism = 'org' in urlParams ? urlParams.org : 'homo-sapiens';
+
+    document.querySelector('#search-button').addEventListener('click', handleSearch);
+    document.querySelector('#search-genes').addEventListener('keyup', handleSearch);
+
+    document.querySelector('select').addEventListener('change', handleOrganism);
 
     function parseUrlParams() {
       var rawParams = document.location.search;
@@ -147,6 +156,28 @@
       // config.showFullyBanded = banded;
       ideogram = new Ideogram(config);
     }
+
+    // Process text input for the "Search" field.
+    function handleSearch(event) {
+      // Ignore non-"Enter" keyups
+      if (event.type === 'keyup' && event.keyCode !== 13) return;
+
+      var searchInput = event.target.value.trim();
+
+      // Handles "BRCA1,BRCA2", "BRCA1 BRCA2", and "BRCA1, BRCA2"
+      let geneSymbols = searchInput.split(/[, ]/).filter(d => d !== '')
+      searchGenes(geneSymbols);
+    }
+
+    ////
+    // End example-specific handling
+    //
+    // Start generic "Related genes" handling
+    ////
+
+    fetchEnsembl = Ideogram.fetchEnsembl;
+
+    annotDescriptions = {}
 
     function maybeGeneSymbol(ixn, gene) {
       return (
@@ -281,7 +312,6 @@
           start: gene.start,
           stop: gene.end,
           id: gene.id,
-          shape: 'triangle',
           color: 'pink'
         };
         // Add to start of array, so searched gene gets top z-index
@@ -338,18 +368,6 @@
       document.querySelector('#_ideogramLegend').style = style;
     }
 
-    // Process text input for the "Search" field.
-    function handleSearch(event) {
-      // Ignore non-"Enter" keyups
-      if (event.type === 'keyup' && event.keyCode !== 13) return;
-
-      var searchInput = event.target.value.trim();
-
-      // Handles "BRCA1,BRCA2", "BRCA1 BRCA2", and "BRCA1, BRCA2"
-      let geneSymbols = searchInput.split(/[, ]/).filter(d => d !== '')
-      searchGenes(geneSymbols);
-    }
-
     function onClickAnnot(annot) {
       searchGenes([annot.name]);
     }
@@ -367,19 +385,10 @@
       return annot
     }
 
-    var urlParams = parseUrlParams();
-
-    var organism = 'org' in urlParams ? urlParams.org : 'homo-sapiens';
-
-    document.querySelector('#search-button').addEventListener('click', handleSearch);
-    document.querySelector('#search-genes').addEventListener('keyup', handleSearch);
-
-    document.querySelector('select').addEventListener('change', handleOrganism);
-
     const shape = 'triangle';
 
     var legend = [{
-      name: 'Click gene to search',
+      name: '<b>Click gene to search</b>',
       rows: [
         {name: 'Interacting gene', color: 'purple', shape: shape},
         {name: 'Paralogous gene', color: 'pink', shape: shape},

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -220,7 +220,7 @@
     }
 
     /**
-     * Retrieve interacting genes from WikiPathways API
+     * Retrieves interacting genes from WikiPathways API
      *
      * Docs:
      * https://webservice.wikipathways.org/ui/
@@ -268,6 +268,15 @@
       return ixns;
     }
 
+    /**
+     * Queries MyGene.info API, returns parsed JSON
+     *
+     * Docs:
+     * https://docs.mygene.info/en/v3/
+     *
+     * Example:
+     * https://mygene.info/v3/query?q=symbol:cdk2%20OR%20symbol:brca1&species=9606&fields=symbol,genomic_pos,name
+     */
     async function fetchMyGeneInfo(queryString) {
       const myGeneBase = 'https://mygene.info/v3/query';
       let response = await fetch(myGeneBase + queryString);
@@ -277,12 +286,6 @@
 
     /**
      * Retrieves positions of interacting genes from MyGene.info
-     *
-     * Docs:
-     * https://docs.mygene.info/en/v3/
-     *
-     * Example:
-     * https://mygene.info/v3/query?q=symbol:cdk2%20OR%20symbol:brca1&species=9606&fields=symbol,genomic_pos,name
      */
     async function fetchInteractingGeneAnnots(interactions) {
 


### PR DESCRIPTION
This refines the "Related genes" example by linking to pathways in tooltips for interacting genes, auto-searching upon switching organisms, improving UX when clicking annotations, making searches linkable via URL, handling more edge cases, and refactoring code.

The improved tooltip lets users see how the gene interaction is biologically relevant, e.g.:
<img width="805" alt="agt_interacts_with_ace2_in_pathway_covid-19_aop_ideogram" src="https://user-images.githubusercontent.com/1334561/81497293-89e7ca00-928b-11ea-9452-2057dc8b228d.png">
