### PR TITLE
Make annotation labels interactive, polish label UX and tooltip analytics

### DIFF
--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -48,8 +48,13 @@
       cursor: pointer;
     }
 
-    #ideogram .annot path {
+    #_ideogram .annot path, ._ideogramLabel {
       cursor: pointer;
+    }
+
+    #_ideogram ._ideogramLabel.selected {
+      fill: #77F !important;
+      stroke: #F0F0FF !important;
     }
 
   </style>

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -229,7 +229,12 @@
     function onWillShowAnnotTooltip(annot) {
       const ideo = this;
       const tooltipAnalytics = ideo.getTooltipAnalytics(annot);
-      console.log(tooltipAnalytics);
+
+      // Reduces analytics noise.  Accounts for quick moves from label to
+      // annot, which flickers tooltip and represents an technical artifact
+      // that is not worth analyzing.
+      if (tooltipAnalytics) console.log(tooltipAnalytics);
+
       return annot
     }
 
@@ -243,6 +248,7 @@
       onLoad: plotGeneFromUrl,
       onPlotRelatedGenes: reportRelatedGenes,
       onWillShowAnnotTooltip,
+      showAnnotLabels: true,
       onClickAnnot
     }
 

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -52,7 +52,7 @@
       cursor: pointer;
     }
 
-    #_ideogram ._ideogramLabel.selected {
+    #_ideogram ._ideogramLabel._ideoActive {
       fill: #77F !important;
       stroke: #F0F0FF !important;
     }

--- a/src/js/annotations/labels.js
+++ b/src/js/annotations/labels.js
@@ -11,49 +11,25 @@ function renderLabel(annot, style, ideo) {
   const config = ideo.config;
 
   const id = getAnnotDomLabelId(annot);
-  const background = style.backgroundColor ? style.backgroundColor : '#FFF';
-  const borderColor = style.borderColor ? style.borderColor : annot.color;
 
   // TODO: De-duplicate with code in getTextWidth and elsewhere
   // perhaps set config.annotLabelSize and config.annotLabelFont upstream.
   const labelSize = config.annotLabelSize ? config.annotLabelSize : 12;
   const font = labelSize + 'px sans-serif';
 
-  // const radius = 1.5;
-  // const offset = 0;
-  // const color = '#FFFF';
-  // const textShadow =
-  //   `-${radius}px -${radius}px ${offset}px ${color}, ` +
-  //   `${radius}px -${radius}px ${offset}px ${color}, ` +
-  //   `-${radius}px ${radius}px ${offset}px ${color}, ` +
-  //   `${radius}px ${radius}px ${offset}px ${color}`;
-
-  d3.select(ideo.config.container + ' #_ideogramOuterWrap').append('div')
-    .attr('class', '_ideogramLabel')
+  d3.select('#_ideogram').append('text')
     .attr('id', id)
-    .style('opacity', 1) // Make label visible
-    .style('left', style.left + 'px')
-    .style('top', style.top + 'px')
-    .style('position', 'fixed')
+    .attr('class', '_ideogramLabel')
+    .attr('x', style.left)
+    .attr('y', style.top)
     .style('text-align', 'center')
     .style('font', font)
-    .style('z-index', '900')
     .style('pointer-events', null) // Prevent bug in clicking chromosome
-
-    // Box the text
-    .style('padding', '0 1px')
-    .style('background', background)
-    .style('border', '1px solid ' + borderColor)
-    .style('border-radius', '5px')
-
-    // Alternatively, like Google Maps.  Enables increasing font size by 1px.
-    // .style('text-shadow', textShadow)
-
-    // A more experimental approach with text-stroke
-    // .style('font-weight', 900)
-    // .style('-webkit-text-stroke', '0.5px white')
-    // .style('-webkit-text-fill-color', '#000')
-    // .style('paint-order', 'stroke fill')
+    .style('fill', annot.color)
+    .style('stroke', 'white')
+    .style('stroke-width', '5px')
+    .style('stroke-linejoin', 'round')
+    .style('paint-order', 'stroke fill')
 
     .html(annot.name);
 }
