### PR TITLE
Enable downloading ideogram image

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -18,7 +18,7 @@ module.exports = function(config) {
       'src/js/index.js',
       'test/offline/**.test.js',
       'test/online/**.test.js',
-      // 'test/online/related-genes.test.js',
+      // 'test/offline/tools.test.js',
       {pattern: 'dist/data/**', watched: false, included: false, served: true, nocache: false}
     ],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3440,6 +3440,11 @@
         "void-elements": "^2.0.0"
       }
     },
+    "dom-to-image": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/dom-to-image/-/dom-to-image-2.6.0.tgz",
+      "integrity": "sha1-ilA2CAiMh7HCL5A0rgMuGJiVWGc="
+    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
     "d3-format": "^1.4.4",
     "d3-scale": "^3.2.1",
     "d3-selection": "^1.4.1",
-    "d3-transition": "^1.3.2",
-    "dom-to-image": "^2.6.0"
+    "d3-transition": "^1.3.2"
   },
   "devDependencies": {
     "@babel/core": "^7.9.6",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "d3-format": "^1.4.4",
     "d3-scale": "^3.2.1",
     "d3-selection": "^1.4.1",
-    "d3-transition": "^1.3.2"
+    "d3-transition": "^1.3.2",
+    "dom-to-image": "^2.6.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.6",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "d3-array": "^2.4.0",
     "d3-brush": "^1.1.5",
     "d3-dispatch": "^1.0.5",
-    "d3-format": "^1.4.4",
     "d3-fetch": "^1.1.2",
+    "d3-format": "^1.4.4",
     "d3-scale": "^3.2.1",
     "d3-selection": "^1.4.1",
     "d3-transition": "^1.3.2"

--- a/src/js/annotations/legend.js
+++ b/src/js/annotations/legend.js
@@ -68,7 +68,7 @@ function writeLegend(ideo) {
   for (i = 0; i < legend.length; i++) {
     list = legend[i];
     if ('name' in list) labels = '<span>' + list.name + '</span>';
-    svg = '<svg width="' + lineHeight + '">';
+    svg = '<svg id="_ideogramLegendSvg" width="' + lineHeight + '">';
     [labels, svg] = getListItems(labels, svg, list);
     svg += '</svg>';
     content += svg + '<ul>' + labels + '</ul>';

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -9,6 +9,7 @@ import * as d3dispatch from 'd3-dispatch';
 import * as d3format from 'd3-format';
 import {scaleLinear} from 'd3-scale';
 import {max} from 'd3-array';
+import domtoimage from 'dom-to-image';
 
 var d3 = Object.assign(
   {}, d3fetch, d3brush, d3dispatch, d3format
@@ -199,55 +200,76 @@ function parseRoman(s) {
 }
 
 function downloadPng(ideo) {
-  var ideoSvg = document.querySelector(ideo.selector);
-  var width = ideoSvg.width.baseVal.value + 30;
-  var canvas = document.createElement('canvas');
-  canvas.setAttribute('style', 'display: none');
-  canvas.setAttribute('id', 'canvas');
-  canvas.setAttribute('width', width);
-  document.body.appendChild(canvas);
 
-  function triggerDownload(imgURI) {
-    var evt = new MouseEvent('click', {
-      view: window,
-      bubbles: false,
-      cancelable: true
+  var ideoDom = document.querySelector(ideo.config.container).cloneNode(true);
+  ideoDom.getElementsByClassName('gearIcon')[0].remove()
+  console.log(ideoDom)
+  domtoimage.toPng(ideoDom)
+    .then(function(dataUrl) {
+      console.log('dataUrl')
+      console.log(dataUrl)
+      var link = document.createElement('a');
+      link.download = 'ideogram.png';
+      link.href = dataUrl;
+      link.click();
     });
 
-    var a = document.createElement('a');
-    a.setAttribute('download', 'ideogram.png');
-    a.setAttribute('href', imgURI);
-    a.setAttribute('target', '_blank');
+  // // var ideoSvg = document.querySelector(ideo.config.container + ' #_ideogramMiddleWrap');
+  // var ideoSvg = document.querySelector(ideo.selector);
+  // var width = ideoSvg.offsetWidth;
+  // console.log('width')
+  // console.log(width)
+  // var canvas = document.createElement('canvas');
+  // canvas.setAttribute('style', 'display: none');
+  // canvas.setAttribute('id', 'canvas');
+  // canvas.setAttribute('width', width);
+  // document.body.appendChild(canvas);
 
-    a.dispatchEvent(evt);
-  }
+  // function triggerDownload(imgUrl) {
+  //   var evt = new MouseEvent('click', {
+  //     view: window,
+  //     bubbles: false,
+  //     cancelable: true
+  //   });
+  //   console.log('imgUrl')
+  //   console.log(imgUrl)
+  //   var a = document.createElement('a');
+  //   a.setAttribute('download', 'ideogram.png');
+  //   a.setAttribute('href', imgUrl);
+  //   a.setAttribute('target', '_blank');
 
-  // btn.addEventListener('click', function () {
-  var canvas = document.getElementById('canvas');
-  canvas.width *= 2;
-  canvas.height *= 2;
-  var ctx = canvas.getContext('2d');
-  ctx.setTransform(2, 0, 0, 2, 0, 0);
-  ctx.imageSmoothingEnabled = false;
-  var data = (new XMLSerializer()).serializeToString(ideoSvg);
-  var DOMURL = window.URL || window.webkitURL || window;
+  //   a.dispatchEvent(evt);
+  // }
 
-  var img = new Image();
-  var svgBlob = new Blob([data], {type: 'image/svg+xml;charset=utf-8'});
-  var url = DOMURL.createObjectURL(svgBlob);
+  // // btn.addEventListener('click', function () {
+  // var canvas = document.getElementById('canvas');
+  // canvas.width *= 2;
+  // canvas.height *= 2;
+  // var ctx = canvas.getContext('2d');
+  // ctx.setTransform(2, 0, 0, 2, 0, 0);
+  // ctx.imageSmoothingEnabled = false;
+  // var data = (new XMLSerializer()).serializeToString(ideoSvg);
+  // var DOMURL = window.URL || window.webkitURL || window;
 
-  img.onload = function() {
-    ctx.drawImage(img, 0, 0);
-    DOMURL.revokeObjectURL(url);
+  // var img = new Image();
+  // var svgBlob = new Blob([data], {type: 'image/svg+xml;charset=utf-8'});
+  // var url = DOMURL.createObjectURL(svgBlob);
 
-    var imgURI = canvas
-      .toDataURL('image/png')
-      .replace('image/png', 'image/octet-stream');
+  // console.log('url')
+  // console.log(url)
 
-    triggerDownload(imgURI);
-  };
+  // img.onload = function() {
+  //   ctx.drawImage(img, 0, 0);
+  //   DOMURL.revokeObjectURL(url);
 
-  img.src = url;
+  //   var imgURI = canvas
+  //     .toDataURL('image/png')
+  //     .replace('image/png', 'image/octet-stream');
+
+  //   triggerDownload(imgURI);
+  // };
+
+  // img.src = url;
 }
 
 export {

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -201,9 +201,11 @@ function parseRoman(s) {
 function downloadPng(ideo) {
   var ideoSvg = document.querySelector(ideo.selector);
   var width = ideoSvg.width.baseVal.value + 30;
-  document.body.innerHTML +=
-    '<canvas style="display: none" id="canvas" width="' + width + '"></canvas>';
-  var canvas = document.querySelector('canvas');
+  var canvas = document.createElement('canvas');
+  canvas.setAttribute('style', 'display: none');
+  canvas.setAttribute('id', 'canvas');
+  canvas.setAttribute('width', width);
+  document.body.appendChild(canvas);
 
   function triggerDownload(imgURI) {
     var evt = new MouseEvent('click', {

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -9,7 +9,6 @@ import * as d3dispatch from 'd3-dispatch';
 import * as d3format from 'd3-format';
 import {scaleLinear} from 'd3-scale';
 import {max} from 'd3-array';
-import domtoimage from 'dom-to-image';
 
 var d3 = Object.assign(
   {}, d3fetch, d3brush, d3dispatch, d3format
@@ -200,76 +199,54 @@ function parseRoman(s) {
 }
 
 function downloadPng(ideo) {
+  var ideoSvg = document.querySelector(ideo.selector);
+  var width = ideoSvg.width.baseVal.value + 30;
+  var canvas = document.createElement('canvas');
+  canvas.setAttribute('style', 'display: none');
+  canvas.setAttribute('id', 'canvas');
+  canvas.setAttribute('width', width);
+  document.body.appendChild(canvas);
 
-  var ideoDom = document.querySelector(ideo.config.container).cloneNode(true);
-  ideoDom.getElementsByClassName('gearIcon')[0].remove()
-  console.log(ideoDom)
-  domtoimage.toPng(ideoDom)
-    .then(function(dataUrl) {
-      console.log('dataUrl')
-      console.log(dataUrl)
-      var link = document.createElement('a');
-      link.download = 'ideogram.png';
-      link.href = dataUrl;
-      link.click();
+  function triggerDownload(imgURI) {
+    var evt = new MouseEvent('click', {
+      view: window,
+      bubbles: false,
+      cancelable: true
     });
 
-  // // var ideoSvg = document.querySelector(ideo.config.container + ' #_ideogramMiddleWrap');
-  // var ideoSvg = document.querySelector(ideo.selector);
-  // var width = ideoSvg.offsetWidth;
-  // console.log('width')
-  // console.log(width)
-  // var canvas = document.createElement('canvas');
-  // canvas.setAttribute('style', 'display: none');
-  // canvas.setAttribute('id', 'canvas');
-  // canvas.setAttribute('width', width);
-  // document.body.appendChild(canvas);
+    var a = document.createElement('a');
+    a.setAttribute('download', 'ideogram.png');
+    a.setAttribute('href', imgURI);
+    a.setAttribute('target', '_blank');
 
-  // function triggerDownload(imgUrl) {
-  //   var evt = new MouseEvent('click', {
-  //     view: window,
-  //     bubbles: false,
-  //     cancelable: true
-  //   });
-  //   console.log('imgUrl')
-  //   console.log(imgUrl)
-  //   var a = document.createElement('a');
-  //   a.setAttribute('download', 'ideogram.png');
-  //   a.setAttribute('href', imgUrl);
-  //   a.setAttribute('target', '_blank');
+    a.dispatchEvent(evt);
+  }
 
-  //   a.dispatchEvent(evt);
-  // }
+  var canvas = document.getElementById('canvas');
+  canvas.width *= 2;
+  canvas.height *= 2;
+  var ctx = canvas.getContext('2d');
+  ctx.setTransform(2, 0, 0, 2, 0, 0);
+  ctx.imageSmoothingEnabled = false;
+  var data = (new XMLSerializer()).serializeToString(ideoSvg);
+  var DOMURL = window.URL || window.webkitURL || window;
 
-  // // btn.addEventListener('click', function () {
-  // var canvas = document.getElementById('canvas');
-  // canvas.width *= 2;
-  // canvas.height *= 2;
-  // var ctx = canvas.getContext('2d');
-  // ctx.setTransform(2, 0, 0, 2, 0, 0);
-  // ctx.imageSmoothingEnabled = false;
-  // var data = (new XMLSerializer()).serializeToString(ideoSvg);
-  // var DOMURL = window.URL || window.webkitURL || window;
+  var img = new Image();
+  var svgBlob = new Blob([data], {type: 'image/svg+xml;charset=utf-8'});
+  var url = DOMURL.createObjectURL(svgBlob);
 
-  // var img = new Image();
-  // var svgBlob = new Blob([data], {type: 'image/svg+xml;charset=utf-8'});
-  // var url = DOMURL.createObjectURL(svgBlob);
+  img.onload = function() {
+    ctx.drawImage(img, 0, 0);
+    DOMURL.revokeObjectURL(url);
 
-  // console.log('url')
-  // console.log(url)
+    var imgURI = canvas
+      .toDataURL('image/png')
+      .replace('image/png', 'image/octet-stream');
 
-  // img.onload = function() {
-  //   ctx.drawImage(img, 0, 0);
-  //   DOMURL.revokeObjectURL(url);
+    triggerDownload(imgURI);
+  };
 
-  //   var imgURI = canvas
-  //     .toDataURL('image/png')
-  //     .replace('image/png', 'image/octet-stream');
-
-  //   triggerDownload(imgURI);
-  // };
-
-  // img.src = url;
+  img.src = url;
 }
 
 export {

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -198,8 +198,58 @@ function parseRoman(s) {
   }, 0);
 }
 
+function downloadPng(ideo) {
+  var ideoSvg = document.querySelector(ideo.selector);
+  var width = ideoSvg.width.baseVal.value + 30;
+  document.body.innerHTML +=
+    '<canvas style="display: none" id="canvas" width="' + width + '"></canvas>';
+  var canvas = document.querySelector('canvas');
+
+  function triggerDownload(imgURI) {
+    var evt = new MouseEvent('click', {
+      view: window,
+      bubbles: false,
+      cancelable: true
+    });
+
+    var a = document.createElement('a');
+    a.setAttribute('download', 'ideogram.png');
+    a.setAttribute('href', imgURI);
+    a.setAttribute('target', '_blank');
+
+    a.dispatchEvent(evt);
+  }
+
+  // btn.addEventListener('click', function () {
+  var canvas = document.getElementById('canvas');
+  canvas.width *= 2;
+  canvas.height *= 2;
+  var ctx = canvas.getContext('2d');
+  ctx.setTransform(2, 0, 0, 2, 0, 0);
+  ctx.imageSmoothingEnabled = false;
+  var data = (new XMLSerializer()).serializeToString(ideoSvg);
+  var DOMURL = window.URL || window.webkitURL || window;
+
+  var img = new Image();
+  var svgBlob = new Blob([data], {type: 'image/svg+xml;charset=utf-8'});
+  var url = DOMURL.createObjectURL(svgBlob);
+
+  img.onload = function() {
+    ctx.drawImage(img, 0, 0);
+    DOMURL.revokeObjectURL(url);
+
+    var imgURI = canvas
+      .toDataURL('image/png')
+      .replace('image/png', 'image/octet-stream');
+
+    triggerDownload(imgURI);
+  };
+
+  img.src = url;
+}
+
 export {
   assemblyIsAccession, hasNonGenBankAssembly, hasGenBankAssembly, getDataDir,
   round, onDidRotate, getSvg, fetch, d3, getTaxid, getCommonName,
-  getScientificName, slug, isRoman, parseRoman
+  getScientificName, slug, isRoman, parseRoman, downloadPng
 };

--- a/src/js/tools/tools.js
+++ b/src/js/tools/tools.js
@@ -400,7 +400,7 @@ function initTools(ideo) {
 
   const toolsHtml = `
     ${style}
-    <div id="gear" class="gearIcon" style="display: none">${gearIcon}</div>
+    <div id="gear" style="display: none">${gearIcon}</div>
     <div id="tools" style="display: none">
       <ul>
         <li id="download-tool" class="ideo-tool-hover">Download ${triangle}</li>

--- a/src/js/tools/tools.js
+++ b/src/js/tools/tools.js
@@ -1,5 +1,6 @@
 // import {getSettings, handleSettingsHeaderClick} from './settings-ui';
 import version from '../version';
+import {downloadPng} from '../lib';
 
 const style = `
   <style>
@@ -269,7 +270,6 @@ function handleToolClick(ideo) {
   const toolHeaders = document.querySelectorAll('#tools > ul > li');
 
   toolHeaders.forEach(toolHeader => {
-
     const trigger = getTrigger(toolHeader);
 
     toolHeader.addEventListener(trigger, event => {
@@ -284,6 +284,14 @@ function handleToolClick(ideo) {
       if (trigger === 'mouseenter') {
         toolHeader.insertAdjacentHTML('beforeend', panel);
         handleHideForHoverables(trigger, tool, toolHeader, toolHeaders);
+
+        if (tool === 'download') {
+          document.querySelector('#download-image')
+            .addEventListener('click', event => {
+              closeTools();
+              downloadPng(ideo);
+            });
+        }
       } else {
         document.querySelector('#gear').insertAdjacentHTML('beforeend', panel);
       }
@@ -294,6 +302,7 @@ function handleToolClick(ideo) {
   document.querySelectorAll('#close').forEach(closeButton => {
     closeButton.addEventListener('click', () => {closeTools();});
   });
+
 }
 
 function handleGearClick(ideo) {
@@ -345,7 +354,7 @@ function getDownload(ideo) {
 
   return `
     <div id="download" class="ideo-tool-panel">
-      <li>Image</li>
+      <li id="download-image">Image</li>
       <li class="${annotsClass}">Annotation data</li>
     </div>
   `;

--- a/src/js/tools/tools.js
+++ b/src/js/tools/tools.js
@@ -400,7 +400,7 @@ function initTools(ideo) {
 
   const toolsHtml = `
     ${style}
-    <div id="gear" style="display: none">${gearIcon}</div>
+    <div id="gear" class="gearIcon" style="display: none">${gearIcon}</div>
     <div id="tools" style="display: none">
       <ul>
         <li id="download-tool" class="ideo-tool-hover">Download ${triangle}</li>

--- a/test/offline/tools.test.js
+++ b/test/offline/tools.test.js
@@ -108,10 +108,11 @@ describe('Ideogram should', function() {
 
         // Ensure the download link has a non-empty data URL
         // Implementation details are in downloadPng() in `lib.js`.
-        assert.equal(downloadedDataUrl > 100 === true);
-      }, 100);
+        assert.equal(downloadedDataUrl > 100, true);
 
-      done();
+        done();
+      }, 50);
+
     }
 
     config.onLoad = callback;

--- a/test/offline/tools.test.js
+++ b/test/offline/tools.test.js
@@ -101,7 +101,7 @@ describe('Ideogram should', function() {
       const downloadImageItem = document.getElementById('download-image');
       downloadImageItem.click();
 
-      // Tick clock infinitesimally (1 ms), to account for trivial async
+      // Briefly wait (100 ms), to account for trivial async
       setTimeout(function() {
         const selector = '#_ideogram-undisplayed-download-link';
         const downloadedDataUrl = document.querySelector(selector).href.length;
@@ -109,7 +109,7 @@ describe('Ideogram should', function() {
         // Ensure the download link has a non-empty data URL
         // Implementation details are in downloadPng() in `lib.js`.
         assert.equal(downloadedDataUrl > 100 === true);
-      }, 1);
+      }, 100);
 
       done();
     }

--- a/test/offline/tools.test.js
+++ b/test/offline/tools.test.js
@@ -85,4 +85,36 @@ describe('Ideogram should', function() {
     config.onLoad = callback;
     ideogram = new Ideogram(config);
   });
+
+  it('download image upon clicking "Download" -> "Image"', done => {
+
+    function callback() {
+      // Hover over ideogram, then click gear
+      d3.select('_ideogram').dispatch('mouseover');
+      const gear = document.getElementById('gear');
+      gear.click();
+
+      // Hover over "Download", then click "Image" in inner panel
+      const downloadTool = document.getElementById('download-tool');
+      const mouseenterEvent = new Event('mouseenter');
+      downloadTool.dispatchEvent(mouseenterEvent);
+      const downloadImageItem = document.getElementById('download-image');
+      downloadImageItem.click();
+
+      // Tick clock infinitesimally (1 ms), to account for trivial async
+      setTimeout(function() {
+        const selector = '#_ideogram-undisplayed-download-link';
+        const downloadedDataUrl = document.querySelector(selector).href.length;
+
+        // Ensure the download link has a non-empty data URL
+        // Implementation details are in downloadPng() in `lib.js`.
+        assert.equal(downloadedDataUrl > 100 === true);
+      }, 1);
+
+      done();
+    }
+
+    config.onLoad = callback;
+    ideogram = new Ideogram(config);
+  });
 });

--- a/test/offline/tools.test.js
+++ b/test/offline/tools.test.js
@@ -72,12 +72,14 @@ describe('Ideogram should', function() {
       const gear = document.getElementById('gear');
       gear.click();
 
+      // Hover over "Download" should show inner panel
       const downloadTool = document.getElementById('download-tool');
       const mouseenterEvent = new Event('mouseenter');
       downloadTool.dispatchEvent(mouseenterEvent);
       const downloadPanel = document.getElementById('download');
       assert.isDefined(downloadPanel);
 
+      // Click on "About" should show modal
       const aboutTool = document.getElementById('about-tool');
       aboutTool.click();
       const aboutPanel = document.getElementById('about');

--- a/test/offline/tools.test.js
+++ b/test/offline/tools.test.js
@@ -11,11 +11,7 @@ describe('Ideogram should', function() {
 
     config = {
       organism: 'human',
-      chrWidth: 10,
-      chrHeight: 150,
-      chrMargin: 10,
-      showChromosomeLabels: true,
-      orientation: 'vertical',
+      showTools: true,
       dataDir: '/dist/data/bands/native/'
     };
   });
@@ -34,7 +30,6 @@ describe('Ideogram should', function() {
       done();
     }
 
-    config.showTools = true;
     config.onLoad = callback;
     ideogram = new Ideogram(config);
   });
@@ -59,7 +54,6 @@ describe('Ideogram should', function() {
       done();
     }
 
-    config.showTools = true;
     config.onLoad = callback;
     ideogram = new Ideogram(config);
   });
@@ -88,7 +82,6 @@ describe('Ideogram should', function() {
       done();
     }
 
-    config.showTools = true;
     config.onLoad = callback;
     ideogram = new Ideogram(config);
   });


### PR DESCRIPTION
This implements PNG image download for ideograms, via the new tools UI (#230).

![download_image_ideogram](https://user-images.githubusercontent.com/1334561/93026590-03dee580-f5d5-11ea-8cf7-cd2760ffb428.gif)

