### PR TITLE
Enable optional "significance" column for cited genes

### DIFF
--- a/data/annotations/gene-cache/homo-sapiens-top-genes.tsv
+++ b/data/annotations/gene-cache/homo-sapiens-top-genes.tsv
@@ -1,17 +1,17 @@
-#name	chromosome	start	length	color	full_name
-TP53	17	7571719	19149	#34a853	tumor protein p53
-UBC	12	125396190	3397	#4285f4	ubiquitin C
-APOE	19	45409005	3647	#4285f4	apolipoprotein E
-IL6	7	22766760	4861	#f06a00	interleukin 6
-MTHFR	1	11845786	20374	#4285f4	methylenetetrahydrofolate reductase (NAD(P)H)
-ESR1	6	152128813	295595	#34a853	estrogen receptor 1
-PTEN	10	89623194	108493	#34a853	phosphatase and tensin homolog
-NFKB1	4	103422485	115974	#f06a00	nuclear factor of kappa light polypeptide gene enhancer in B-cells
-IL10	1	206940947	4892	#f06a00	interleukin 10
-ACE	17	61554421	21320	#ee0000	angiotensin I converting enzyme
-LPL	9	19901717	1	#ee0000	lipoprotein lipase
-APP	21	27252860	290278	#4285f4	amyloid beta (A4) precursor protein
-ACE2	X	15579155	41037	#ee0000	angiotensin I converting enzyme 2
-GLA	X	101407924	0	#ee0000	galactosidase, alpha
-AKT1	14	105235686	0	#34a853	v-akt murine thymoma viral oncogene homolog 1
-HTR2A	13	47405676	0	#4285f4	5-hydroxytryptamine (serotonin) receptor 2A, G protein-coupled
+#name	chromosome	start	length	color	full_name	significance
+TP53	17	7571719	19149	#34a853	tumor protein p53	Tumor suppressor, mutated in up to half of all cancers
+UBC	12	125396190	3397	#4285f4	ubiquitin C	Stress-regulated gene with roles in innate immunity and DNA repair
+APOE	19	45409005	3647	#4285f4	apolipoprotein E	Involved in fat metabolism, implicated in Alzheimer's disease and cardiovascular disease
+IL6	7	22766760	4861	#f06a00	interleukin 6	Has roles in inflammation and immunity
+MTHFR	1	11845786	20374	#4285f4	methylenetetrahydrofolate reductase (NAD(P)H)	Involved in amino acid metabolism
+ESR1	6	152128813	295595	#34a853	estrogen receptor 1	Nuclear receptor implicated in breast, ovarian, and endometrial cancer
+PTEN	10	89623194	108493	#34a853	phosphatase and tensin homolog	Tumor suppressor, mutated in many cancers
+NFKB1	4	103422485	115974	#f06a00	nuclear factor of kappa light polypeptide gene enhancer in B-cells	Has roles in inflammation, immunity, synaptic plasticity, and memory
+IL10	1	206940947	4892	#f06a00	interleukin 10	Anti-inflammatory cytokine
+ACE	17	61554421	21320	#ee0000	angiotensin I converting enzyme	Helps control blood pressure
+LPL	9	19901717	1	#ee0000	lipoprotein lipase	Involved in fat and cholesterol metabolism
+APP	21	27252860	290278	#4285f4	amyloid beta (A4) precursor protein	integral membrane protein, concentrated in neural synapses
+ACE2	X	15579155	41037	#ee0000	angiotensin I converting enzyme 2	Cell entry point for SARS-CoV-2 and some other coranaviruses
+GLA	X	101407924	0	#ee0000	galactosidase, alpha	Implicated in Fabry disease; clinically actionable
+AKT1	14	105235686	0	#34a853	v-akt murine thymoma viral oncogene homolog 1	Inhibits apotosis, has roles in cancer
+HTR2A	13	47405676	0	#4285f4	5-hydroxytryptamine (serotonin) receptor 2A, G protein-coupled	Important target for serotonergic drugs

