### PR TITLE
Ensure labels for higher-ranked annotations appear in front

### DIFF
--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -246,7 +246,7 @@
       chrHeight: 100,
       chrLabelSize: 12,
       annotationHeight: 7,
-      fontFamily: "'Montserrat', sans-serif",
+      // fontFamily: "'Montserrat', sans-serif",
       onLoad: plotGeneFromUrl,
       onPlotRelatedGenes: reportRelatedGenes,
       showAnnotLabels: true,

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -246,7 +246,7 @@
       chrHeight: 100,
       chrLabelSize: 12,
       annotationHeight: 7,
-      // fontFamily: "'Montserrat', sans-serif",
+      fontFamily: "'Montserrat', sans-serif",
       onLoad: plotGeneFromUrl,
       onPlotRelatedGenes: reportRelatedGenes,
       showAnnotLabels: true,

--- a/src/js/annotations/labels.js
+++ b/src/js/annotations/labels.js
@@ -230,6 +230,11 @@ function fillAnnotLabels(sortedAnnots=[]) {
     spacedLayouts.push(layout);
   });
 
+  // Ensure highest-ranked annots are ordered last in SVG,
+  // to ensure the are written before lower-ranked annots
+  // (which, due to SVG z-index being tied to layering)
+  spacedAnnots.reverse();
+
   spacedAnnots.forEach((annot) => {
     ideo.addAnnotLabel(annot.name);
   });

--- a/src/js/annotations/legend.js
+++ b/src/js/annotations/legend.js
@@ -4,10 +4,10 @@
  * Icons may have different shapes.  A legend may also have a name.
  */
 
-import {d3, getTextSize} from '../lib';
+import {d3, getTextSize, round} from '../lib';
 
 var legendStyle =
-  '#_ideogramLegend {font: 12px Arial; line-height: 19px; overflow: auto;} ' +
+  '#_ideogramLegend {font: 12px Arial; overflow: auto;} ' +
   '#_ideogramLegend svg {float: left;} ' +
   '#_ideogramLegend ul {' +
     'position: relative; left: -14px; list-style: none; float: left; ' +
@@ -50,7 +50,7 @@ function getListItems(labels, svg, list, nameHeight, ideo) {
   for (i = 0; i < list.rows.length; i++) {
     row = list.rows[i];
     labels += '<li>' + row.name + '</li>';
-    y = lineHeight * i + nameHeight;
+    y = lineHeight * (i - 1) + nameHeight + 1;
     if ('name' in list) y += lineHeight;
     icon = getIcon(row, ideo);
     const transform = 'translate(0, ' + y + ')';
@@ -61,7 +61,7 @@ function getListItems(labels, svg, list, nameHeight, ideo) {
 }
 
 function getLineHeight(ideo) {
-  return getTextSize('I', ideo).height + 10.5;
+  return round(getTextSize('A', ideo).height) * 2 + 0.5;
 }
 
 /**
@@ -80,8 +80,9 @@ function writeLegend(ideo) {
   for (i = 0; i < legend.length; i++) {
     list = legend[i];
     const nameHeight = list.nameHeight ? list.nameHeight : 0;
+    const heightCss = (nameHeight) ? ` style="height: ${nameHeight}px;"` : '';
     if ('name' in list) {
-      labels = '<div>' + list.name + '</div>';
+      labels = `<div${heightCss}>` + list.name + `</div>`;
     }
     svg = '<svg id="_ideogramLegendSvg" width="' + lineHeight + '">';
     [labels, svg] = getListItems(labels, svg, list, nameHeight, ideo);
@@ -89,12 +90,10 @@ function writeLegend(ideo) {
     content += svg + '<ul>' + labels + '</ul>';
   }
 
-  if (config.fontFamily) {
-    var fontFamily = `font-family: ${config.fontFamily};`;
-    var lineHeightCss = `line-height: ${getLineHeight(ideo)}px;`;
-    legendStyle +=
-      `#_ideogramLegend {${fontFamily}} ${lineHeightCss}}`;
-  }
+  var fontFamily = `font-family: ${config.fontFamily};`;
+  var lineHeightCss = `line-height: ${getLineHeight(ideo)}px;`;
+  legendStyle +=
+    `#_ideogramLegend {${fontFamily} ${lineHeightCss}}`;
 
   var target = d3.select(config.container + ' #_ideogramOuterWrap');
   target.append('style').html(legendStyle);

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -741,12 +741,12 @@ const legendHeaderStyle =
   `font-size: 14px; font-weight: bold; font-color: #333;`;
 const relatedLegend = [{
   name: `
-    <div style="position: relative; left: -15px; padding-bottom: 10px;">
+    <div style="position: relative; left: -15px;">
       <div style="${legendHeaderStyle}">Related genes</div>
       <i>Click gene to search</i>
     </div>
   `,
-  nameHeight: 30,
+  nameHeight: 50,
   rows: [
     {name: 'Interacting gene', color: 'purple', shape: shape},
     {name: 'Paralogous gene', color: 'pink', shape: shape},
@@ -756,7 +756,7 @@ const relatedLegend = [{
 
 const citedLegend = [{
   name: `
-    <div style="position: relative; left: -15px; padding-bottom: 10px;">
+    <div style="position: relative; left: -15px;">
       <div style="${legendHeaderStyle}">Highly cited genes</div>
       <i>Click gene to search</i>
     </div>

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -114,9 +114,9 @@ function getDataDir() {
 }
 
 /**
- * Rounds an SVG coordinates to two decimal places
+ * Rounds a float (e.g. SVG coordinate) to two decimal places
  *
- * @param coord SVG coordinate, e.g. 42.1234567890
+ * @param coord Floating-point number, e.g. 42.1234567890
  * @returns {number} Rounded value, e.g. 42.12
  */
 function round(coord) {


### PR DESCRIPTION
This fixes a z-index bug, in which the label for higher-ranked annotation (e.g. a searched gene) could be overwritten by the label of a lower-ranked annotation (e.g. a related, interacting gene).

Example with [genes related to CD8A](https://eweitz.github.io/ideogram/related-genes?org=homo-sapiens&q=CD8A):

### Before
<img width="886" alt="Label_z-index_bug_ideogram_2021-05-11" src="https://user-images.githubusercontent.com/1334561/117806811-ce080480-b228-11eb-8404-9a4fe66b8d82.png">

### After
<img width="890" alt="Label_z-index_bug_fix_ideogram_2021-05-11" src="https://user-images.githubusercontent.com/1334561/117806854-deb87a80-b228-11eb-9789-adafcb39dcc5.png">
