### PR TITLE
Enable richer analytics for related genes

### DIFF
--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -221,6 +221,13 @@
       ideogram.plotRelatedGenes(annot.name);
     }
 
+    function onWillShowAnnotTooltip(annot) {
+      const ideo = this;
+      const tooltipAnalytics = ideo.getTooltipAnalytics(annot, ideo);
+      console.log(tooltipAnalytics);
+      return annot
+    }
+
     config = {
       organism: organism,
       container: '#ideogram-container',
@@ -228,9 +235,10 @@
       chrHeight: 100,
       chrLabelSize: 12,
       annotationHeight: 7,
-      onClickAnnot: onClickAnnot,
       onLoad: plotGeneFromUrl,
-      onPlotRelatedGenes: reportRelatedGenes
+      onPlotRelatedGenes: reportRelatedGenes,
+      onWillShowAnnotTooltip,
+      onClickAnnot
     }
 
     // annotsInList = ['CDK9', 'CDK19', 'CDK1'];

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -52,9 +52,6 @@
       cursor: pointer;
     }
 
-    #ideogram-container #_ideogramInnerWrap {
-      visibility: hidden;
-    }
   </style>
   <script type="text/javascript" src="../../dist/js/ideogram.min.js"></script>
 <link rel="icon" type="image/x-icon" href="img/ideogram_favicon.ico">
@@ -221,13 +218,7 @@
       updateUrl();
 
       const selector = '#ideogram-container #_ideogramInnerWrap'
-      document.querySelector(selector).style.visibility = 'hidden';
       ideogram.plotRelatedGenes(annot.name);
-    }
-
-    function showIdeogram() {
-      const selector = '#ideogram-container #_ideogramInnerWrap'
-      document.querySelector(selector).style.visibility = 'visible';
     }
 
     config = {
@@ -239,7 +230,6 @@
       annotationHeight: 7,
       onClickAnnot: onClickAnnot,
       onLoad: plotGeneFromUrl,
-      onFindRelatedGenes: showIdeogram,
       onPlotRelatedGenes: reportRelatedGenes
     }
 

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -223,7 +223,7 @@
 
     function onWillShowAnnotTooltip(annot) {
       const ideo = this;
-      const tooltipAnalytics = ideo.getTooltipAnalytics(annot, ideo);
+      const tooltipAnalytics = ideo.getTooltipAnalytics(annot);
       console.log(tooltipAnalytics);
       return annot
     }

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -178,7 +178,7 @@
       // const banded = !['homo sapiens', 'mus musculus'].includes(selectedOrg);
       // config.showFullyBanded = banded;
       delete ideogram;
-      ideogram = new Ideogram(config);
+      ideogram = Ideogram.initRelatedGenes(config);
 
     }
 
@@ -244,7 +244,7 @@
     // annotsInList = ['CDK9', 'CDK19', 'CDK1'];
     // let ideogram = Ideogram.initRelatedGenes(config, annotsInList)
 
-    let ideogram = Ideogram.initRelatedGenes(config)
+    let ideogram = Ideogram.initRelatedGenes(config);
   </script>
 </body>
 </html>

