### PR TITLE
Refine handling of Ensembl outages in related genes kit

### DIFF
--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -51,6 +51,10 @@
     #ideogram .annot path {
       cursor: pointer;
     }
+
+    #ideogram-container #_ideogramInnerWrap {
+      visibility: hidden;
+    }
   </style>
   <script type="text/javascript" src="../../dist/js/ideogram.min.js"></script>
 <link rel="icon" type="image/x-icon" href="img/ideogram_favicon.ico">
@@ -215,7 +219,15 @@
       document.querySelector('#search-genes').value = annot.name;
       urlParams['q'] = annot.name;
       updateUrl();
+
+      const selector = '#ideogram-container #_ideogramInnerWrap'
+      document.querySelector(selector).style.visibility = 'hidden';
       ideogram.plotRelatedGenes(annot.name);
+    }
+
+    function showIdeogram() {
+      const selector = '#ideogram-container #_ideogramInnerWrap'
+      document.querySelector(selector).style.visibility = 'visible';
     }
 
     config = {
@@ -227,6 +239,7 @@
       annotationHeight: 7,
       onClickAnnot: onClickAnnot,
       onLoad: plotGeneFromUrl,
+      onFindRelatedGenes: showIdeogram,
       onPlotRelatedGenes: reportRelatedGenes
     }
 

--- a/src/js/ideogram.js
+++ b/src/js/ideogram.js
@@ -207,9 +207,20 @@ export default class Ideogram {
       // Method is POST, so content-type must be defined in header
       init.headers = {'Content-Type': 'application/json'};
     }
+
+    // const random = Math.random();
+    // console.log(random)
+    // if (random < 0.5) {
     const response = await fetch(`https://rest.ensembl.org${path}`, init);
     const json = await response.json();
     return json;
+    // } else {
+    //   // Mock error
+    //   init.headers = {'Content-Type': 'application/json'};
+    //   const response = await fetch('https://httpstat.us/500/cors', init);
+    //   const json = await response.json();
+    //   return json;
+    // }
   }
 
   /**

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -379,6 +379,9 @@ function finishPlotRelatedGenes(ideoInnerDom, ideo) {
     if (b.color === 'purple' && a.color === 'pink') return -1;
     return b.name.length - a.name.length;
   });
+  if (annots.length > 1 && ideo.onFindRelatedGenesCallback) {
+    ideo.onFindRelatedGenesCallback();
+  }
   ideo.drawAnnots(annots);
   moveLegend(ideoInnerDom);
 }
@@ -594,6 +597,10 @@ function _initRelatedGenes(config, annotsInList) {
 
   if (config.onPlotRelatedGenes) {
     ideogram.onPlotRelatedGenesCallback = config.onPlotRelatedGenes;
+  }
+
+  if (config.onFindRelatedGenes) {
+    ideogram.onFindRelatedGenesCallback = config.onFindRelatedGenes;
   }
 
   return ideogram;


### PR DESCRIPTION
This enables the related genes ideogram to be shown only when a paralog or related gene is actually found.