### PR TITLE
Enable annotation labels

### DIFF
--- a/src/js/annotations/annotations.js
+++ b/src/js/annotations/annotations.js
@@ -23,7 +23,7 @@ import {
 } from './filter';
 import {processAnnotData} from './process';
 import {ExpressionMatrixParser} from '../parsers/expression-matrix-parser';
-  import {downloadAnnotations} from './download';
+import {downloadAnnotations} from './download';
 
 function initNumTracksAndBarWidth(ideo, config) {
 

--- a/src/js/annotations/annotations.js
+++ b/src/js/annotations/annotations.js
@@ -13,7 +13,7 @@ import {inflateHeatmaps} from './heatmap-collinear';
 import {
   onLoadAnnots, onDrawAnnots, startHideAnnotTooltipTimeout,
   onWillShowAnnotTooltip, showAnnotTooltip, onClickAnnot,
-  showAnnotLabel
+  addAnnotLabel, removeAnnotLabel, fadeOutAnnotLabels
 } from './events';
 import {drawAnnots, drawProcessedAnnots} from './draw';
 import {getHistogramBars} from './histogram';
@@ -53,12 +53,12 @@ function initTooltip(ideo, config) {
 }
 
 function initAnnotLabel(ideo, config) {
-  if (config.showAnnotLabel !== false) {
-    ideo.config.showAnnotLabel = true;
+  if (config.addAnnotLabel !== false) {
+    ideo.config.addAnnotLabel = true;
   }
 
-  if (config.onWillShowAnnotLabel) {
-    ideo.onWillShowAnnotLabelCallback = config.onWillShowAnnotLabel;
+  if (config.onWillAddAnnotLabel) {
+    ideo.onWillAddAnnotLabelCallback = config.onWillAddAnnotLabel;
   }
 }
 
@@ -234,5 +234,6 @@ export {
   getHistogramBars, drawHeatmaps, deserializeAnnotsForHeatmap, fillAnnots,
   drawProcessedAnnots, drawSynteny, startHideAnnotTooltipTimeout,
   showAnnotTooltip, onWillShowAnnotTooltip, setOriginalTrackIndexes,
-  afterRawAnnots, onClickAnnot, downloadAnnotations, showAnnotLabel
+  afterRawAnnots, onClickAnnot, downloadAnnotations, addAnnotLabel,
+  removeAnnotLabel, fadeOutAnnotLabels
 };

--- a/src/js/annotations/annotations.js
+++ b/src/js/annotations/annotations.js
@@ -12,7 +12,8 @@ import {inflateThresholds} from './heatmap-lib';
 import {inflateHeatmaps} from './heatmap-collinear';
 import {
   onLoadAnnots, onDrawAnnots, startHideAnnotTooltipTimeout,
-  onWillShowAnnotTooltip, showAnnotTooltip, onClickAnnot
+  onWillShowAnnotTooltip, showAnnotTooltip, onClickAnnot,
+  showAnnotLabel
 } from './events';
 import {drawAnnots, drawProcessedAnnots} from './draw';
 import {getHistogramBars} from './histogram';
@@ -48,6 +49,16 @@ function initTooltip(ideo, config) {
 
   if (config.onWillShowAnnotTooltip) {
     ideo.onWillShowAnnotTooltipCallback = config.onWillShowAnnotTooltip;
+  }
+}
+
+function initAnnotLabel(ideo, config) {
+  if (config.showAnnotLabel !== false) {
+    ideo.config.showAnnotLabel = true;
+  }
+
+  if (config.onWillShowAnnotLabel) {
+    ideo.onWillShowAnnotLabelCallback = config.onWillShowAnnotLabel;
   }
 }
 
@@ -94,6 +105,7 @@ function initAnnotSettings() {
   }
 
   initTooltip(ideo, config);
+  initAnnotLabel(ideo, config);
 }
 
 function validateAnnotsUrl(annotsUrl) {
@@ -222,5 +234,5 @@ export {
   getHistogramBars, drawHeatmaps, deserializeAnnotsForHeatmap, fillAnnots,
   drawProcessedAnnots, drawSynteny, startHideAnnotTooltipTimeout,
   showAnnotTooltip, onWillShowAnnotTooltip, setOriginalTrackIndexes,
-  afterRawAnnots, onClickAnnot, downloadAnnotations
+  afterRawAnnots, onClickAnnot, downloadAnnotations, showAnnotLabel
 };

--- a/src/js/annotations/draw.js
+++ b/src/js/annotations/draw.js
@@ -227,4 +227,4 @@ function drawProcessedAnnots(annots) {
   if (ideo.onDrawAnnotsCallback) ideo.onDrawAnnotsCallback();
 }
 
-export {drawAnnots, drawProcessedAnnots};
+export {drawAnnots, drawProcessedAnnots, getShapes};

--- a/src/js/annotations/events.js
+++ b/src/js/annotations/events.js
@@ -154,7 +154,7 @@ function getAnnotByName(annotName, ideo) {
   return annot;
 }
 
-/** Get list annotation objects by list of names, e.g. ["BRCA1", "APOE"] */
+/** Get list of annotation objects by names, e.g. ["BRCA1", "APOE"] */
 function getAnnotsByName(annotNames, ideo) {
   return annotNames.map(name => getAnnotByName(name, ideo));
 }
@@ -164,7 +164,7 @@ function getAnnotsByName(annotNames, ideo) {
  *
  * @param annotName {String} Name of annotation, e.g. "BRCA1"
  * @param backgroundColor {String} Background color.  Default: white.
- * * @param backgroundColor {String} Border color.  Default: black.
+ * @param backgroundColor {String} Border color.  Default: black.
  */
 function addAnnotLabel(annotName, backgroundColor, borderColor) {
   var annot, annotRect, labelLength,
@@ -210,7 +210,7 @@ function pulseAnnots(annotNames, ideo, duration=2000) {
 
   const annotPulses = d3.selectAll('._ideogramAnnotPulse');
   annotPulses.transition()
-    .duration(duration) // fade out for 5 seconds
+    .duration(duration) // fade out for `duration` milliseconds
     .style('opacity', 0)
     .style('pointer-events', 'none')
     .on('end', function(d, i) {

--- a/src/js/annotations/process.js
+++ b/src/js/annotations/process.js
@@ -136,6 +136,7 @@ function addAnnotsForChr(annots, omittedAnnots, annotsByChr, chrModel,
     annot.startPx = ideo.convertBpToPx(chrModel, annot.start);
     annot.stopPx = ideo.convertBpToPx(chrModel, annot.stop);
     annot.px = Math.round((annot.startPx + annot.stopPx) / 2);
+    annot.id = '_c' + m + '_a' + j;
 
     [annots, omittedAnnots] =
       addAnnot(annot, keys, ra, omittedAnnots, annots, m, ideo);

--- a/src/js/ideogram.js
+++ b/src/js/ideogram.js
@@ -18,7 +18,7 @@ import {
   getHistogramBars, drawHeatmaps, deserializeAnnotsForHeatmap, fillAnnots,
   drawProcessedAnnots, drawSynteny, startHideAnnotTooltipTimeout,
   showAnnotTooltip, onWillShowAnnotTooltip, setOriginalTrackIndexes,
-  afterRawAnnots, onClickAnnot, downloadAnnotations
+  afterRawAnnots, onClickAnnot, downloadAnnotations, showAnnotLabel
 } from './annotations/annotations';
 
 import {highlight, unhighlight} from './annotations/highlight';
@@ -98,6 +98,7 @@ export default class Ideogram {
     this.setOriginalTrackIndexes = setOriginalTrackIndexes;
     this.afterRawAnnots = afterRawAnnots;
     this.downloadAnnotations = downloadAnnotations;
+    this.showAnnotLabel = showAnnotLabel;
 
     this.highlight = highlight;
     this.unhighlight = unhighlight;

--- a/src/js/ideogram.js
+++ b/src/js/ideogram.js
@@ -18,7 +18,8 @@ import {
   getHistogramBars, drawHeatmaps, deserializeAnnotsForHeatmap, fillAnnots,
   drawProcessedAnnots, drawSynteny, startHideAnnotTooltipTimeout,
   showAnnotTooltip, onWillShowAnnotTooltip, setOriginalTrackIndexes,
-  afterRawAnnots, onClickAnnot, downloadAnnotations, showAnnotLabel
+  afterRawAnnots, onClickAnnot, downloadAnnotations, addAnnotLabel,
+  removeAnnotLabel, fadeOutAnnotLabels
 } from './annotations/annotations';
 
 import {highlight, unhighlight} from './annotations/highlight';
@@ -98,7 +99,9 @@ export default class Ideogram {
     this.setOriginalTrackIndexes = setOriginalTrackIndexes;
     this.afterRawAnnots = afterRawAnnots;
     this.downloadAnnotations = downloadAnnotations;
-    this.showAnnotLabel = showAnnotLabel;
+    this.addAnnotLabel = addAnnotLabel;
+    this.removeAnnotLabel = removeAnnotLabel;
+    this.fadeOutAnnotLabels = fadeOutAnnotLabels;
 
     this.highlight = highlight;
     this.unhighlight = unhighlight;

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -446,7 +446,7 @@ function adjustPlaceAndVisibility(ideo) {
     // Accounts for moving legend when external content at left or right
     // is variable upon first rendering plotted genes
     var ideoDom = document.querySelector('#_ideogram');
-    const legendWidth = 140;
+    const legendWidth = 150;
     ideoInnerDom.style.maxWidth =
       (parseInt(ideoInnerDom.style.maxWidth) + legendWidth) + 'px';
     ideoDom.style.maxWidth =

--- a/src/js/layouts/vertical-layout.js
+++ b/src/js/layouts/vertical-layout.js
@@ -157,7 +157,8 @@ class VerticalLayout extends Layout {
         var barWidth = this._ideo.config.barWidth;
         return margin + setIndex * (margin + width + 3) + barWidth * 2;
       } else {
-        translate = width + setIndex * (margin + width) + pad * 2;
+        const pulsePad = 5; // Prevents shaving in chr1 annot pulses
+        translate = width + setIndex * (margin + width) + pad * 2 + pulsePad;
         if (pad > 0) {
           return translate;
         } else {

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -9,6 +9,7 @@ import * as d3dispatch from 'd3-dispatch';
 import * as d3format from 'd3-format';
 import {scaleLinear} from 'd3-scale';
 import {max} from 'd3-array';
+import {easeExpIn} from 'd3-ease';
 
 var d3 = Object.assign(
   {}, d3fetch, d3brush, d3dispatch, d3format
@@ -18,6 +19,7 @@ d3.select = select;
 d3.selectAll = selectAll;
 d3.scaleLinear = scaleLinear;
 d3.max = max;
+d3.easeExpIn = easeExpIn;
 
 /**
  * Is the assembly in this.config an NCBI Assembly accession?

--- a/src/js/tools/tools.js
+++ b/src/js/tools/tools.js
@@ -7,7 +7,7 @@ const style = `
 
     #gear {
       position: absolute;
-      right: 8px;
+      right: 3px;
       top: 24px;
       z-index: 8001;
       cursor: pointer;
@@ -18,7 +18,7 @@ const style = `
     #tools {
       position: absolute;
       width: 120px;
-      right: 32px;
+      right: 27px;
       top: 16px;
       z-index: 8000;
       background: white;
@@ -55,7 +55,7 @@ const style = `
 
     #download {
       position: absolute;
-      right: 8px;
+      right: 3px;
       top: 16px;
       z-index: 8000;
       background: white;
@@ -65,7 +65,7 @@ const style = `
 
     #settings {
       position: absolute;
-      right: 8px;
+      right: 3px;
       top: 16px;
       z-index: 8000;
       background: white;

--- a/test/offline/annotation-labels.test.js
+++ b/test/offline/annotation-labels.test.js
@@ -1,0 +1,49 @@
+describe('Ideogram annotation labels', function() {
+
+
+  d3 = Ideogram.d3;
+
+  beforeEach(function() {
+    delete window.chrBands;
+    d3.selectAll('div').remove();
+  });
+
+  it('supports annotation labels, pulse, and fade', done => {
+    // Tests use case from ../examples/vanilla/related-genes.html
+    //
+    // This test is contrived and superficial, merely ensuring the feature
+    // doesn't throw an error.
+
+    function callback() {
+      const ideo = this;
+      ideo.addAnnotLabel('MTOR', '#fdd', '#f00');
+      ideo.addAnnotLabel('BRCA1', '#feeefe', '#800080');
+
+      ideo.fadeOutAnnotLabels();
+      done();
+    }
+
+    var config = {
+      organism: 'human',
+      annotations: [
+        {
+          name: 'MTOR',
+          chr: '1',
+          start: 11106535,
+          stop: 11262551
+        },
+        {
+          name: 'BRCA1',
+          chr: '17',
+          start: 43044294,
+          stop: 43125482
+        }
+      ],
+      dataDir: '/dist/data/bands/native/',
+      onDrawAnnots: callback
+    };
+
+    ideogram = new Ideogram(config);
+  });
+
+});

--- a/test/offline/core.test.js
+++ b/test/offline/core.test.js
@@ -259,7 +259,7 @@ describe('Ideogram', function() {
       // Ensure distal track of chromosome 1 is visible
       annot2 = document.querySelector('#chr1-9606-chromosome-set');
       transform = annot2.getAttribute('transform');
-      assert.equal(transform, 'rotate(90) translate(30, -29)');
+      assert.equal(transform, 'rotate(90) translate(30, -34)');
 
       done();
     }

--- a/test/offline/filter.test.js
+++ b/test/offline/filter.test.js
@@ -284,9 +284,9 @@ describe('Ideogram filter support', function() {
       track2 = document.querySelector('#chr2-9606-canvas-1').getBoundingClientRect();
       track3 = document.querySelector('#chr2-9606-canvas-2').getBoundingClientRect();
 
-      assert.equal(track1.x, 95);
-      assert.equal(track2.x, 104);
-      assert.equal(track3.x, 113);
+      assert.equal(track1.x, 100);
+      assert.equal(track2.x, 109);
+      assert.equal(track3.x, 118);
 
       // Filters tracks to show only 4th and 5th track (of 9)
       ideogram.updateDisplayedTracks([4, 5]);
@@ -294,8 +294,8 @@ describe('Ideogram filter support', function() {
       track1 = document.querySelector('#chr2-9606-canvas-0').getBoundingClientRect();
       track2 = document.querySelector('#chr2-9606-canvas-1').getBoundingClientRect();
 
-      assert.equal(track1.x, 104);
-      assert.equal(track2.x, 113);
+      assert.equal(track1.x, 109);
+      assert.equal(track2.x, 118);
 
       done();
     }
@@ -323,9 +323,9 @@ describe('Ideogram filter support', function() {
       track2 = document.querySelector('#chr2-9606-canvas-1').getBoundingClientRect();
       track3 = document.querySelector('#chr2-9606-canvas-2').getBoundingClientRect();
 
-      assert.equal(track1.x, 95);
-      assert.equal(track2.x, 104);
-      assert.equal(track3.x, 113);
+      assert.equal(track1.x, 100);
+      assert.equal(track2.x, 109);
+      assert.equal(track3.x, 118);
 
       done();
     }


### PR DESCRIPTION
This adds support for labeling annotations, i.e. marked genomic features.  The labels show the name of the feature beside the annotation shape.  They are designed to be small and (in a subsequent PR) visible by default.

The labels are not designed to appear for all annotations.  Like genomic features in the "Genes" track of NCBI Genome Data Viewer, or geographic features in Google Maps, the annotations labels in Ideogram often leave features unlabeled for merely geometric reasons (to minimize collisions and overlap), while prioritizing important features where possible.  With this preliminary work done, the plan is to first maximize label counts while minimizing overlap, then enable clients to prioritize features for labeling.

The intent for now is to make genomic information more glanceable, and suggest to users that annotations are interactive.

![annotation_labels_ideogram_2020-10-21](https://user-images.githubusercontent.com/1334561/96672785-0bf81680-1333-11eb-9a61-9f78fb0c3da1.gif)


