### PR TITLE
Fix ideogram width in various examples

### DIFF
--- a/examples/vanilla/annotations-track-filters.html
+++ b/examples/vanilla/annotations-track-filters.html
@@ -59,7 +59,7 @@
     organism: 'human',
     container: '#ideogram-container',
     chrHeight: 400,
-    chrMargin: 5,
+    chrMargin: 4,
     rotatable: false,
     annotationsLayout: 'heatmap',
     annotationsPath: '../../data/annotations/9_tracks_virtual_snvs.json',
@@ -125,7 +125,7 @@
         selectedTracks.push(trackIndex);
       }
     });
-    
+
     return selectedTracks;
   }
 
@@ -152,7 +152,7 @@
   }
 
   function updateIdeogram() {
-    
+
     var tracks = getSelectedTracks();
     var layout = document.querySelector('input[name=layout]:checked').id;
     var geometry = document.querySelector('input[name=geometry]:checked').id;
@@ -166,14 +166,14 @@
       return;
     }
     if (checkTracks() === false) return;
-    
+
     config.annotationsDisplayedTracks = tracks;
     config.annotationsLayout = layout;
     config.geometry = geometry;
 
     if (geometry === 'collinear') {
       config.orientation = 'horizontal';
-      config.chrHeight = 105;
+      config.chrHeight = 95;
       config.annotationHeight = 30;
       config.demarcateCollinearChromosomes = false;
     } else {

--- a/examples/vanilla/annotations-track-filters.html
+++ b/examples/vanilla/annotations-track-filters.html
@@ -66,6 +66,7 @@
     onLoadAnnots: createTrackFilters,
     annotationsNumTracks: 3,
     annotationsDisplayedTracks: [1, 5, 9],
+    geometry: 'parallel'
     // annotationsPath: '../../data/annotations/all_human_genes.json',
     // annotationsNumTracks: 2,
     // annotationsDisplayedTracks: [1, 2],

--- a/examples/vanilla/differential-expression.html
+++ b/examples/vanilla/differential-expression.html
@@ -618,7 +618,7 @@
   **/
   function getChrMargin(ideoWidth, numChrs, chrWidth) {
     var chrMargin;
-    const calcChrMargin = ideoWidth/numChrs - chrWidth - chrWidth * 1.8;
+    const calcChrMargin = ideoWidth/numChrs - chrWidth - chrWidth * 2;
     const maxChrMargin = 50;
     const minChrMargin = 13;
 

--- a/src/js/init/configure.js
+++ b/src/js/init/configure.js
@@ -56,7 +56,7 @@ function configureWidth(ideo) {
 }
 
 function configureMargin(ideo) {
-  if (ideo.config.geometry) {
+  if (ideo.config.geometry && ideo.config.geometry === 'collinear') {
     if ('chrMargin' in ideo.config === false) {
       ideo.config.chrMargin = 0;
     }
@@ -166,7 +166,6 @@ function configureTextStyle(ideo) {
  * Docs: https://github.com/eweitz/ideogram/blob/master/api.md
  */
 function configure(config) {
-
   // Clone the config object, to allow multiple instantiations
   // without picking up prior ideogram's settings
   this.config = JSON.parse(JSON.stringify(config));
@@ -183,7 +182,7 @@ function configure(config) {
   configureSingleChromosome(config, this);
   configureTextStyle(this);
   this.initAnnotSettings();
-  if ('geometry' in this.config === false) {
+  if (!this.config.geometry || this.config.geometry === 'parallel') {
     this.config.chrMargin += this.config.chrWidth;
     if (this.config.annotationsLayout === 'heatmap') {
       this.config.chrMargin += this.config.annotTracksHeight;

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -271,15 +271,13 @@ async function plotRelatedGenes(geneSymbol) {
   });
 
   const chrHeight = ideo.config.chrHeight;
-  const chrHeightPadded = chrHeight + 10;
-  let ideoLeft =
-    document.querySelector('#_ideogramInnerWrap').style['max-width'];
-  ideoLeft = parseInt(ideoLeft.slice(0, -2)) + chrHeightPadded;
-  var legendLeft = ideoLeft - chrHeightPadded - 40;
-
   const topPx = chrHeight + 30;
+  const leftPx =
+    Array.from(document.querySelectorAll('.chromosome-set'))
+      .slice(-1)[0].getBoundingClientRect().right;
+
   const style =
-    `float: left; position: relative; top: -${topPx}px; left: ${legendLeft}px;`;
+    `float: left; position: relative; top: -${topPx}px; left: ${leftPx}px;`;
 
   // Fetch positon of searched gene
   const taxid = ideo.config.taxid;

--- a/src/js/layouts/small-layout.js
+++ b/src/js/layouts/small-layout.js
@@ -125,7 +125,7 @@ class SmallLayout extends Layout {
 
   getChromosomeSetYTranslate(setIndex) {
     // Get additional padding caused by annotation tracks
-    var additionalPadding = this._getAdditionalOffset();
+    var additionalPadding = this._getAdditionalOffset() * 0.3;
     // If no detailed description provided just use one formula for all cases
     return (
       this.margin.left * (setIndex) + this._config.chrWidth +

--- a/test/offline/filter.test.js
+++ b/test/offline/filter.test.js
@@ -312,4 +312,35 @@ describe('Ideogram filter support', function() {
 
     ideogram = new Ideogram(config);
   });
+
+  it('should have expected width with explicit `geometry: "parallel"`', done => {
+    // Tests use case from ../examples/vanilla/annotations-track-filters.html
+    // Similar to "should filter heatmap tracks and show track labels", except
+    // one (now explicit) configuration option.
+
+    function callback() {
+      track1 = document.querySelector('#chr2-9606-canvas-0').getBoundingClientRect();
+      track2 = document.querySelector('#chr2-9606-canvas-1').getBoundingClientRect();
+      track3 = document.querySelector('#chr2-9606-canvas-2').getBoundingClientRect();
+
+      assert.equal(track1.x, 95);
+      assert.equal(track2.x, 104);
+      assert.equal(track3.x, 113);
+
+      done();
+    }
+
+    var config = {
+      organism: 'human',
+      annotationsPath: '../dist/data/annotations/9_tracks_virtual_snvs.json',
+      dataDir: '/dist/data/bands/native/',
+      annotationsNumTracks: 3,
+      annotationsDisplayedTracks: [1, 5, 9],
+      onDrawAnnots: callback,
+      annotationsLayout: 'heatmap',
+      geometry: 'parallel'
+    };
+
+    ideogram = new Ideogram(config);
+  });
 });


### PR DESCRIPTION
This fixes layout issues with ideogram width, due to bugs in edge cases of chromosome margin (`chrMargin`) calculations.