### PR TITLE
Use gene cache to detect if interaction node is gene

### DIFF
--- a/src/js/gene-cache.js
+++ b/src/js/gene-cache.js
@@ -10,7 +10,8 @@
  *
  */
 
-import {slug} from './lib';
+import {slug, getEarlyTaxid} from './lib';
+import {organismMetadata} from './init/organism-metadata';
 
 /** Get URL for gene cache file */
 function getCacheUrl(orgName, cacheDir, ideo) {
@@ -78,10 +79,22 @@ function parseCache(rawTsv) {
   return [citedNames, lociByName, sortedAnnots];
 }
 
+/** Reports if current organism has a gene cache */
+function hasGeneCache(orgName) {
+  const taxid = getEarlyTaxid(orgName);
+  const metadata = organismMetadata[taxid];
+  return ('hasGeneCache' in metadata && metadata.hasGeneCache === true);
+}
+
 /**
  * Fetch cached gene data, transform it usefully, and set it as ideo prop
  */
 export default async function initGeneCache(orgName, ideo, cacheDir=null) {
+
+  if (!hasGeneCache(orgName)) {
+    return; // Skip initialization if cache doesn't exist
+  }
+
   const cacheUrl = getCacheUrl(orgName, cacheDir, ideo);
 
   const response = await fetch(cacheUrl);

--- a/src/js/init/organism-metadata.js
+++ b/src/js/init/organism-metadata.js
@@ -7,7 +7,8 @@ var organismMetadata = {
       GRCh38: 'GCF_000001405.26',
       GRCh37: 'GCF_000001405.13',
       NCBI36: 'GCF_000001405.12'
-    }
+    },
+    hasGeneCache: true
   },
   10090: {
     commonName: 'Mouse',

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -11,6 +11,8 @@ import {scaleLinear} from 'd3-scale';
 import {max} from 'd3-array';
 import {easeExpIn} from 'd3-ease';
 
+import {organismMetadata} from './init/organism-metadata';
+
 var d3 = Object.assign(
   {}, d3fetch, d3brush, d3dispatch, d3format
 );
@@ -150,6 +152,21 @@ function fetchWithAuth(url, contentType) {
   } else {
     return d3.json(url, {headers: headers});
   }
+}
+
+/** getTaxid(), but without need to initialize ideogram  */
+function getEarlyTaxid(name) {
+  name = slug(name);
+  for (const taxid in organismMetadata) {
+    const organism = organismMetadata[taxid];
+    const commonName = slug(organism.commonName);
+    const scientificName = slug(organism.scientificName);
+    if (commonName === name || scientificName === name) {
+      return taxid;
+    }
+  }
+
+  return null;
 }
 
 /**
@@ -337,8 +354,8 @@ function getTextSize(text, ideo) {
 
 export {
   assemblyIsAccession, hasNonGenBankAssembly, hasGenBankAssembly, getDataDir,
-  getDir, round, onDidRotate, getSvg, d3, getTaxid, getCommonName,
-  getScientificName, slug, isRoman, parseRoman, downloadPng,
+  getDir, round, onDidRotate, getSvg, d3, getEarlyTaxid, getTaxid,
+  getCommonName, getScientificName, slug, isRoman, parseRoman, downloadPng,
   fetchWithRetry, getTextSize, getFont,
   fetchWithAuth as fetch
 };


### PR DESCRIPTION
This uses the new gene cache (#272) to detect if an interaction node represents a gene.  It fixes a bug in the related genes kit, e.g. when searching e.g. PIK3R1 as shown below.

Bug:
<img width="939" alt="Bug_in_PIK3R1_related_genes_ideogram_2021-06-04" src="https://user-images.githubusercontent.com/1334561/120803513-9fbcd280-c511-11eb-87bb-947651b8aaae.png">

Fix:
<img width="930" alt="PIK3R1_related_genes_ideogram_2021-06-04" src="https://user-images.githubusercontent.com/1334561/120803514-9fbcd280-c511-11eb-859d-3d9b523e6cd1.png">

The problem occurred when WikiPathways returned nodes for non-genes, and Ideogram would query MyGene.info using the non-gene labels as gene symbols, e.g. https://mygene.info/v3/query?q=symbol:PRKCA%20OR%20symbol:GRB2%20OR%20symbol:PIK3CA%20OR%20symbol:AKT1%20OR%20symbol:VAV1%20OR%20symbol:PIP3%20OR%20symbol:PTPN11%20OR%20symbol:PIK3CD%20OR%20symbol:CRK%20OR%20symbol:SRC%20OR%20symbol:CD28%20OR%20symbol:CBL%20OR%20symbol:SHB%20OR%20symbol:IL5RA%20OR%20symbol:GNB1%20OR%20symbol:hsa-mir-15b%20OR%20symbol:IL1B%20OR%20symbol:LAT%20OR%20symbol:GAB1%20OR%20symbol:IRS2%20OR%20symbol:SH2B1%20OR%20symbol:LCK%20OR%20symbol:PI(3,4,5)P3%20OR%20symbol:AKT3%20OR%20symbol:PIK3CB%20OR%20symbol:AP2A1%20OR%20symbol:PIP2%20OR%20symbol:TRB%20OR%20symbol:AKT2%20OR%20symbol:PDK1%20OR%20symbol:Invasion%20OR%20symbol:Osteoblast%20OR%20symbol:PIK3C2B%20OR%20symbol:PIK3%20OR%20symbol:PRKCZ&species=9606&fields=symbol,genomic_pos,name&size=20.

In that case, some non-gene "symbols" _would convert to gene symbols_ in MyGene.info, and be spuriously displayed as interacting genes in the related genes ideogram.  

By using the complete list of known genes from the gene cache, Ideogram can not robustly detect if a WikiPathways interaction node represents a gene.