@@ -65,7 +41,7 @@ function renderLabel(annot, style, ideo) {
  */
 function getTextWidth(text, ideo) {
   var config = ideo.config;
-  var labelSize = config.annotLabelSize ? config.annotLabelSize : 12;
+  var labelSize = config.annotLabelSize ? config.annotLabelSize : 13;
 
   var font = labelSize + 'px sans-serif';
 
@@ -99,9 +75,12 @@ function getAnnotByName(annotName, ideo) {
 
 /** Get label's top and left offsets relative to chromosome, and width */
 function getAnnotLabelLayout(annot, ideo) {
-  var annotRect, width, height, top, bottom, left, right,
+  var annotRect, ideoRect, width, height, top, bottom, left, right,
     config = ideo.config;
 
+
+  ideoRect =
+    document.querySelector('#_ideogram').getBoundingClientRect();
   annotRect =
     document.querySelector('#' + annot.domId).getBoundingClientRect();
 
@@ -112,14 +91,14 @@ function getAnnotLabelLayout(annot, ideo) {
   //  as set in renderLabel
   width = width + 4;
 
-  const labelSize = config.annotLabelSize ? config.annotLabelSize : 12;
+  const labelSize = config.annotLabelSize ? config.annotLabelSize : 13;
 
   // Accounts for 1px top border, 1px bottom border as set in renderLabel
-  height = labelSize + 2;
+  height = labelSize;
 
-  top = annotRect.top - 1;
+  top = annotRect.top - ideoRect.top + height - 2;
   bottom = top + height;
-  left = annotRect.left - width - 1; // Put 1 px between label and annot
+  left = annotRect.left - ideoRect.left - width;
   right = left + width;
 
   return {top, bottom, right, left, width, height};
@@ -138,9 +117,9 @@ function addAnnotLabel(annotName, backgroundColor, borderColor) {
 
   annot = getAnnotByName(annotName, ideo);
 
-  const {top, left} = getAnnotLabelLayout(annot, ideo);
+  const layout = getAnnotLabelLayout(annot, ideo);
 
-  const style = {left, top, backgroundColor, borderColor};
+  const style = Object.assign(layout, {backgroundColor, borderColor});
 
   renderLabel(annot, style, ideo);
 }

--- a/src/js/annotations/labels.js
+++ b/src/js/annotations/labels.js
@@ -12,7 +12,7 @@ function renderLabel(annot, style, ideo) {
 
   const id = getAnnotDomLabelId(annot);
   const background = style.backgroundColor ? style.backgroundColor : '#FFF';
-  const borderColor = style.borderColor ? style.borderColor : '#CCC';
+  const borderColor = style.borderColor ? style.borderColor : annot.color;
 
   // TODO: De-duplicate with code in getTextWidth and elsewhere
   // perhaps set config.annotLabelSize and config.annotLabelFont upstream.

--- a/src/js/annotations/labels.js
+++ b/src/js/annotations/labels.js
@@ -5,7 +5,7 @@ function getAnnotDomLabelId(annot) {
   return 'ideogramLabel_' + annot.domId;
 }
 
-function triggerAnnotEvent(event) {
+function triggerAnnotEvent(event, ideo) {
   let labelId, annotId;
   const target = event.target;
   const type = event.type;
@@ -19,6 +19,11 @@ function triggerAnnotEvent(event) {
     const annotElement = target.parentElement;
     labelId = 'ideogramLabel_' + annotElement.id;
     annotId = annotElement.id;
+  }
+
+  if (type === 'mouseout') {
+    ideo.time.prevTooltipOff = performance.now();
+    ideo.time.prevTooltipAnnotDomId = annotId;
   }
 
   const state = (type === 'mouseover') ? ' _ideoActive' : '';
@@ -54,7 +59,7 @@ function renderLabel(annot, style, ideo) {
 
   d3.selectAll('#' + id + ', #' + annot.domId)
     .on('mouseover', (event) => triggerAnnotEvent(event))
-    .on('mouseout', (event) => triggerAnnotEvent(event))
+    .on('mouseout', (event) => triggerAnnotEvent(event, ideo))
     .on('click', (event) => triggerAnnotEvent(event));
 }
 

--- a/src/js/annotations/labels.js
+++ b/src/js/annotations/labels.js
@@ -17,7 +17,7 @@ function renderLabel(annot, style, ideo) {
   const labelSize = config.annotLabelSize ? config.annotLabelSize : 13;
   const font = labelSize + 'px sans-serif';
 
-  const fill = annot.color === 'pink' ? '#DF708B' : annot.color;
+  const fill = annot.color === 'pink' ? '#CF406B' : annot.color;
 
   d3.select('#_ideogram').append('text')
     .attr('id', id)

--- a/src/js/annotations/labels.js
+++ b/src/js/annotations/labels.js
@@ -2,9 +2,27 @@ import {d3} from '../lib';
 
 /** Return DOM ID of annotation object */
 function getAnnotDomLabelId(annot) {
-  return (
-    'ideogramLabel_' + annot.chr + '_' + annot.start + '_' + annot.length
-  );
+  return 'ideogramLabel_' + annot.domId;
+}
+
+function triggerAnnotEvent(event) {
+  let labelId, annotId;
+  const target = event.target;
+  const type = event.type;
+
+  const targetClasses = Array.from(target.classList);
+  if (targetClasses.includes('_ideogramLabel')) {
+    labelId = target.id;
+    annotId = target.id.split('ideogramLabel_')[1];
+    d3.select('#' + annotId + ' path').dispatch(type);
+  } else {
+    const annotElement = target.parentElement;
+    labelId = 'ideogramLabel_' + annotElement.id;
+    annotId = annotElement.id;
+  }
+
+  const state = (type === 'mouseover') ? ' _ideoActive' : '';
+  d3.select('#' + labelId).attr('class', '_ideogramLabel ' + state);
 }
 
 function renderLabel(annot, style, ideo) {
@@ -32,8 +50,12 @@ function renderLabel(annot, style, ideo) {
     .style('stroke-width', '5px')
     .style('stroke-linejoin', 'round')
     .style('paint-order', 'stroke fill')
-
     .html(annot.name);
+
+  d3.selectAll('#' + id + ', #' + annot.domId)
+    .on('mouseover', (event) => triggerAnnotEvent(event))
+    .on('mouseout', (event) => triggerAnnotEvent(event))
+    .on('click', (event) => triggerAnnotEvent(event));
 }
 
 /**

--- a/src/js/annotations/labels.js
+++ b/src/js/annotations/labels.js
@@ -14,8 +14,10 @@ function renderLabel(annot, style, ideo) {
 
   // TODO: De-duplicate with code in getTextWidth and elsewhere
   // perhaps set config.annotLabelSize and config.annotLabelFont upstream.
-  const labelSize = config.annotLabelSize ? config.annotLabelSize : 12;
+  const labelSize = config.annotLabelSize ? config.annotLabelSize : 13;
   const font = labelSize + 'px sans-serif';
+
+  const fill = annot.color === 'pink' ? '#DF708B' : annot.color;
 
   d3.select('#_ideogram').append('text')
     .attr('id', id)
@@ -24,8 +26,8 @@ function renderLabel(annot, style, ideo) {
     .attr('y', style.top)
     .style('text-align', 'center')
     .style('font', font)
+    .style('fill', fill)
     .style('pointer-events', null) // Prevent bug in clicking chromosome
-    .style('fill', annot.color)
     .style('stroke', 'white')
     .style('stroke-width', '5px')
     .style('stroke-linejoin', 'round')
@@ -89,14 +91,14 @@ function getAnnotLabelLayout(annot, ideo) {
   // Accounts for:
   // 1px left pad, 1px right pad, 1px right border, 1px left border
   //  as set in renderLabel
-  width = width + 4;
+  width = width + 7;
 
   const labelSize = config.annotLabelSize ? config.annotLabelSize : 13;
 
   // Accounts for 1px top border, 1px bottom border as set in renderLabel
   height = labelSize;
 
-  top = annotRect.top - ideoRect.top + height - 2;
+  top = annotRect.top - ideoRect.top + height - 1;
   bottom = top + height;
   left = annotRect.left - ideoRect.left - width;
   right = left + width;

--- a/src/js/kit/analyze-related-genes.js
+++ b/src/js/kit/analyze-related-genes.js
@@ -31,6 +31,13 @@ function getRelatedGenesByType() {
 function getRelatedGenesTooltipAnalytics(annot) {
   const ideo = this;
 
+  const timeSincePrevTooltip = performance.now() - ideo.time.prevTooltipOff;
+  const prevAnnotDomId = ideo.time.prevTooltipAnnotDomId;
+
+  if (timeSincePrevTooltip < 300 && annot.domId === prevAnnotDomId) {
+    return null;
+  }
+
   const tooltipGene = annot.name;
 
   // e.g. "interacting gene" -> "interacting"

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -28,6 +28,7 @@ import {
 
 import {getAnnotDomId} from '../annotations/process';
 
+/** Sets DOM IDs for ideo.relatedAnnots; needed to associate labels */
 function setRelatedAnnotDomIds(ideo) {
   const updated = [];
 

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -370,14 +370,14 @@ function parseAnnotFromMgiGene(gene, ideo, color='red') {
     start: genomicPos.start,
     stop: genomicPos.end,
     id: genomicPos.ensemblgene,
-    color: color
+    color
   };
 
   return annot;
 }
 
 function moveLegend(ideoInnerDom) {
-  const legendStyle = 'position: absolute; top: 15px';
+  const legendStyle = 'position: absolute; top: 15px; left: 50px';
   const legend = document.querySelector('#_ideogramLegend');
   ideoInnerDom.prepend(legend);
   legend.style = legendStyle;
@@ -489,15 +489,23 @@ function adjustPlaceAndVisibility(ideo) {
   ideoInnerDom.style.overflowY = 'hidden';
   document.querySelector('#_ideogramMiddleWrap').style.overflowY = 'hidden';
 
+  const annotDecorPad = ideo.config.annotDecorPad;
+
   if (typeof ideo.didAdjustIdeogramLegend === 'undefined') {
     // Accounts for moving legend when external content at left or right
     // is variable upon first rendering plotted genes
     var ideoDom = document.querySelector('#_ideogram');
     const legendWidth = 150;
     ideoInnerDom.style.maxWidth =
-      (parseInt(ideoInnerDom.style.maxWidth) + legendWidth) + 'px';
+      (
+        parseInt(ideoInnerDom.style.maxWidth) +
+        legendWidth +
+        annotDecorPad
+      ) + 'px';
+    ideoDom.style.minWidth =
+      (parseInt(ideoDom.style.minWidth) + annotDecorPad) + 'px';
     ideoDom.style.maxWidth =
-      (parseInt(ideoDom.style.minWidth)) + 'px';
+      (parseInt(ideoDom.style.minWidth) + annotDecorPad) + 'px';
     ideoDom.style.position = 'relative';
     ideoDom.style.left = legendWidth + 'px';
 
@@ -650,6 +658,7 @@ function _initRelatedGenes(config, annotsInList) {
     legend: legend,
     chrBorderColor: '#333',
     chrLabelColor: '#333',
+    annotDecorPad: 60,
     onWillShowAnnotTooltip: decorateGene,
     annotsInList: annotsInList,
     showTools: true

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -443,8 +443,10 @@ function finishPlotRelatedGenes(type, ideo) {
   }
   ideo.drawAnnots(annots);
 
-  setRelatedAnnotDomIds(ideo);
-  ideo.fillAnnotLabels(ideo.relatedAnnots);
+  if (ideo.config.showAnnotLabels) {
+    setRelatedAnnotDomIds(ideo);
+    ideo.fillAnnotLabels(ideo.relatedAnnots);
+  }
 
   const ideoInnerDom = document.querySelector('#_ideogramInnerWrap');
   moveLegend(ideoInnerDom);
@@ -659,10 +661,10 @@ function _initRelatedGenes(config, annotsInList) {
     legend: legend,
     chrBorderColor: '#333',
     chrLabelColor: '#333',
-    annotDecorPad: 60,
     onWillShowAnnotTooltip: decorateGene,
     annotsInList: annotsInList,
-    showTools: true
+    showTools: true,
+    showAnnotLabels: true
   };
 
   if ('onWillShowAnnotTooltip' in config) {
@@ -680,6 +682,12 @@ function _initRelatedGenes(config, annotsInList) {
 
   // Override kit defaults if client specifies otherwise
   const kitConfig = Object.assign(kitDefaults, config);
+
+  if (kitConfig.showAnnotLabels) {
+    kitConfig.annotDecorPad = 60;
+  } else {
+    kitConfig.annotDecorPad = 30;
+  }
 
   const ideogram = new Ideogram(kitConfig);
 

--- a/src/js/layouts/vertical-layout.js
+++ b/src/js/layouts/vertical-layout.js
@@ -138,12 +138,13 @@ class VerticalLayout extends Layout {
   getChromosomeSetYTranslate(setIndex) {
     // Get additional padding caused by annotation/histogram tracks
     var pad = this._getAdditionalOffset(),
-      margin = this._config.chrMargin,
-      width = this._config.chrWidth,
+      config = this._config,
+      margin = config.chrMargin,
+      width = config.chrWidth,
       translate;
 
     // If no detailed description provided just use one formula for all cases
-    if (!this._config.ploidyDesc) {
+    if (!config.ploidyDesc) {
       // TODO:
       // This part of code contains a lot magic numbers and if
       // statements for exactly corresponing to original ideogram examples.
@@ -153,12 +154,13 @@ class VerticalLayout extends Layout {
       // not meet for cases when no annotation, when annotation exists and
       // when histogram used
 
-      if (this._config.annotationsLayout === 'histogram') {
-        var barWidth = this._ideo.config.barWidth;
+      if (config.annotationsLayout === 'histogram') {
+        var barWidth = config.barWidth;
         return margin + setIndex * (margin + width + 3) + barWidth * 2;
       } else {
-        const pulsePad = 5; // Prevents shaving in chr1 annot pulses
-        translate = width + setIndex * (margin + width) + pad * 2 + pulsePad;
+        const decorPad =
+          'annotDecorPad' in config ? config.annotDecorPad : 0;
+        translate = width + setIndex * (margin + width) + pad * 2 + decorPad;
         if (pad > 0) {
           return translate;
         } else {

--- a/test/offline/core.test.js
+++ b/test/offline/core.test.js
@@ -259,7 +259,7 @@ describe('Ideogram', function() {
       // Ensure distal track of chromosome 1 is visible
       annot2 = document.querySelector('#chr1-9606-chromosome-set');
       transform = annot2.getAttribute('transform');
-      assert.equal(transform, 'rotate(90) translate(30, -34)');
+      assert.equal(transform, 'rotate(90) translate(30, -29)');
 
       done();
     }

--- a/test/offline/filter.test.js
+++ b/test/offline/filter.test.js
@@ -284,9 +284,9 @@ describe('Ideogram filter support', function() {
       track2 = document.querySelector('#chr2-9606-canvas-1').getBoundingClientRect();
       track3 = document.querySelector('#chr2-9606-canvas-2').getBoundingClientRect();
 
-      assert.equal(track1.x, 100);
-      assert.equal(track2.x, 109);
-      assert.equal(track3.x, 118);
+      assert.equal(track1.x, 95);
+      assert.equal(track2.x, 104);
+      assert.equal(track3.x, 113);
 
       // Filters tracks to show only 4th and 5th track (of 9)
       ideogram.updateDisplayedTracks([4, 5]);
@@ -294,8 +294,8 @@ describe('Ideogram filter support', function() {
       track1 = document.querySelector('#chr2-9606-canvas-0').getBoundingClientRect();
       track2 = document.querySelector('#chr2-9606-canvas-1').getBoundingClientRect();
 
-      assert.equal(track1.x, 109);
-      assert.equal(track2.x, 118);
+      assert.equal(track1.x, 104);
+      assert.equal(track2.x, 113);
 
       done();
     }
@@ -323,9 +323,9 @@ describe('Ideogram filter support', function() {
       track2 = document.querySelector('#chr2-9606-canvas-1').getBoundingClientRect();
       track3 = document.querySelector('#chr2-9606-canvas-2').getBoundingClientRect();
 
-      assert.equal(track1.x, 100);
-      assert.equal(track2.x, 109);
-      assert.equal(track3.x, 118);
+      assert.equal(track1.x, 95);
+      assert.equal(track2.x, 104);
+      assert.equal(track3.x, 113);
 
       done();
     }

--- a/test/online/related-genes.test.js
+++ b/test/online/related-genes.test.js
@@ -24,10 +24,16 @@ describe('Ideogram related genes kit', function() {
     async function callback() {
       await ideogram.plotRelatedGenes('RAD51');
 
+      const rad54lLabel = document.querySelector('#ideogramLabel__c0_a0');
+      rad54lLabel.dispatchEvent(new Event('mouseover'));
+      let relatedGene = document.querySelector('#ideo-related-gene');
+      assert.equal(relatedGene.textContent, 'RAD54L');
+      rad54lLabel.dispatchEvent(new Event('mouseout'));
+
       const brca2Annot = document.querySelector('#chr13-9606 .annot path');
       brca2Annot.dispatchEvent(new Event('mouseover'));
 
-      const relatedGene = document.querySelector('#ideo-related-gene');
+      relatedGene = document.querySelector('#ideo-related-gene');
 
       assert.equal(relatedGene.textContent, 'BRCA2');
 


### PR DESCRIPTION
This refines annotation labels, building on #248 and #249.  Label UI and interaction design are inspired by Google Maps.

Labels are now interactive, and have the same hover and click handling as the annotations they supplement.  Label graphics are also polished -- text is bigger, colored to match annotation (for glanceability), wrapped in fitting text-stroke instead of boxes, and changes color when active.  Labels can be disabled via `showAnnotLabels: false`.

Quickly moving the cursor from label to annotation will flicker the tooltip.  Analytics from #247 now silence such noisy events.

These updates are currently confined to the "Related genes" example, and will be made more generally available later.

Screenshot of refined annotation labels:
<img width="887" alt="refined_annotation_labels_ideogram_2020-10-28" src="https://user-images.githubusercontent.com/1334561/97391297-4a528000-18b5-11eb-9767-2a39da46e96d.png">