--- a/src/js/ideogram.js
+++ b/src/js/ideogram.js
@@ -61,7 +61,7 @@ import {
 } from './views/chromosome-labels.js';
 
 import {
-  _initRelatedGenes, plotRelatedGenes
+  _initRelatedGenes, plotRelatedGenes, getRelatedGenesByType
 } from './kit/related-genes';
 
 export default class Ideogram {
@@ -168,6 +168,7 @@ export default class Ideogram {
     this.setOverflowScroll = setOverflowScroll;
 
     this.plotRelatedGenes = plotRelatedGenes;
+    this.getRelatedGenesByType = getRelatedGenesByType;
 
     this.configure(config);
   }

--- a/src/js/init/init.js
+++ b/src/js/init/init.js
@@ -263,6 +263,9 @@ function init(ideo) {
         ideo.config.taxid = taxid;
         ideo.config.taxids = taxids;
 
+        ideo.organismScientificName =
+          ideo.getScientificName(ideo.config.taxid);
+
         var t0 = new Date().getTime();
         getBandsAndPrepareContainer(taxids, t0, ideo);
 

--- a/src/js/kit/analyze-related-genes.js
+++ b/src/js/kit/analyze-related-genes.js
@@ -15,7 +15,8 @@ function initAnalyzeRelatedGenes(ideo) {
   }
 }
 
-function getRelatedGenesByType(ideo) {
+function getRelatedGenesByType() {
+  const ideo = this;
   const relatedGenes = ideo.annotDescriptions.annots;
 
   const related = Object.values(relatedGenes);
@@ -46,7 +47,7 @@ function analyzePlotTimes(type, ideo) {
     paralogous: 'interacting',
     interacting: 'paralogous'
   };
-  const related = getRelatedGenesByType(ideo);
+  const related = ideo.getRelatedGenesByType();
   const otherType = otherTypes[type];
   const numThisRelated = related[type].length;
   const numOtherRelated = related[otherType] ? related[otherType].length : 0;
@@ -90,7 +91,7 @@ function analyzePlotTimes(type, ideo) {
 
 /** Summarizes number and kind of related genes, performance, etc. */
 function analyzeRelatedGenes(ideo) {
-  const related = getRelatedGenesByType(ideo);
+  const related = ideo.getRelatedGenesByType();
 
   const numRelatedGenes = related['related'].length;
   const numParalogs = related['paralogous'].length;
@@ -115,5 +116,6 @@ function analyzeRelatedGenes(ideo) {
 }
 
 export {
-  initAnalyzeRelatedGenes, analyzePlotTimes, analyzeRelatedGenes, timeDiff
+  initAnalyzeRelatedGenes, analyzePlotTimes, analyzeRelatedGenes, timeDiff,
+  getRelatedGenesByType
 };

--- a/src/js/kit/analyze-related-genes.js
+++ b/src/js/kit/analyze-related-genes.js
@@ -28,7 +28,8 @@ function getRelatedGenesByType() {
   return {related, paralogous, interacting, searched};
 }
 
-function getRelatedGenesTooltipAnalytics(annot, ideo) {
+function getRelatedGenesTooltipAnalytics(annot) {
+  const ideo = this;
 
   const tooltipGene = annot.name;
 

--- a/src/js/kit/analyze-related-genes.js
+++ b/src/js/kit/analyze-related-genes.js
@@ -28,6 +28,23 @@ function getRelatedGenesByType() {
   return {related, paralogous, interacting, searched};
 }
 
+function getRelatedGenesTooltipAnalytics(annot, ideo) {
+
+  const tooltipGene = annot.name;
+
+  // e.g. "interacting gene" -> "interacting"
+  const tooltipRelatedType =
+    ideo.annotDescriptions.annots[annot.name].type.split(' ')[0];
+
+  const countsByType = getCountsByType(ideo);
+
+  const analytics = Object.assign(
+    {tooltipGene, tooltipRelatedType}, countsByType
+  );
+
+  return analytics;
+}
+
 /** Compute granular related genes plotting analytics */
 function analyzePlotTimes(type, ideo) {
   // Paralogs and interacting genes:
@@ -89,14 +106,23 @@ function analyzePlotTimes(type, ideo) {
   }
 }
 
-/** Summarizes number and kind of related genes, performance, etc. */
-function analyzeRelatedGenes(ideo) {
+function getCountsByType(ideo) {
   const related = ideo.getRelatedGenesByType();
 
   const numRelatedGenes = related['related'].length;
   const numParalogs = related['paralogous'].length;
   const numInteractingGenes = related['interacting'].length;
   const searchedGene = related['searched'];
+
+  return {
+    numRelatedGenes, numParalogs, numInteractingGenes, searchedGene
+  };
+}
+
+/** Summarizes number and kind of related genes, performance, etc. */
+function analyzeRelatedGenes(ideo) {
+
+  const countsByType = getCountsByType(ideo);
 
   const timeTotal = ideo.time.rg.total;
   const timeTotalFirstPlot = ideo.time.rg.totalFirstPlot;
@@ -106,16 +132,16 @@ function analyzeRelatedGenes(ideo) {
   const timeSearchedGene = ideo.time.rg.searchedGene;
   const firstPlotType = ideo._relatedGenesFirstPlotType;
 
-  ideo.relatedGenesAnalytics = {
-    searchedGene,
+  const analytics = Object.assign({
     firstPlotType,
-    numRelatedGenes, numParalogs, numInteractingGenes,
     timeTotal, timeTotalFirstPlot, timeTotalLastPlotDiff,
     timeSearchedGene, timeInteractingGenes, timeParalogs
-  };
+  }, countsByType);
+
+  ideo.relatedGenesAnalytics = analytics;
 }
 
 export {
   initAnalyzeRelatedGenes, analyzePlotTimes, analyzeRelatedGenes, timeDiff,
-  getRelatedGenesByType
+  getRelatedGenesByType, getRelatedGenesTooltipAnalytics
 };

--- a/src/js/kit/analyze-related-genes.js
+++ b/src/js/kit/analyze-related-genes.js
@@ -1,0 +1,119 @@
+/** Get time in milliseconds between a start time (t0) and now */
+function timeDiff(t0) {
+  return Math.round(performance.now() - t0);
+}
+
+/** Initialize performance analysis settings */
+function initAnalyzeRelatedGenes(ideo) {
+  ideo.time = {
+    rg: { // times for related genes
+      t0: performance.now()
+    }
+  };
+  if ('_didRelatedGenesFirstPlot' in ideo) {
+    delete ideo._didRelatedGenesFirstPlot;
+  }
+}
+
+function getRelatedGenesByType(ideo) {
+  const relatedGenes = ideo.annotDescriptions.annots;
+
+  const related = Object.values(relatedGenes);
+  const paralogous = related.filter(r => r.type === 'paralogous gene');
+  const interacting = related.filter(r => r.type === 'interacting gene');
+  const searched = Object.entries(relatedGenes)
+    .filter((entry) => entry[1].type === 'searched gene')[0][0];
+
+  return {related, paralogous, interacting, searched};
+}
+
+/** Compute granular related genes plotting analytics */
+function analyzePlotTimes(type, ideo) {
+  // Paralogs and interacting genes:
+  // http://localhost:8080/examples/vanilla/related-genes?q=RAD51
+  //
+  // No paralogs:
+  // http://localhost:8080/examples/vanilla/related-genes?q=BRCA1&org=mus-musculus
+  //
+  // No interacting genes:
+  // http://localhost:8080/examples/vanilla/related-genes?q=DMC1
+  //
+  // No paralogs, no interacting genes:
+  // http://localhost:8080/examples/vanilla/related-genes?q=BRCA1&org=macaca-mulatta
+
+
+  const otherTypes = {
+    paralogous: 'interacting',
+    interacting: 'paralogous'
+  };
+  const related = getRelatedGenesByType(ideo);
+  const otherType = otherTypes[type];
+  const numThisRelated = related[type].length;
+  const numOtherRelated = related[otherType] ? related[otherType].length : 0;
+
+  if (!ideo._didRelatedGenesFirstPlot) {
+    // 1st of 2 attempted plot logs
+    ideo._didRelatedGenesFirstPlot = true;
+
+    ideo.time.rg.totalFirstPlot = timeDiff(ideo.time.rg.t0);
+
+    if (numThisRelated > 0) {
+      ideo.time.rg.timestampFirstPlot = performance.now();
+      ideo._relatedGenesFirstPlotType = type;
+    }
+  } else {
+    // 2nd of 2 attempted plot logs
+    if (numThisRelated > 0 && numOtherRelated > 0) {
+      // Paralogs and interacting genes were found, e.g. human RAD51
+      const timestampFirstPlot = ideo.time.rg.timestampFirstPlot;
+      ideo.time.rg.totalLastPlotDiff = timeDiff(timestampFirstPlot);
+    } else if (numThisRelated > 0 && numOtherRelated === 0) {
+      // Other attempt did not plot, and this did, so log this as 1st
+      // Often seen when no interacting genes found, e.g. human DMC1
+      ideo.time.rg.timestampFirstPlot = performance.now();
+      ideo.time.rg.totalFirstPlot = timeDiff(ideo.time.rg.t0);
+      ideo._relatedGenesFirstPlotType = type;
+      ideo.time.rg.totalLastPlotDiff = 0;
+
+    } else if (numThisRelated === 0 && numOtherRelated > 0) {
+      // This attempt did not plot, the other did, so log 1st plot as also last
+      // Often seen when no paralogs found, e.g. mouse BRCA1
+      ideo.time.rg.totalLastPlotDiff = 0;
+    } else {
+      // No related genes found, so note only the searched gene is plotted
+      // Example: Macaca mulatta BRCA1
+      ideo._relatedGenesFirstPlotType = 'searched';
+      ideo.time.rg.totalLastPlotDiff = 0;
+    }
+  }
+}
+
+/** Summarizes number and kind of related genes, performance, etc. */
+function analyzeRelatedGenes(ideo) {
+  const related = getRelatedGenesByType(ideo);
+
+  const numRelatedGenes = related['related'].length;
+  const numParalogs = related['paralogous'].length;
+  const numInteractingGenes = related['interacting'].length;
+  const searchedGene = related['searched'];
+
+  const timeTotal = ideo.time.rg.total;
+  const timeTotalFirstPlot = ideo.time.rg.totalFirstPlot;
+  const timeTotalLastPlotDiff = ideo.time.rg.totalLastPlotDiff;
+  const timeParalogs = ideo.time.rg.paralogs;
+  const timeInteractingGenes = ideo.time.rg.interactions;
+  const timeSearchedGene = ideo.time.rg.searchedGene;
+  const firstPlotType = ideo._relatedGenesFirstPlotType;
+
+  ideo.relatedGenesAnalytics = {
+    searchedGene,
+    firstPlotType,
+    numRelatedGenes, numParalogs, numInteractingGenes,
+    timeTotal, timeTotalFirstPlot, timeTotalLastPlotDiff,
+    timeSearchedGene, timeInteractingGenes, timeParalogs
+  };
+}
+
+export {
+  initAnalyzeRelatedGenes, analyzePlotTimes, analyzeRelatedGenes, timeDiff
+};

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -23,7 +23,7 @@
 
 import {
   initAnalyzeRelatedGenes, analyzePlotTimes, analyzeRelatedGenes, timeDiff,
-  getRelatedGenesByType
+  getRelatedGenesByType, getRelatedGenesTooltipAnalytics
 } from './analyze-related-genes';
 
 /**
@@ -601,6 +601,19 @@ function _initRelatedGenes(config, annotsInList) {
     showTools: true
   };
 
+  if ('onWillShowAnnotTooltip' in config) {
+    const key = 'onWillShowAnnotTooltip';
+    const clientFn = config[key];
+    const defaultFunction = kitDefaults[key];
+    const newFunction = function(annot) {
+      annot = defaultFunction.bind(this)(annot);
+      annot = clientFn.bind(this)(annot);
+      return annot;
+    };
+    kitDefaults[key] = newFunction;
+    delete config[key];
+  }
+
   // Override kit defaults if client specifies otherwise
   const kitConfig = Object.assign(kitDefaults, config);
 
@@ -615,6 +628,8 @@ function _initRelatedGenes(config, annotsInList) {
   if (config.onFindRelatedGenes) {
     ideogram.onFindRelatedGenesCallback = config.onFindRelatedGenes;
   }
+
+  ideogram.getTooltipAnalytics = getRelatedGenesTooltipAnalytics;
 
   return ideogram;
 }

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -22,7 +22,8 @@
  */
 
 import {
-  initAnalyzeRelatedGenes, analyzePlotTimes, analyzeRelatedGenes, timeDiff
+  initAnalyzeRelatedGenes, analyzePlotTimes, analyzeRelatedGenes, timeDiff,
+  getRelatedGenesByType
 } from './analyze-related-genes';
 
 /**
@@ -618,4 +619,4 @@ function _initRelatedGenes(config, annotsInList) {
   return ideogram;
 }
 
-export {_initRelatedGenes, plotRelatedGenes};
+export {_initRelatedGenes, plotRelatedGenes, getRelatedGenesByType};

--- a/test/online/related-genes.test.js
+++ b/test/online/related-genes.test.js
@@ -45,6 +45,13 @@ describe('Ideogram related genes kit', function() {
       // pass through
     }
 
+    function onWillShowAnnotTooltip(annot) {
+      const ideo = this;
+      const analytics = ideo.getTooltipAnalytics(annot, ideo);
+      assert.equal(analytics.tooltipRelatedType, 'interacting');
+      return annot;
+    }
+
     var config = {
       organism: 'Homo sapiens', // Also tests standard, non-slugged name
       chrWidth: 8,
@@ -54,7 +61,8 @@ describe('Ideogram related genes kit', function() {
       onLoad: callback,
       dataDir: '/dist/data/bands/native/',
       onClickAnnot,
-      onPlotRelatedGenes
+      onPlotRelatedGenes,
+      onWillShowAnnotTooltip
     };
 
     const ideogram = Ideogram.initRelatedGenes(config);

--- a/test/online/related-genes.test.js
+++ b/test/online/related-genes.test.js
@@ -18,7 +18,7 @@ describe('Ideogram related genes kit', function() {
     d3.selectAll('div').remove();
   });
 
-  it('should handle "Related genes" kit', done => {
+  it('handles searched gene and annotation click', done => {
     // Tests use case from ../examples/vanilla/related-genes
 
     async function callback() {
@@ -41,6 +41,10 @@ describe('Ideogram related genes kit', function() {
       ideogram.plotRelatedGenes(annot.name);
     }
 
+    function onPlotRelatedGenes() {
+      // pass through
+    }
+
     var config = {
       organism: 'Homo sapiens', // Also tests standard, non-slugged name
       chrWidth: 8,
@@ -49,9 +53,122 @@ describe('Ideogram related genes kit', function() {
       annotationHeight: 5,
       onLoad: callback,
       dataDir: '/dist/data/bands/native/',
-      onClickAnnot: onClickAnnot
+      onClickAnnot,
+      onPlotRelatedGenes
     };
 
     const ideogram = Ideogram.initRelatedGenes(config);
   });
+
+  it('handles gene with interacting genes but no paralogs', done => {
+    // Tests use case from ../examples/vanilla/related-genes
+
+    async function callback() {
+      const ideo = this;
+
+      await ideogram.plotRelatedGenes('BRCA2');
+
+      const related = ideo.getRelatedGenesByType();
+
+      const numParalogs = related.paralogous.length;
+      const numInteractingGenes = related.interacting.length;
+
+      assert.isAtLeast(numInteractingGenes, 1);
+      assert.equal(numParalogs, 0);
+
+      done();
+    }
+
+    function onClickAnnot(annot) {
+      ideogram.plotRelatedGenes(annot.name);
+    }
+
+    var config = {
+      organism: 'Homo sapiens', // Also tests standard, non-slugged name
+      chrWidth: 8,
+      chrHeight: 90,
+      chrLabelSize: 10,
+      annotationHeight: 5,
+      onLoad: callback,
+      dataDir: '/dist/data/bands/native/',
+      onClickAnnot
+    };
+
+    const ideogram = Ideogram.initRelatedGenes(config);
+  });
+
+  it('handles gene with paralogs but no interacting genes', done => {
+    // Tests use case from ../examples/vanilla/related-genes
+
+    async function callback() {
+      const ideo = this;
+
+      await ideogram.plotRelatedGenes('DMC1');
+
+      const related = ideo.getRelatedGenesByType();
+
+      const numParalogs = related.paralogous.length;
+      const numInteractingGenes = related.interacting.length;
+
+      assert.equal(numInteractingGenes, 0);
+      assert.isAtLeast(numParalogs, 1);
+
+      done();
+    }
+
+    function onClickAnnot(annot) {
+      ideogram.plotRelatedGenes(annot.name);
+    }
+
+    var config = {
+      organism: 'Homo sapiens', // Also tests standard, non-slugged name
+      chrWidth: 8,
+      chrHeight: 90,
+      chrLabelSize: 10,
+      annotationHeight: 5,
+      onLoad: callback,
+      dataDir: '/dist/data/bands/native/',
+      onClickAnnot
+    };
+
+    const ideogram = Ideogram.initRelatedGenes(config);
+  });
+
+  it('handles gene with no interacting genes and no paralogs', done => {
+    // Tests use case from ../examples/vanilla/related-genes
+
+    async function callback() {
+      const ideo = this;
+
+      await ideogram.plotRelatedGenes('BRCA1');
+
+      const related = ideo.getRelatedGenesByType();
+
+      const numParalogs = related.paralogous.length;
+      const numInteractingGenes = related.interacting.length;
+
+      assert.equal(numInteractingGenes, 0);
+      assert.equal(numParalogs, 0);
+
+      done();
+    }
+
+    function onClickAnnot(annot) {
+      ideogram.plotRelatedGenes(annot.name);
+    }
+
+    var config = {
+      organism: 'Macaca mulatta', // Also tests standard, non-slugged name
+      chrWidth: 8,
+      chrHeight: 90,
+      chrLabelSize: 10,
+      annotationHeight: 5,
+      onLoad: callback,
+      dataDir: '/dist/data/bands/native/',
+      onClickAnnot
+    };
+
+    const ideogram = Ideogram.initRelatedGenes(config);
+  });
+
 });


### PR DESCRIPTION
This enhances optional analytics for the related genes kit, building atop #245.  

Now, clients can obtain detailed timing data on time taken to process searched gene, paralogs, and interacting genes; time and type of first plot; and time between first and last plot.  They can also obtain related genes metrics upon display of an annotation tooltip.

This also fixes bugs in the "Related genes" example, and adds a convenience property for organism scientific name.

The screenshot below shows analytics available upon plotting related genes, and upon hovering over an annotation:
<img width="1209" alt="related_gene_analytics_detailed_times_and_tooltip_analytics_ideogram_2020-10-18" src="https://user-images.githubusercontent.com/1334561/96386481-57f75f80-1169-11eb-92cd-c7ab1c8d1a91.png">
