### PR TITLE
Further speed up and polish UI in "Related genes"

### DIFF
--- a/api.md
+++ b/api.md
@@ -34,9 +34,11 @@ var ideogram = new Ideogram({
 * [assembly](#assembly)
 * [barWidth](#barwidth)
 * [brush](#brush)
+* [chrBorderColor](#chrbordercolor)
 * [chrHeight](#chrheight)
 * [chrMargin](#chrmargin)
 * [chrWidth](#chrwidth)
+* [chrLabelColor](#chrlabelcolor)
 * [chrLabelSize](#chrlabelsize)
 * [chromosomes](#chromosomes)
 * [chromosomeScale](#chromosomescale)
@@ -126,6 +128,9 @@ Number.  Optional.  Default: 3.  The pixel width of bars drawn when `annotations
 ## brush
 String.  Optional.  Default: null.  Genomic coordinate range (e.g. "chr1:104325484-119977655") for a [brush](https://github.com/d3/d3-brush) on a chromosome.  Useful when ideogram consists of one chromosome and you want to be able to focus on a region within that chromosome, and create an interactive sliding window to other regions.  Example in [Brush](https://eweitz.github.io/ideogram/brush).
 
+## chrBorderColor
+String.  Optional.  Default: "#000".  The color of the border for each chromosome.
+
 ## chrHeight
 Number.  Optional.  Default: 400.  The pixel height of the tallest chromosome in the ideogram.  Examples in [Layout, small](https://eweitz.github.io/ideogram/layout_small) and [Annotations, basic](https://eweitz.github.io/ideogram/annotations-basic).
 
@@ -134,6 +139,9 @@ Number.  Optional.  Default: 10.  The pixel space of the margin between each chr
 
 ## chrWidth
 Number.  Optional.  Default: 10.  The pixel width of each chromosome.  Example in [Annotations, tracks](https://eweitz.github.io/ideogram/annotations-tracks).
+
+## chrLabelColor
+String. Optional.  Default: "#000".  The color of the label for each chromosome.
 
 ## chrLabelSize
 Number.  Optional.  Default: 9.  The pixel font size of chromosome labels.  Example in [Differential expression of genes](https://eweitz.github.io/ideogram/differential-expression).

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -116,7 +116,7 @@
       </span>
       <div style="font-size: 12px">
         Examples:
-        <a href="?q=BRCA1">BRCA1</a>,
+        <a href="?q=RAD51">RAD51</a>,
         <a href="?q=CD4">CD4</a>,
         <a href="?q=APOE">APOE</a>
       </div>

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -62,7 +62,7 @@
   <a href="differential-expression">Next</a> |
   <a href="https://github.com/eweitz/ideogram/blob/gh-pages/related-genes.html" target="_blank">Source</a>
   <p>
-    Find interacting pathway genes and paralogs.  Uses data from
+    Search a gene and find interacting pathway genes and paralogs.  Uses data from
     <a href="https://rest.ensembl.org">Ensembl</a>,
     <a href="https://www.wikipathways.org">WikiPathways</a>, and
     <a href="https://mygene.info">MyGene.info</a>.
@@ -110,10 +110,16 @@
   </div>
   <div style="float: left; width: 350px;">
     <label for="search-genes" id="search-container">
-      <input id="search-genes" autocomplete="off" placeholder="Search gene (e.g. RAD51)"/>
+      <input id="search-genes" autocomplete="off" placeholder="Search gene"/>
       <span id="search-button">
         <svg width="12" height="13"><g stroke-width="2" stroke="#FFF" fill="none"><path d="M11.29 11.71l-4-4"/><circle cx="5" cy="5" r="4"/></g></svg>
       </span>
+      <div style="font-size: 12px">
+        Examples:
+        <a href="?q=BRCA1">BRCA1</a>,
+        <a href="?q=CD4">CD4</a>,
+        <a href="?q=APOE">APOE</a>
+      </div>
     </label>
   </div>
   <br/><br/><br/>

--- a/src/js/annotations/legend.js
+++ b/src/js/annotations/legend.js
@@ -18,7 +18,7 @@ var legendStyle =
   '#_ideogramLegend li {float: none; margin: 0;}' +
   '#_ideogramLegend ul span {position: relative; left: -15px;} ';
 
-function getIcon(row) {
+function getIcon(row, ideo) {
   var icon, triangleAttrs, circleAttrs, rectAttrs,
     fill = 'fill="' + row.color + '" style="stroke: #AAA;"',
     shape = row.shape;
@@ -31,7 +31,12 @@ function getIcon(row) {
     if (shape === 'circle') {
       icon = '<path ' + circleAttrs + ' ' + fill + '></path>';
     } else if (shape === 'triangle') {
-      icon = '<path ' + triangleAttrs + ' ' + fill + '></path>';
+      var transform = '';
+      if (ideo.config.orientation === 'vertical') {
+        // Orient arrows in legend as they are in annotations
+        transform = ' transform="rotate(90, 7, 7)"';
+      }
+      icon = '<path ' + triangleAttrs + transform + ' ' + fill + '></path>';
     }
   } else {
     icon = '<rect ' + rectAttrs + ' ' + fill + '/>';
@@ -40,15 +45,17 @@ function getIcon(row) {
   return icon;
 }
 
-function getListItems(labels, svg, list, nameHeight) {
+function getListItems(labels, svg, list, nameHeight, ideo) {
   var i, icon, y, row;
+
   for (i = 0; i < list.rows.length; i++) {
     row = list.rows[i];
     labels += '<li>' + row.name + '</li>';
     y = lineHeight * i + nameHeight;
     if ('name' in list) y += lineHeight;
-    icon = getIcon(row);
-    svg += '<g transform="translate(0, ' + y + ')">' + icon + '</g>';
+    icon = getIcon(row, ideo);
+    const transform = 'translate(0, ' + y + ')';
+    svg += '<g transform="' + transform + '">' + icon + '</g>';
   }
 
   return [labels, svg];
@@ -72,7 +79,7 @@ function writeLegend(ideo) {
       labels = '<div>' + list.name + '</div>';
     }
     svg = '<svg id="_ideogramLegendSvg" width="' + lineHeight + '">';
-    [labels, svg] = getListItems(labels, svg, list, nameHeight);
+    [labels, svg] = getListItems(labels, svg, list, nameHeight, ideo);
     svg += '</svg>';
     content += svg + '<ul>' + labels + '</ul>';
   }

--- a/src/js/color.js
+++ b/src/js/color.js
@@ -19,10 +19,12 @@ export class Color {
   }
 
   getBorderColor(chrSetIndex, chrIndex, armIndex) {
-    if (chrIndex < this._config.ploidy) {
-      return '#000';
+    const config = this._config;
+    const color = config.chrBorderColor ? config.chrBorderColor : '#000';
+    if (chrIndex < config.ploidy) {
+      return color;
     } else if (this._ploidy.exists(chrSetIndex, chrIndex, armIndex)) {
-      return '#000';
+      return color;
     } else {
       return '#fff';
     }

--- a/src/js/ideogram.js
+++ b/src/js/ideogram.js
@@ -196,10 +196,17 @@ export default class Ideogram {
    */
   static async fetchEnsembl(path, body = null, method = 'GET') {
     const init = {
-      method: method,
-      headers: {'Content-Type': 'application/json'}
+      method: method
     };
     if (body !== null) init.body = JSON.stringify(body);
+    if (method === 'GET') {
+      // Use HTTP parameter, not header, to avoid needless OPTIONS request
+      const delimiter = path.includes('&') ? '&' : '?';
+      path += delimiter + 'content-type=application/json';
+    } else {
+      // Method is POST, so content-type must be defined in header
+      init.headers = {'Content-Type': 'application/json'};
+    }
     const response = await fetch(`https://rest.ensembl.org${path}`, init);
     const json = await response.json();
     return json;

--- a/src/js/init/configure.js
+++ b/src/js/init/configure.js
@@ -151,13 +151,13 @@ function configureBands(ideo) {
 
 let configuredCss = staticCss;
 function configureTextStyle(ideo) {
-  if (!ideo.config.chrLabelSize) {
-    ideo.config.chrLabelSize = 9;
-    return;
-  }
+  const config = ideo.config;
+  if (!config.chrLabelSize) ideo.config.chrLabelSize = 9;
+  if (!config.chrLabelColor) ideo.config.chrLabelColor = '#000';
 
-  const size = ideo.config.chrLabelSize;
-  configuredCss += `#_ideogram text {font-size: ${size}px}`;
+  const size = `font-size: ${config.chrLabelSize}px`;
+  const color = `fill: ${config.chrLabelColor}`;
+  configuredCss += `#_ideogram text {${size}; ${color};}`;
 }
 
 /**

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -107,6 +107,21 @@ async function fetchMyGeneInfo(queryString) {
   return data;
 }
 
+function parseNameAndEnsemblIdFromMgiGene(gene) {
+  const name = gene.name;
+  const id = gene.genomic_pos.ensemblgene;
+  let ensemblId = id;
+  if (typeof id === 'undefined') {
+    // Encountered in AKT3, when querying related genes for MTOR
+    // A 'chr'omosome value containing _ indicates an alt loci scaffold,
+    // so ignore that and take the Ensembl ID associated with the
+    // first position of a primary chromosome.
+    ensemblId =
+      gene.genomic_pos.filter(pos => !pos.chr.includes('_'))[0].ensemblgene;
+  }
+  return {name, ensemblId};
+}
+
 /**
  * Summarizes interactions for a gene
  *
@@ -137,17 +152,7 @@ function describeInteractions(gene, ixns) {
       ${links}`;
   }
 
-  const name = gene.name;
-  const id = gene.genomic_pos.ensemblgene;
-  let ensemblId = id;
-  if (typeof id === 'undefined') {
-    // Encountered in AKT3, when querying related genes for MTOR
-    // A 'chr'omosome value containing _ indicates an alt loci scaffold,
-    // so ignore that and take the Ensembl ID associated with the
-    // first position of a primary chromosome.
-    ensemblId =
-      gene.genomic_pos.filter(pos => !pos.chr.includes('_'))[0].ensemblgene;
-  }
+  const {name, ensemblId} = parseNameAndEnsemblIdFromMgiGene(gene);
   const type = 'interacting gene';
   const descriptionObj = {
     description, ensemblId, name, type, pathwayIds, pathwayNames
@@ -192,53 +197,99 @@ async function fetchInteractingGeneAnnots(interactions, ideo) {
   return annots;
 }
 
-/**
- * Fetch paralogs of searched gene
- */
-async function fetchParalogPositions(annot, ideo) {
+// Commented out because call to Ensembl threw false-positive 400 error
+// Also had historically been slow, and included an extraneous OPTIONS
+// request that would often double effective response time.
+//
+// See alternative in fetchParalogPositionsFromMyGeneInfo
+//
+// /** Fetch positions of paralogs from Ensembl REST API */
+// async function fetchParalogPositionsFromEnsembl(homologs, ideo) {
+//   const annots = [];
+//   const orgUnderscored = ideo.config.organism.replace(/[ -]/g, '_');
+
+//   const homologIds = homologs.map(homolog => homolog.id);
+//   const path = '/lookup/id/' + orgUnderscored;
+//   const body = {
+//     ids: homologIds,
+//     species: orgUnderscored,
+//     object_type: 'gene'
+//   };
+//   const ensemblHomologGenes =
+//     await Ideogram.fetchEnsembl(path, body, 'POST');
+
+//   Object.entries(ensemblHomologGenes).map((idGene, i) => {
+//     const gene = idGene[1];
+
+//     // Seen in related genes for SIRT2 in Pan troglodytes
+//     if ('display_name' in gene === false) return;
+
+//     const annot = {
+//       name: gene.display_name,
+//       chr: gene.seq_region_name,
+//       start: gene.start,
+//       stop: gene.end,
+//       id: gene.id,
+//       color: 'pink'
+//     };
+
+//     annots.push(annot);
+//     const description = gene.description;
+//     const ensemblId = gene.id;
+//     const name = gene.description.split(' [')[0];
+//     const type = 'paralogous gene';
+//     const descriptionObj = {description, ensemblId, name, type};
+//     ideo.annotDescriptions.annots[annot.name] = descriptionObj;
+//   });
+
+//   return annots;
+// }
+
+/** Fetch paralog positions from MyGeneInfo */
+async function fetchParalogPositionsFromMyGeneInfo(homologs, ideo) {
   const annots = [];
+  const qParam = homologs.map(homolog => {
+    return `ensemblgene:${homolog.id}`;
+  }).join(' OR ');
+
   const taxid = ideo.config.taxid;
-  const orgUnderscored = ideo.config.organism.replace(/[ -]/g, '_');
+  const queryString =
+    `?q=${qParam}&species=${taxid}&fields=symbol,genomic_pos,name`;
+  const data = await fetchMyGeneInfo(queryString);
 
-  // Fetch paralogs
-  const params = `&format=condensed&type=paralogues&target_taxon=${taxid}`;
-  let path = `/homology/id/${annot.id}?${params}`;
-  const ensemblHomologs = await Ideogram.fetchEnsembl(path);
-  const homologs = ensemblHomologs.data[0].homologies;
+  data.hits.forEach(gene => {
 
-  // Fetch positions of paralogs
-  const homologIds = homologs.map(homolog => homolog.id);
-  path = '/lookup/id/' + orgUnderscored;
-  const body = {
-    ids: homologIds,
-    species: orgUnderscored,
-    object_type: 'gene'
-  };
-  const ensemblHomologGenes = await Ideogram.fetchEnsembl(path, body, 'POST');
+    // If hit lacks position, skip processing
+    if ('genomic_pos' in gene === false) return;
+    if ('name' in gene === false) return;
 
-  Object.entries(ensemblHomologGenes).map((idGene, i) => {
-    const gene = idGene[1];
-
-    // Seen in related genes for SIRT2 in Pan troglodytes
-    if ('display_name' in gene === false) return;
-
-    const annot = {
-      name: gene.display_name,
-      chr: gene.seq_region_name,
-      start: gene.start,
-      stop: gene.end,
-      id: gene.id,
-      color: 'pink'
-    };
-
+    const annot = parseAnnotFromMgiGene(gene, ideo, 'pink');
     annots.push(annot);
-    const description = gene.description;
-    const ensemblId = gene.id;
-    const name = gene.description.split(' [')[0];
+
+    const description = gene.name;
+    const {name, ensemblId} = parseNameAndEnsemblIdFromMgiGene(gene);
     const type = 'paralogous gene';
     const descriptionObj = {description, ensemblId, name, type};
     ideo.annotDescriptions.annots[annot.name] = descriptionObj;
   });
+
+  return annots;
+}
+
+/**
+ * Fetch paralogs of searched gene
+ */
+async function fetchParalogs(annot, ideo) {
+  const taxid = ideo.config.taxid;
+
+  // Fetch paralogs
+  const params = `&format=condensed&type=paralogues&target_taxon=${taxid}`;
+  const path = `/homology/id/${annot.id}?${params}`;
+  const ensemblHomologs = await Ideogram.fetchEnsembl(path);
+  const homologs = ensemblHomologs.data[0].homologies;
+
+  // Fetch positions of paralogs
+  const annots = await fetchParalogPositionsFromMyGeneInfo(homologs, ideo);
 
   return annots;
 }
@@ -305,9 +356,10 @@ function processInteractions(annot, ideoInnerDom, ideo) {
   });
 }
 
+/** Find and draw paralogs, return Promise for annots */
 function processParalogs(annot, ideoInnerDom, ideo) {
   return new Promise(async (resolve) => {
-    const annots = await fetchParalogPositions(annot, ideo);
+    const annots = await fetchParalogs(annot, ideo);
     ideo.relatedAnnots.push(...annots);
     finishPlotRelatedGenes(ideoInnerDom, ideo);
     resolve();
@@ -374,8 +426,8 @@ async function plotRelatedGenes(geneSymbol) {
     const legendWidth = 140;
     ideoInnerDom.style.maxWidth =
       (parseInt(ideoInnerDom.style.maxWidth) + legendWidth) + 'px';
-    ideoDom.style.minWidth =
-      (parseInt(ideoDom.style.minWidth) + legendWidth) + 'px';
+    ideoDom.style.maxWidth =
+      (parseInt(ideoDom.style.minWidth)) + 'px';
     ideoDom.style.position = 'relative';
     ideoDom.style.left = legendWidth + 'px';
 

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -418,6 +418,7 @@ async function plotRelatedGenes(geneSymbol) {
   ideoInnerDom.style.marginLeft = 'auto';
   ideoInnerDom.style.marginRight = 'auto';
   ideoInnerDom.style.overflowY = 'hidden';
+  document.querySelector('#_ideogramMiddleWrap').style.overflowY = 'hidden';
 
   if (typeof ideo.didAdjustIdeogramLegend === 'undefined') {
     // Accounts for moving legend when external content at left or right

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -496,6 +496,7 @@ function _initRelatedGenes(config, annotsInList) {
     rotatable: false,
     legend: legend,
     chrBorderColor: '#333',
+    chrLabelColor: '#333',
     onWillShowAnnotTooltip: decorateGene,
     annotsInList: annotsInList
   });

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -318,7 +318,11 @@ function processParalogs(annot, ideoInnerDom, ideo) {
 function finishPlotRelatedGenes(ideoInnerDom, ideo) {
   let annots = ideo.relatedAnnots.slice();
   annots = applyAnnotsIncludeList(annots, ideo);
-  annots.sort((a, b) => {return b.name.length - a.name.length;});
+  annots.sort((a, b) => {
+    if (b.color === 'red') return -1;
+    if (b.color === 'purple' && a.color === 'pink') return -1;
+    return b.name.length - a.name.length;
+  });
   ideo.drawAnnots(annots);
   moveLegend(ideoInnerDom);
 }

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -519,7 +519,7 @@ const legend = [{
   name: `
     <div style="position: relative; left: -15px; padding-bottom: 10px;">
       <div style="${legendHeaderStyle}">Related genes</div>
-      <i>Click gene to search</i>
+      <i>Click gene to explore</i>
     </div>
   `,
   nameHeight: 30,

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -461,10 +461,12 @@ function decorateGene(annot) {
 
 const shape = 'triangle';
 
+const legendHeaderStyle =
+  'font-size: 14px; font-weight: bold; font-color: #333';
 const legend = [{
   name: `
     <div style="position: relative; left: -15px; padding-bottom: 10px;">
-      <div style="font-size: 14px; font-weight: bold;">Related genes</div>
+      <div style="${legendHeaderStyle}">Related genes</div>
       <i>Click gene to search</i>
     </div>
   `,
@@ -493,6 +495,7 @@ function _initRelatedGenes(config, annotsInList) {
     showFullyBanded: false,
     rotatable: false,
     legend: legend,
+    chrBorderColor: '#333',
     onWillShowAnnotTooltip: decorateGene,
     annotsInList: annotsInList
   });


### PR DESCRIPTION
This improves performance and user interface in the "Related genes" kit and example.

# Performance
Building on #243, which parallelized requests, these changes optimize performance through fewer requests and faster APIs.

#### Fewer requests
Defining content-type in a URL parameter instead of an HTTP header cuts out an extraneous preflight CORS OPTIONS request in a GET to fetch paralogs from Ensembl REST API.

#### Faster APIs
Replacing Ensembl REST API with MyGene.info's REST API made gene position lookups much faster.

Ensembl REST API requires using a [POST to lookup/id](https://rest.ensembl.org/documentation/info/lookup_post) to fetch multiple gene positions.  These can be quite slow: sometimes taking 2 seconds, other times 15 seconds or more for the same parameters.  

The POSTs also lack ways to omit preflight requests, because, [as documented](https://github.com/Ensembl/ensembl-rest/wiki/Output-formats#types), Ensembl REST API only supports defining POST `Content-Type` in HTTP headers.  This makes POSTs for JSON not [simple requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Simple_requests), which means each POST to Ensembl must have an additional preceding OPTIONS request.

[MyGene.info has a comparable API](https://docs.mygene.info/) that is much faster.  Swapping it in yields snappy lookups for gene positions, typically less than 0.5 seconds -- between 4x and 30x faster than Ensembl.

# User interface

Suggested UI refinements are included:
* Chromosome labels and borders have softer colors
* Extraneous scrolling is gone
* Legend icon rotation matches chromosome annotations

Also, clickable gene search examples have been added below the search box, and coloring options for `chrBorderColor` and `chrLabelColor` are now available as Ideogram API options.

# Screenshots
Screenshots below show these performance and UI enhancements.

#### Before
<img width="1440" alt="related_genes_before_refinement_ideogram_2020-10-12" src="https://user-images.githubusercontent.com/1334561/95748011-5dcfdb00-0c67-11eb-86be-327949eb08a5.png">

#### After
<img width="1440" alt="related_genes_after_refinement_ideogram_2020-10-12" src="https://user-images.githubusercontent.com/1334561/95748055-6fb17e00-0c67-11eb-8b4f-28d44e20d5d1.png">