--- a/dist/data/annotations/gene-cache/homo-sapiens-top-genes.tsv
+++ b/dist/data/annotations/gene-cache/homo-sapiens-top-genes.tsv
@@ -1,17 +1,17 @@
-#name	chromosome	start	length	color	full_name
-TP53	17	7571719	19149	#34a853	tumor protein p53
-UBC	12	125396190	3397	#4285f4	ubiquitin C
-APOE	19	45409005	3647	#4285f4	apolipoprotein E
-IL6	7	22766760	4861	#f06a00	interleukin 6
-MTHFR	1	11845786	20374	#4285f4	methylenetetrahydrofolate reductase (NAD(P)H)
-ESR1	6	152128813	295595	#34a853	estrogen receptor 1
-PTEN	10	89623194	108493	#34a853	phosphatase and tensin homolog
-NFKB1	4	103422485	115974	#f06a00	nuclear factor of kappa light polypeptide gene enhancer in B-cells
-IL10	1	206940947	4892	#f06a00	interleukin 10
-ACE	17	61554421	21320	#ee0000	angiotensin I converting enzyme
-LPL	9	19901717	1	#ee0000	lipoprotein lipase
-APP	21	27252860	290278	#4285f4	amyloid beta (A4) precursor protein
-ACE2	X	15579155	41037	#ee0000	angiotensin I converting enzyme 2
-GLA	X	101407924	0	#ee0000	galactosidase, alpha
-AKT1	14	105235686	0	#34a853	v-akt murine thymoma viral oncogene homolog 1
-HTR2A	13	47405676	0	#4285f4	5-hydroxytryptamine (serotonin) receptor 2A, G protein-coupled
+#name	chromosome	start	length	color	full_name	significance
+TP53	17	7571719	19149	#34a853	tumor protein p53	Tumor suppressor, mutated in up to half of all cancers
+UBC	12	125396190	3397	#4285f4	ubiquitin C	Stress-regulated gene with roles in innate immunity and DNA repair
+APOE	19	45409005	3647	#4285f4	apolipoprotein E	Involved in fat metabolism, implicated in Alzheimer's disease and cardiovascular disease
+IL6	7	22766760	4861	#f06a00	interleukin 6	Has roles in inflammation and immunity
+MTHFR	1	11845786	20374	#4285f4	methylenetetrahydrofolate reductase (NAD(P)H)	Involved in amino acid metabolism
+ESR1	6	152128813	295595	#34a853	estrogen receptor 1	Nuclear receptor implicated in breast, ovarian, and endometrial cancer
+PTEN	10	89623194	108493	#34a853	phosphatase and tensin homolog	Tumor suppressor, mutated in many cancers
+NFKB1	4	103422485	115974	#f06a00	nuclear factor of kappa light polypeptide gene enhancer in B-cells	Has roles in inflammation, immunity, synaptic plasticity, and memory
+IL10	1	206940947	4892	#f06a00	interleukin 10	Anti-inflammatory cytokine
+ACE	17	61554421	21320	#ee0000	angiotensin I converting enzyme	Helps control blood pressure
+LPL	9	19901717	1	#ee0000	lipoprotein lipase	Involved in fat and cholesterol metabolism
+APP	21	27252860	290278	#4285f4	amyloid beta (A4) precursor protein	integral membrane protein, concentrated in neural synapses
+ACE2	X	15579155	41037	#ee0000	angiotensin I converting enzyme 2	Cell entry point for SARS-CoV-2 and some other coranaviruses
+GLA	X	101407924	0	#ee0000	galactosidase, alpha	Implicated in Fabry disease; clinically actionable
+AKT1	14	105235686	0	#34a853	v-akt murine thymoma viral oncogene homolog 1	Inhibits apotosis, has roles in cancer
+HTR2A	13	47405676	0	#4285f4	5-hydroxytryptamine (serotonin) receptor 2A, G protein-coupled	Important target for serotonergic drugs

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -254,6 +254,9 @@
     if ('q' in urlParams) {
       ideogram = Ideogram.initRelatedGenes(config);
     } else {
+      if ('default-hints' in urlParams) {
+        config.annotationsPath = urlParams['default-hints'];
+      }
       ideogram = Ideogram.initGeneHints(config);
     }
   </script>

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -841,8 +841,16 @@ function plotGeneHints() {
   ideo.annotDescriptions = {annots: {}};
 
   ideo.flattenAnnots().map((annot) => {
+    let description = [];
+    if ('significance' in annot && annot.significance !== 'n/a') {
+      description.push(annot.significance);
+    }
+    if ('citations' in annot && annot.citations !== undefined) {
+      description.push(annot.citations);
+    }
+    description = description.join('<br/><br/>');
     ideo.annotDescriptions.annots[annot.name] = {
-      description: annot.significance,
+      description,
       name: annot.fullName
     };
   });

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -842,7 +842,7 @@ function plotGeneHints() {
 
   ideo.flattenAnnots().map((annot) => {
     ideo.annotDescriptions.annots[annot.name] = {
-      description: '',
+      description: annot.significance,
       name: annot.fullName
     };
   });

--- a/src/js/parsers/tsv-parser.js
+++ b/src/js/parsers/tsv-parser.js
@@ -25,7 +25,7 @@ export class TsvParser {
    * Parses an annotation from a tab-separated line of a TSV file
    */
   parseAnnotFromTsvLine(tsvLine, chrs) {
-    var annot, chrIndex, chr, start, color, fullName, name,
+    var annot, chrIndex, chr, start, color, fullName, significance, name,
       columns = tsvLine.split(/\t/g);
 
     [chr, start, stop, length] =
@@ -44,6 +44,10 @@ export class TsvParser {
       fullName = columns[5];
       annot.push(fullName);
     }
+    if (columns.length >= 6) {
+      significance = columns[6];
+      annot.push(significance);
+    }
 
     return [chrIndex, annot];
   }
@@ -61,6 +65,7 @@ export class TsvParser {
     keys = ['name', 'start', 'length', 'trackIndex'];
     if (tsvLines[tsvStartIndex].length >= 4) keys.push('color');
     if (tsvLines[tsvStartIndex].length >= 5) keys.push('fullName');
+    if (tsvLines[tsvStartIndex].length >= 6) keys.push('significance');
 
     rawAnnots = {keys: keys, annots: annots};
 

--- a/src/js/parsers/tsv-parser.js
+++ b/src/js/parsers/tsv-parser.js
@@ -21,11 +21,21 @@ export class TsvParser {
     return [chr, start, stop, length];
   }
 
+  /** If value has substring match in headers, return column index */
+  getValueColumnIndex(value, headerLine) {
+    let index;
+    headerLine.split(/\t/g).forEach((header, i) => {
+      if (header.includes(value)) index = i;
+    });
+    return index;
+  }
+
   /**
    * Parses an annotation from a tab-separated line of a TSV file
    */
-  parseAnnotFromTsvLine(tsvLine, chrs) {
-    var annot, chrIndex, chr, start, color, fullName, significance, name,
+  parseAnnotFromTsvLine(tsvLine, headerLine, chrs) {
+    var annot, chrIndex, chr, start, color, fullName, significance, citations,
+      name, index,
       columns = tsvLine.split(/\t/g);
 
     [chr, start, stop, length] =
@@ -36,16 +46,24 @@ export class TsvParser {
     name = columns[0];
     annot = [name, start, length, 0];
 
-    if (columns.length >= 4) {
-      color = columns[4];
+    if (headerLine.includes('color')) {
+      index = this.getValueColumnIndex('color', headerLine);
+      color = columns[index];
       annot.push(color);
     }
-    if (columns.length >= 5) {
-      fullName = columns[5];
+    if (headerLine.includes('full_name')) {
+      index = this.getValueColumnIndex('full_name', headerLine);
+      fullName = columns[index];
       annot.push(fullName);
     }
-    if (columns.length >= 6) {
-      significance = columns[6];
+    if (headerLine.includes('citations')) {
+      index = this.getValueColumnIndex('citations', headerLine);
+      citations = columns[index];
+      annot.push(citations);
+    }
+    if (headerLine.includes('significance')) {
+      index = this.getValueColumnIndex('significance', headerLine);
+      significance = columns[index];
       annot.push(significance);
     }
 
@@ -55,17 +73,20 @@ export class TsvParser {
   parseRawAnnots(annots, tsvStartIndex, tsvLines, chrs) {
     var i, line, chrIndex, annot, keys, rawAnnots;
 
+    const headerLine = tsvLines[0];
+
     for (i = tsvStartIndex; i < tsvLines.length; i++) {
       line = tsvLines[i];
       if (line.length === 0) continue; // Skip blank lines
-      [chrIndex, annot] = this.parseAnnotFromTsvLine(line, chrs);
+      [chrIndex, annot] = this.parseAnnotFromTsvLine(line, headerLine, chrs);
       if (chrIndex !== null) annots[chrIndex].annots.push(annot);
     }
 
     keys = ['name', 'start', 'length', 'trackIndex'];
-    if (tsvLines[tsvStartIndex].length >= 4) keys.push('color');
-    if (tsvLines[tsvStartIndex].length >= 5) keys.push('fullName');
-    if (tsvLines[tsvStartIndex].length >= 6) keys.push('significance');
+    if (headerLine.includes('color')) keys.push('color');
+    if (headerLine.includes('full_name')) keys.push('fullName');
+    if (headerLine.includes('citations')) keys.push('citations');
+    if (headerLine.includes('significance')) keys.push('significance');
 
     rawAnnots = {keys: keys, annots: annots};
 
@@ -93,6 +114,23 @@ export class TsvParser {
     }
 
     rawAnnots = this.parseRawAnnots(annots, tsvStartIndex, tsvLines, chrs);
+
+    if (tsvStartIndex === 1 && tsvLines[0].includes('citations')) {
+      // TSV has a header, so parse citation_from_<start_date>_to_<end_date>
+      const headers = tsvLines[0].split('\t');
+      const citeIndex = 6;
+      const citeHeader = headers[citeIndex];
+      const fromTo = citeHeader.split('citations_')[1];
+      rawAnnots.annots = rawAnnots.annots.map((annotsByChr) => {
+        annotsByChr.annots = annotsByChr.annots.map((annot) => {
+          annot[citeIndex] =
+            annot[citeIndex] + ' citations ' + fromTo.replace(/_/g, ' ');
+          return annot;
+        });
+        return annotsByChr;
+      });
+    }
+
     return rawAnnots;
   }
 

--- a/test/online/annotation.test.js
+++ b/test/online/annotation.test.js
@@ -8,7 +8,7 @@
 //  - http://martinfowler.com/articles/asyncJS.html
 //  - https://mochajs.org/#asynchronous-code
 
-describe('Ideogram remote annotations', function() {
+describe('Ideogram annotations', function() {
 
   var config = {};
 
@@ -43,6 +43,25 @@ describe('Ideogram remote annotations', function() {
       organism: 'human',
       assembly: 'GRCh37',
       annotationsPath: 'https://raw.githubusercontent.com/NCBI-Hackathons/Scan2CNV/master/files/201113910010_R08C02.PennCnvOut.bed',
+      dataDir: '/dist/data/bands/native/',
+      onDrawAnnots: callback
+    };
+
+    ideogram = new Ideogram(config);
+  });
+
+  it('should have 16 annotations for TSV file', done => {
+    // Tests use case from ../examples/vanilla/related-genes
+
+    function callback() {
+      var numAnnots = document.getElementsByClassName('annot').length;
+      assert.equal(numAnnots, 16);
+      done();
+    }
+
+    var config = {
+      organism: 'human',
+      annotationsPath: '/dist/data/annotations/gene-cache/homo-sapiens-top-genes.tsv',
       dataDir: '/dist/data/bands/native/',
       onDrawAnnots: callback
     };


### PR DESCRIPTION
This allows users to pass in a TSV with an optional "significance" column, yielding tooltips with more human-friendly descriptions like "Has roles in inflammation and immunity" as shown below.

<img width="907" alt="cited_genes_ideogram_significance_in_tooltip_2020-11-30" src="https://user-images.githubusercontent.com/1334561/100697281-959ff880-3363-11eb-9a22-dd726a2dc552.png">


