### PR TITLE
Enable changing font family

### DIFF
--- a/api.md
+++ b/api.md
@@ -49,6 +49,7 @@ var ideogram = new Ideogram({
 * [histogramScaling](#histogramscaling)
 * [heatmaps](#heatmaps)
 * [filterable](#filterable)
+* [fontFamily](#fontfamily)
 * [fullChromosomeLabels](#fullchromosomelabels)
 * [legend](#legend)
 * [onBrushMove](#onbrushmove)
@@ -173,6 +174,9 @@ the heatmap.  Threshold values are specified in ascending order.  Example in [An
 
 ## filterable
 Boolean.  Optional.  Whether annotations should be filterable.  Example in [Annotations, histogram](https://eweitz.github.io/ideogram/annotations-histogram).
+
+## fontFamily
+String.  Optional.  The font family to use for text in the ideogram, e.g. `fontFamily: "'Montserrat', sans-serif"`.
 
 ## fullChromosomeLabels
 Boolean.  Optional.  Whether to include abbreviation species name in chromosome label.  Example in [Homology, interspecies](https://eweitz.github.io/ideogram/homology-interspecies).

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -246,7 +246,7 @@
       chrHeight: 100,
       chrLabelSize: 12,
       annotationHeight: 7,
-      fontFamily: "'Montserrat', sans-serif",
+      // fontFamily: "'Montserrat', sans-serif",
       onLoad: plotGeneFromUrl,
       onPlotRelatedGenes: reportRelatedGenes,
       showAnnotLabels: true,

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -3,7 +3,9 @@
 <head>
   <title>Related genes | Ideogram</title>
   <style>
-    body {font: 14px Arial; line-height: 19.6px; padding: 0 15px;}
+    body {font: 14px Arial; line-height: 19.6px; padding: 0 15px;
+    /* font-family: 'Montserrat', sans-serif; */
+    }
     a, a:visited {text-decoration: none;}
     a:hover {text-decoration: underline;}
     a, a:hover, a:visited, a:active {color: #0366d6;}
@@ -50,7 +52,9 @@
 
   </style>
   <script type="text/javascript" src="../../dist/js/ideogram.min.js"></script>
-<link rel="icon" type="image/x-icon" href="img/ideogram_favicon.ico">
+  <link rel="preconnect" href="https://fonts.gstatic.com">
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300&display=swap" rel="stylesheet">
+  <link rel="icon" type="image/x-icon" href="img/ideogram_favicon.ico">
 </head>
 <body>
   <h1>Related genes | Ideogram</h1>
@@ -242,6 +246,7 @@
       chrHeight: 100,
       chrLabelSize: 12,
       annotationHeight: 7,
+      // font: "'Montserrat', sans-serif",
       onLoad: plotGeneFromUrl,
       onPlotRelatedGenes: reportRelatedGenes,
       showAnnotLabels: true,

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -53,7 +53,7 @@
   </style>
   <script type="text/javascript" src="../../dist/js/ideogram.min.js"></script>
   <link rel="preconnect" href="https://fonts.gstatic.com">
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Montserrat%3A100%2C100italic%2C200%2C200italic%2C300%2C300italic%2C400%2C400italic%2C500%2C500italic%2C600%2C600italic%2C700%2C700italic%2C800%2C800italic%2C900%2C900italic&display=swap&ver=5.7.1" rel="stylesheet">
   <link rel="icon" type="image/x-icon" href="img/ideogram_favicon.ico">
 </head>
 <body>
@@ -246,7 +246,7 @@
       chrHeight: 100,
       chrLabelSize: 12,
       annotationHeight: 7,
-      // font: "'Montserrat', sans-serif",
+      fontFamily: "'Montserrat', sans-serif",
       onLoad: plotGeneFromUrl,
       onPlotRelatedGenes: reportRelatedGenes,
       showAnnotLabels: true,

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -246,7 +246,7 @@
       chrHeight: 100,
       chrLabelSize: 12,
       annotationHeight: 7,
-      // fontFamily: "'Montserrat', sans-serif",
+      fontFamily: "'Montserrat', sans-serif",
       onLoad: plotGeneFromUrl,
       onPlotRelatedGenes: reportRelatedGenes,
       showAnnotLabels: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11690,6 +11690,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -12216,6 +12217,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"

--- a/src/js/annotations/events.js
+++ b/src/js/annotations/events.js
@@ -43,6 +43,7 @@ function renderTooltip(tooltip, content, matrix, yOffset, ideo) {
     .style('opacity', 1) // Make tooltip visible
     .style('left', matrix.e + 'px')
     .style('top', (matrix.f - yOffset) + 'px')
+    .style('font-family', ideo.config.fontFamily)
     .style('pointer-events', null) // Prevent bug in clicking chromosome
     .on('mouseover', function() {
       clearTimeout(ideo.hideAnnotTooltipTimeout);

--- a/src/js/annotations/labels.js
+++ b/src/js/annotations/labels.js
@@ -64,7 +64,6 @@ function triggerAnnotEvent(event, ideo) {
 }
 
 function renderLabel(annot, style, ideo) {
-  const config = ideo.config;
 
   if (!ideo.didSetLabelStyle) {
     document.querySelector('#_ideogramInnerWrap')
@@ -97,10 +96,8 @@ function getFont(ideo) {
     family = config.fontFamily;
   }
 
-  // TODO: De-duplicate with code in getTextWidth and elsewhere
-  // perhaps set config.annotLabelSize and config.annotLabelFont upstream.
   const labelSize = config.annotLabelSize ? config.annotLabelSize : 13;
-  const font = '500 ' + labelSize + 'px ' + family;
+  const font = '600 ' + labelSize + 'px ' + family;
 
   return font;
 }
@@ -110,17 +107,20 @@ function getFont(ideo) {
  *
  * @see https://stackoverflow.com/questions/118241/calculate-text-width-with-javascript/21015393#21015393
  */
-function getTextWidth(text, ideo) {
+function getTextRight(text, ideo) {
   var font = getFont(ideo);
 
   // re-use canvas object for better performance
   var canvas =
-    getTextWidth.canvas ||
-    (getTextWidth.canvas = document.createElement('canvas'));
+    getTextRight.canvas ||
+    (getTextRight.canvas = document.createElement('canvas'));
   var context = canvas.getContext('2d');
   context.font = font;
   var metrics = context.measureText(text);
-  return metrics.width;
+  var right = metrics.actualBoundingBoxRight;
+  var left = metrics.actualBoundingBoxLeft;
+  var width = Math.abs(left) + Math.abs(right);
+  return width;
 }
 
 /** Get annotation object by name, e.g. "BRCA1" */
@@ -156,12 +156,13 @@ function getAnnotLabelLayout(annot, ideo) {
   ideoRect =
     document.querySelector('#_ideogram').getBoundingClientRect();
 
-  width = getTextWidth(annot.name, ideo);
+  right = getTextRight(annot.name, ideo);
 
-  // Accounts for:
+  // `pad` is a heuristic that accounts for:
   // 1px left pad, 1px right pad, 1px right border, 1px left border
-  //  as set in renderLabel
-  width = width + 7;
+  // as set in renderLabel
+  const pad = (config.fontFamily) ? 9 : 7;
+  width = right + pad;
 
   const labelSize = config.annotLabelSize ? config.annotLabelSize : 13;
 

--- a/src/js/annotations/labels.js
+++ b/src/js/annotations/labels.js
@@ -21,6 +21,14 @@ const allLabelStyle = `
       stroke: #D0D0DD !important;
       stroke-width: 1.5px;
     }
+
+    #_ideogram ._ideogramLabel {
+      stroke: white;
+      stroke-width: 5px;
+      stroke-linejoin: round;
+      paint-order: stroke fill;
+      text-align: center;
+    }
   </style>
   `;
 
@@ -78,14 +86,9 @@ function renderLabel(annot, style, ideo) {
     .attr('class', '_ideogramLabel')
     .attr('x', style.left)
     .attr('y', style.top)
-    .style('text-align', 'center')
     .style('font', font)
     .style('fill', fill)
     .style('pointer-events', null) // Prevent bug in clicking chromosome
-    .style('stroke', 'white')
-    .style('stroke-width', '5px')
-    .style('stroke-linejoin', 'round')
-    .style('paint-order', 'stroke fill')
     .html(annot.name);
 }
 

--- a/src/js/annotations/labels.js
+++ b/src/js/annotations/labels.js
@@ -92,10 +92,15 @@ function renderLabel(annot, style, ideo) {
 function getFont(ideo) {
   const config = ideo.config;
 
+  let family = 'sans-serif';
+  if (config.fontFamily) {
+    family = config.fontFamily;
+  }
+
   // TODO: De-duplicate with code in getTextWidth and elsewhere
   // perhaps set config.annotLabelSize and config.annotLabelFont upstream.
   const labelSize = config.annotLabelSize ? config.annotLabelSize : 13;
-  const font = labelSize + 'px sans-serif';
+  const font = '500 ' + labelSize + 'px ' + family;
 
   return font;
 }

--- a/src/js/annotations/labels.js
+++ b/src/js/annotations/labels.js
@@ -74,10 +74,7 @@ function renderLabel(annot, style, ideo) {
 
   const id = getAnnotDomLabelId(annot);
 
-  // TODO: De-duplicate with code in getTextWidth and elsewhere
-  // perhaps set config.annotLabelSize and config.annotLabelFont upstream.
-  const labelSize = config.annotLabelSize ? config.annotLabelSize : 13;
-  const font = labelSize + 'px sans-serif';
+  const font = getFont(ideo);
 
   const fill = annot.color === 'pink' ? '#CF406B' : annot.color;
 
@@ -92,16 +89,24 @@ function renderLabel(annot, style, ideo) {
     .html(annot.name);
 }
 
+function getFont(ideo) {
+  const config = ideo.config;
+
+  // TODO: De-duplicate with code in getTextWidth and elsewhere
+  // perhaps set config.annotLabelSize and config.annotLabelFont upstream.
+  const labelSize = config.annotLabelSize ? config.annotLabelSize : 13;
+  const font = labelSize + 'px sans-serif';
+
+  return font;
+}
+
 /**
  * Compute and return the width of the given text of given font in pixels.
  *
  * @see https://stackoverflow.com/questions/118241/calculate-text-width-with-javascript/21015393#21015393
  */
 function getTextWidth(text, ideo) {
-  var config = ideo.config;
-  var labelSize = config.annotLabelSize ? config.annotLabelSize : 13;
-
-  var font = labelSize + 'px sans-serif';
+  var font = getFont(ideo);
 
   // re-use canvas object for better performance
   var canvas =

--- a/src/js/annotations/legend.js
+++ b/src/js/annotations/legend.js
@@ -61,11 +61,7 @@ function getListItems(labels, svg, list, nameHeight, ideo) {
 }
 
 function getLineHeight(ideo) {
-  const lineHeight = getTextSize('I', ideo).height + 10.5;
-  // const lineHeight = 19
-  console.log(lineHeight)
-
-  return lineHeight;
+  return getTextSize('I', ideo).height + 10.5;
 }
 
 /**
@@ -94,7 +90,6 @@ function writeLegend(ideo) {
   }
 
   if (config.fontFamily) {
-    console.log('ok')
     var fontFamily = `font-family: ${config.fontFamily};`;
     var lineHeightCss = `line-height: ${getLineHeight(ideo)}px;`;
     legendStyle +=

--- a/src/js/annotations/legend.js
+++ b/src/js/annotations/legend.js
@@ -4,9 +4,7 @@
  * Icons may have different shapes.  A legend may also have a name.
  */
 
-import {d3} from '../lib';
-
-var lineHeight = 19;
+import {d3, getTextSize} from '../lib';
 
 var legendStyle =
   '#_ideogramLegend {font: 12px Arial; line-height: 19px; overflow: auto;} ' +
@@ -46,7 +44,8 @@ function getIcon(row, ideo) {
 }
 
 function getListItems(labels, svg, list, nameHeight, ideo) {
-  var i, icon, y, row;
+  var i, icon, y, row,
+    lineHeight = getLineHeight(ideo);
 
   for (i = 0; i < list.rows.length; i++) {
     row = list.rows[i];
@@ -61,12 +60,21 @@ function getListItems(labels, svg, list, nameHeight, ideo) {
   return [labels, svg];
 }
 
+function getLineHeight(ideo) {
+  const lineHeight = getTextSize('I', ideo).height + 10.5;
+  // const lineHeight = 19
+  console.log(lineHeight)
+
+  return lineHeight;
+}
+
 /**
  * Display a legend for genome annotations, using `legend` configuration option
  */
 function writeLegend(ideo) {
   var i, legend, svg, labels, list, content,
-    config = ideo.config;
+    config = ideo.config,
+    lineHeight = getLineHeight(ideo);
 
   d3.select(config.container + ' #_ideogramLegend').remove();
 
@@ -86,8 +94,11 @@ function writeLegend(ideo) {
   }
 
   if (config.fontFamily) {
+    console.log('ok')
+    var fontFamily = `font-family: ${config.fontFamily};`;
+    var lineHeightCss = `line-height: ${getLineHeight(ideo)}px;`;
     legendStyle +=
-      `#_ideogramLegend {font-family: ${config.fontFamily}}`;
+      `#_ideogramLegend {${fontFamily}} ${lineHeightCss}}`;
   }
 
   var target = d3.select(config.container + ' #_ideogramOuterWrap');

--- a/src/js/annotations/legend.js
+++ b/src/js/annotations/legend.js
@@ -65,11 +65,12 @@ function getListItems(labels, svg, list, nameHeight, ideo) {
  * Display a legend for genome annotations, using `legend` configuration option
  */
 function writeLegend(ideo) {
-  var i, legend, svg, labels, list, content;
+  var i, legend, svg, labels, list, content,
+    config = ideo.config;
 
-  d3.select(ideo.config.container + ' #_ideogramLegend').remove();
+  d3.select(config.container + ' #_ideogramLegend').remove();
 
-  legend = ideo.config.legend;
+  legend = config.legend;
   content = '';
 
   for (i = 0; i < legend.length; i++) {
@@ -84,7 +85,12 @@ function writeLegend(ideo) {
     content += svg + '<ul>' + labels + '</ul>';
   }
 
-  var target = d3.select(ideo.config.container + ' #_ideogramOuterWrap');
+  if (config.fontFamily) {
+    legendStyle +=
+      `#_ideogramLegend {font-family: ${config.fontFamily}}`;
+  }
+
+  var target = d3.select(config.container + ' #_ideogramOuterWrap');
   target.append('style').html(legendStyle);
   target.append('div').attr('id', '_ideogramLegend').html(content);
 }

--- a/src/js/init/configure.js
+++ b/src/js/init/configure.js
@@ -155,10 +155,13 @@ function configureTextStyle(ideo) {
   const config = ideo.config;
   if (!config.chrLabelSize) ideo.config.chrLabelSize = 9;
   if (!config.chrLabelColor) ideo.config.chrLabelColor = '#000';
+  if (!config.font) ideo.config.font = '';
 
   const size = `font-size: ${config.chrLabelSize}px`;
   const color = `fill: ${config.chrLabelColor}`;
-  configuredCss += `#_ideogram text {${size}; ${color};}`;
+  const font = `font-family: ${config.font}`;
+  configuredCss += `#_ideogram text {${font}; ${size}; ${color};}`;
+  configuredCss += `#_ideogramLabel text {${font};}`;
 }
 
 /**

--- a/src/js/init/configure.js
+++ b/src/js/init/configure.js
@@ -159,9 +159,9 @@ function configureTextStyle(ideo) {
 
   const size = `font-size: ${config.chrLabelSize}px`;
   const color = `fill: ${config.chrLabelColor}`;
-  const font = `font-family: ${config.font}`;
-  configuredCss += `#_ideogram text {${font}; ${size}; ${color};}`;
-  configuredCss += `#_ideogramLabel text {${font};}`;
+  const fontFamily = `font-family: ${config.fontFamily}`;
+  configuredCss += `#_ideogram text {${fontFamily}; ${size}; ${color};}`;
+  configuredCss += `#_ideogramLabel text {${fontFamily};}`;
 }
 
 /**

--- a/src/js/init/configure.js
+++ b/src/js/init/configure.js
@@ -155,7 +155,7 @@ function configureTextStyle(ideo) {
   const config = ideo.config;
   if (!config.chrLabelSize) ideo.config.chrLabelSize = 9;
   if (!config.chrLabelColor) ideo.config.chrLabelColor = '#000';
-  if (!config.font) ideo.config.font = '';
+  if (!config.fontFamily) ideo.config.fontFamily = '';
 
   const size = `font-size: ${config.chrLabelSize}px`;
   const color = `fill: ${config.chrLabelColor}`;

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -737,10 +737,8 @@ function decorateRelatedGene(annot) {
 
 const shape = 'triangle';
 
-let fontFamily;
-
 const legendHeaderStyle =
-  `font-size: 14px; font-weight: bold; font-color: #333; ${fontFamily}`;
+  `font-size: 14px; font-weight: bold; font-color: #333;`;
 const relatedLegend = [{
   name: `
     <div style="position: relative; left: -15px; padding-bottom: 10px;">
@@ -789,8 +787,6 @@ function _initRelatedGenes(config, annotsInList) {
   if (annotsInList !== 'all') {
     annotsInList = annotsInList.map(name => name.toLowerCase());
   }
-
-  fontFamily = (config.fontFamily) ? config.fontFamily : '';
 
   const kitDefaults = {
     showFullyBanded: false,
@@ -886,8 +882,6 @@ function _initGeneHints(config, annotsInList) {
   if (annotsInList !== 'all') {
     annotsInList = annotsInList.map(name => name.toLowerCase());
   }
-
-  fontFamily = (config.fontFamily) ? config.fontFamily : '';
 
   const annotsPath =
     getDir('annotations/gene-cache/homo-sapiens-top-genes.tsv');

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -590,7 +590,7 @@ function adjustPlaceAndVisibility(ideo) {
     // is variable upon first rendering plotted genes
 
     var ideoDom = document.querySelector('#_ideogram');
-    const legendWidth = 150;
+    const legendWidth = 160;
     ideoInnerDom.style.maxWidth =
       (
         parseInt(ideoInnerDom.style.maxWidth) +
@@ -737,8 +737,10 @@ function decorateRelatedGene(annot) {
 
 const shape = 'triangle';
 
+let fontFamily;
+
 const legendHeaderStyle =
-  'font-size: 14px; font-weight: bold; font-color: #333';
+  `font-size: 14px; font-weight: bold; font-color: #333; ${fontFamily}`;
 const relatedLegend = [{
   name: `
     <div style="position: relative; left: -15px; padding-bottom: 10px;">
@@ -768,7 +770,7 @@ const citedLegend = [{
 /** Sets annotDecorPad for related genes view */
 function setRelatedDecorPad(kitConfig) {
   if (kitConfig.showAnnotLabels) {
-    kitConfig.annotDecorPad = 60;
+    kitConfig.annotDecorPad = 70;
   } else {
     kitConfig.annotDecorPad = 30;
   }
@@ -787,6 +789,8 @@ function _initRelatedGenes(config, annotsInList) {
   if (annotsInList !== 'all') {
     annotsInList = annotsInList.map(name => name.toLowerCase());
   }
+
+  fontFamily = (config.fontFamily) ? config.fontFamily : '';
 
   const kitDefaults = {
     showFullyBanded: false,
@@ -882,6 +886,8 @@ function _initGeneHints(config, annotsInList) {
   if (annotsInList !== 'all') {
     annotsInList = annotsInList.map(name => name.toLowerCase());
   }
+
+  fontFamily = (config.fontFamily) ? config.fontFamily : '';
 
   const annotsPath =
     getDir('annotations/gene-cache/homo-sapiens-top-genes.tsv');

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -397,7 +397,7 @@ function parseAnnotFromMgiGene(gene, ideo, color='red') {
 
 function moveLegend() {
   const ideoInnerDom = document.querySelector('#_ideogramInnerWrap');
-  const decorPad = setRelatedDecorPad({}).annotDecorPad;
+  const decorPad = setRelatedDecorPad({}).legendPad;
   const left = decorPad + 20;
   const legendStyle = `position: absolute; top: 15px; left: ${left}px`;
   const legend = document.querySelector('#_ideogramLegend');
@@ -583,7 +583,7 @@ function adjustPlaceAndVisibility(ideo) {
   ideoInnerDom.style.overflowY = 'hidden';
   document.querySelector('#_ideogramMiddleWrap').style.overflowY = 'hidden';
 
-  const annotDecorPad = ideo.config.annotDecorPad;
+  const legendPad = ideo.config.legendPad;
 
   if (typeof ideo.didAdjustIdeogramLegend === 'undefined') {
     // Accounts for moving legend when external content at left or right
@@ -595,13 +595,13 @@ function adjustPlaceAndVisibility(ideo) {
       (
         parseInt(ideoInnerDom.style.maxWidth) +
         legendWidth +
-        annotDecorPad
+        legendPad
       ) + 'px';
 
     ideoDom.style.minWidth =
-      (parseInt(ideoDom.style.minWidth) + annotDecorPad) + 'px';
+      (parseInt(ideoDom.style.minWidth) + legendPad) + 'px';
     ideoDom.style.maxWidth =
-      (parseInt(ideoDom.style.minWidth) + annotDecorPad) + 'px';
+      (parseInt(ideoDom.style.minWidth) + legendPad) + 'px';
     ideoDom.style.position = 'relative';
     ideoDom.style.left = legendWidth + 'px';
 
@@ -767,12 +767,12 @@ const citedLegend = [{
   rows: []
 }];
 
-/** Sets annotDecorPad for related genes view */
+/** Sets legendPad for related genes view */
 function setRelatedDecorPad(kitConfig) {
   if (kitConfig.showAnnotLabels) {
-    kitConfig.annotDecorPad = 70;
+    kitConfig.legendPad = 70;
   } else {
-    kitConfig.annotDecorPad = 30;
+    kitConfig.legendPad = 30;
   }
   return kitConfig;
 }
@@ -936,9 +936,9 @@ function _initGeneHints(config, annotsInList) {
   const kitConfig = Object.assign(kitDefaults, config);
 
   if (kitConfig.showAnnotLabels) {
-    kitConfig.annotDecorPad = 80;
+    kitConfig.legendPad = 80;
   } else {
-    kitConfig.annotDecorPad = 30;
+    kitConfig.legendPad = 30;
   }
 
   const ideogram = new Ideogram(kitConfig);

--- a/src/js/layouts/vertical-layout.js
+++ b/src/js/layouts/vertical-layout.js
@@ -159,7 +159,7 @@ class VerticalLayout extends Layout {
         return margin + setIndex * (margin + width + 3) + barWidth * 2;
       } else {
         const decorPad =
-          'annotDecorPad' in config ? config.annotDecorPad : 0;
+          'legendPad' in config ? config.legendPad : 0;
         translate = width + setIndex * (margin + width) + pad * 2 + decorPad;
         if (pad > 0) {
           return translate;

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -292,10 +292,53 @@ function downloadPng(ideo) {
   img.src = url;
 }
 
+
+function getFont(ideo) {
+  const config = ideo.config;
+
+  let family = 'sans-serif';
+  if (config.fontFamily) {
+    family = config.fontFamily;
+  }
+
+  const labelSize = config.annotLabelSize ? config.annotLabelSize : 13;
+  const font = '600 ' + labelSize + 'px ' + family;
+
+  return font;
+}
+
+/**
+ * Get width and height of given text in pixels.
+ *
+ * Background: https://erikonarheim.com/posts/canvas-text-metrics/
+ */
+function getTextSize(text, ideo) {
+  var font = getFont(ideo);
+
+  // re-use canvas object for better performance
+  var canvas =
+    getTextSize.canvas ||
+    (getTextSize.canvas = document.createElement('canvas'));
+  var context = canvas.getContext('2d');
+  context.font = font;
+  var metrics = context.measureText(text);
+
+  // metrics.width is less precise than technique below
+  var right = metrics.actualBoundingBoxRight;
+  var left = metrics.actualBoundingBoxLeft;
+  var width = Math.abs(left) + Math.abs(right);
+
+  const height =
+    Math.abs(metrics.actualBoundingBoxAscent) +
+    Math.abs(metrics.actualBoundingBoxDescent);
+
+  return {width, height};
+}
+
 export {
   assemblyIsAccession, hasNonGenBankAssembly, hasGenBankAssembly, getDataDir,
   getDir, round, onDidRotate, getSvg, d3, getTaxid, getCommonName,
   getScientificName, slug, isRoman, parseRoman, downloadPng,
-  fetchWithRetry,
+  fetchWithRetry, getTextSize, getFont,
   fetchWithAuth as fetch
 };

--- a/test/offline/core.test.js
+++ b/test/offline/core.test.js
@@ -783,5 +783,4 @@ describe('Ideogram', function() {
 
     var ideogram = new Ideogram(config);
   });
-
 });

--- a/test/online/related-genes.test.js
+++ b/test/online/related-genes.test.js
@@ -16,7 +16,12 @@ describe('Ideogram related genes kit', function() {
     d3.selectAll('div').remove();
   });
 
-  it('handles searched gene and annotation click', done => {
+  function getFontFamily(selector) {
+    const element = document.querySelector(selector);
+    return window.getComputedStyle(element).getPropertyValue('font-family');
+  }
+
+  it('handles searched gene, annotation click, and font', done => {
 
     async function callback() {
       await ideogram.plotRelatedGenes('RAD51');
@@ -45,7 +50,9 @@ describe('Ideogram related genes kit', function() {
     }
 
     function onPlotRelatedGenes() {
-      // pass through
+      const legendFontFamily = getFontFamily('#_ideogramLegend');
+      assert.equal(legendFontFamily, 'serif');
+      assert.equal(getFontFamily('.chrLabel'), 'serif');
     }
 
     function onWillShowAnnotTooltip(annot) {
@@ -65,7 +72,8 @@ describe('Ideogram related genes kit', function() {
       dataDir: '/dist/data/bands/native/',
       onClickAnnot,
       onPlotRelatedGenes,
-      onWillShowAnnotTooltip
+      onWillShowAnnotTooltip,
+      fontFamily: 'serif'
     };
 
     const ideogram = Ideogram.initRelatedGenes(config);


### PR DESCRIPTION
This adds support for specifying the font family to use for text in the ideogram.  It helps ideogram match the look and feel of the embedding application, in cases where this is important.

Example in the "Related genes" kit, using `fontFamily: "'Montserrat', sans-serif"`:
<img width="924" alt="font_family_ideogram_2021-05-09" src="https://user-images.githubusercontent.com/1334561/117575973-fde0cc00-b0b1-11eb-8ded-83de7bd0429f.png">

With default font:
<img width="919" alt="font_family_default_ideogram_2021-05-09" src="https://user-images.githubusercontent.com/1334561/117576156-bc9cec00-b0b2-11eb-85b1-132ccb73a14f.png">

This also fixes a few minor style and interaction issues, building on #252.