### PR TITLE
Prototype gene cache

### DIFF
--- a/src/js/gene-cache.js
+++ b/src/js/gene-cache.js
@@ -1,8 +1,16 @@
 /**
  * @fileoverview Fetch cached gene data: name, position, etc.
+ *
+ * Gene cache eliminates needing to fetch names and positions of genes.
+ *
+ * Use cases:
+ *
+ * - test if a given string is a gene name, e.g. for gene search
+ * - find genomic position of a given gene (or all genes)
+ *
  */
 
-import {slug} from './lib'
+import {slug} from './lib';
 
 /** Get URL for gene cache file */
 function getCacheUrl(orgName, cacheDir, ideo) {
@@ -20,36 +28,71 @@ function getCacheUrl(orgName, cacheDir, ideo) {
   return cacheUrl;
 }
 
+/**
+ * Convert array of [chr, start, gene] arrays to Ideogram annotations
+ * sorted by genomic position.
+ */
+function parseAnnots(chrStartGenes) {
+  const chromosomes = {};
+
+  chrStartGenes.forEach(([chromosome, start, gene]) => {
+    if (!(chromosome in chromosomes)) {
+      chromosomes[chromosome] = {chr: chromosome, annots: []};
+    } else {
+      chromosomes[chromosome].annots.push({name: gene, start})
+    }
+  });
+
+  const annotsSortedByPosition = {};
+
+  Object.entries(chromosomes).forEach(([chr, annotsByChr]) => {
+    annotsSortedByPosition[chr] = {
+      chr,
+      annots: annotsByChr.annots.sort((a, b) => a.start - b.start)
+    };
+  });
+
+  return annotsSortedByPosition;
+}
+
 function parseCache(rawTsv) {
   const citedNames = [];
   const lociByName = {};
+  const chrStartGenes = [];
 
   const lines = rawTsv.split(/\r\n|\n/);
 
   lines.forEach((line) => {
-    if (line[0] === '#') return;
-    const {gene, chromosome, start} = line.split(/\t/);
+    if (line[0] === '#' || line === '') return; // Skip headers, empty lines
+    const [chromosome, rawStart, gene] = line.split(/\t/);
+    const start = parseInt(rawStart);
+    chrStartGenes.push([chromosome, start, gene]);
 
     citedNames.push(gene);
     lociByName[gene] = [chromosome, start];
   });
 
-  return citedNames, lociByName;
+  const sortedAnnots = parseAnnots(chrStartGenes);
+
+  return [citedNames, lociByName, sortedAnnots];
 }
 
 /**
  * Fetch cached gene data, transform it usefully, and set it as ideo prop
  */
-export default async function initGeneCache(orgName, cacheDir=null, ideo) {
+export default async function initGeneCache(orgName, ideo, cacheDir=null) {
   const cacheUrl = getCacheUrl(orgName, cacheDir, ideo);
 
   const response = await fetch(cacheUrl);
   const data = await response.text();
 
-  const [citedNames, lociByName] = parseCache(data);
+  console.log('data', data)
+
+  const [citedNames, lociByName, sortedAnnots] = parseCache(data);
 
   ideo.geneCache = {
     citedNames, // Array of gene names, ordered by citation count
-    lociByName // Object of gene positions, keyed by gene name
+    lociByName, // Object of gene positions, keyed by gene name
+    sortedAnnots // Ideogram annotations sorted by genomic position
   };
 }

--- a/src/js/gene-cache.js
+++ b/src/js/gene-cache.js
@@ -55,6 +55,7 @@ function parseAnnots(chrStartGenes) {
   return annotsSortedByPosition;
 }
 
+/** Parse a gene cache TSV file, return array of useful transforms */
 function parseCache(rawTsv) {
   const citedNames = [];
   const lociByName = {};
@@ -85,8 +86,6 @@ export default async function initGeneCache(orgName, ideo, cacheDir=null) {
 
   const response = await fetch(cacheUrl);
   const data = await response.text();
-
-  console.log('data', data)
 
   const [citedNames, lociByName, sortedAnnots] = parseCache(data);
 

--- a/src/js/gene-cache.js
+++ b/src/js/gene-cache.js
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview Fetch cached gene data: name, position, etc.
+ */
+
+import {slug} from './lib'
+
+/** Get URL for gene cache file */
+function getCacheUrl(orgName, cacheDir, ideo) {
+  const organism = slug(orgName);
+
+  if (!cacheDir) {
+    const splitDataDir = ideo.config.dataDir.split('/');
+    const dataIndex = splitDataDir.indexOf('data');
+    const baseDir = splitDataDir.slice(0, dataIndex).join('/') + '/data/';
+    cacheDir = baseDir + 'annotations/gene-cache/';
+  }
+
+  const cacheUrl = cacheDir + organism + '.tsv';
+
+  return cacheUrl;
+}
+
+function parseCache(rawTsv) {
+  const citedNames = [];
+  const lociByName = {};
+
+  const lines = rawTsv.split(/\r\n|\n/);
+
+  lines.forEach((line) => {
+    if (line[0] === '#') return;
+    const {gene, chromosome, start} = line.split(/\t/);
+
+    citedNames.push(gene);
+    lociByName[gene] = [chromosome, start];
+  });
+
+  return citedNames, lociByName;
+}
+
+/**
+ * Fetch cached gene data, transform it usefully, and set it as ideo prop
+ */
+export default async function initGeneCache(orgName, cacheDir=null, ideo) {
+  const cacheUrl = getCacheUrl(orgName, cacheDir, ideo);
+
+  const response = await fetch(cacheUrl);
+  const data = await response.text();
+
+  const [citedNames, lociByName] = parseCache(data);
+
+  ideo.geneCache = {
+    citedNames, // Array of gene names, ordered by citation count
+    lociByName // Object of gene positions, keyed by gene name
+  };
+}

--- a/src/js/ideogram.js
+++ b/src/js/ideogram.js
@@ -286,7 +286,6 @@ export default class Ideogram {
    * - Among non-nuclear chromosomes, i.e. "MT" (mitochondrial DNA) and
    *   "CP" (chromoplast DNA), MT comes first
    *
-   *
    * @param a Chromosome string or object "A"
    * @param b Chromosome string or object "B"
    * @returns {Number} JavaScript sort order indicator

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -5,7 +5,7 @@
  * which finds and displays related genes for a searched gene.
  *
  * Related genes here are either "interacting genes" or "paralogs".
- * Interacting genes are genes that immediate upstream or downstream of the
+ * Interacting genes are genes immediately upstream or downstream of the
  * searched gene in a biochemical pathway. Paralogs are evolutionarily
  * similar genes in the same species.
  *

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -30,6 +30,7 @@ import {
 import {writeLegend} from '../annotations/legend';
 import {getAnnotDomId} from '../annotations/process';
 import {getDir} from '../lib';
+import initGeneCache from '../gene-cache';
 
 /** Sets DOM IDs for ideo.relatedAnnots; needed to associate labels */
 function setRelatedAnnotDomIds(ideo) {
@@ -835,6 +836,8 @@ function _initRelatedGenes(config, annotsInList) {
   ideogram.annotSortFunction = sortAnnotsByRelatedStatus;
 
   initAnalyzeRelatedGenes(ideogram);
+
+  initGeneCache(ideogram.config.organism, ideogram);
 
   return ideogram;
 }


### PR DESCRIPTION
This adds an early prototype of gene caching.   Use cases:

* Speed up and ease plotting genes along chromosomes
* Test if a given string is a gene name, e.g. for related genes and gene search
* Find genomic position of a given gene (or all genes)