### PR TITLE
Speed up gene search in "Related genes"

### DIFF
--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -132,6 +132,7 @@
       'saccharomyces-cerevisiae': ['rad51', 'atp6', 'cytb'],
       'arabidopsis-thaliana': ['PHYA', 'FLC', 'FT'],
       'danio-rerio': ['bmp4', 'myod1', 'cyp1a'],
+      'pan-troglodytes': ['RAD51', 'CD4', 'APOE'],
       'macaca-mulatta': ['RAD51', 'CD4', 'APOE'],
       'macaca-fascicularis': ['RAD51', 'CD4', 'APOE'],
       'felis-catus': ['RAD51', 'CD4', 'APOE'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "d3-dispatch": "^2.0.0",
         "d3-fetch": "^2.0.0",
         "d3-format": "^2.0.0",
-        "d3-scale": "^3.2.3"
+        "d3-scale": "^3.2.3",
+        "idb-keyval": "^6.0.3"
       },
       "bin": {
         "ideogram": "cli/ideo-cli.js"
@@ -6286,6 +6287,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/idb-keyval": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.0.3.tgz",
+      "integrity": "sha512-yh8V7CnE6EQMu9YDwQXhRxwZh4nv+8xm/HV4ZqK4IiYFJBWYGjJuykADJbSP+F/GDXUBwCSSNn/14IpGL81TuA==",
+      "dependencies": {
+        "safari-14-idb-fix": "^3.0.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -9661,6 +9670,11 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
+    },
+    "node_modules/safari-14-idb-fix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-3.0.0.tgz",
+      "integrity": "sha512-eBNFLob4PMq8JA1dGyFn6G97q3/WzNtFK4RnzT1fnLq+9RyrGknzYiM/9B12MnKAxuj1IXr7UKYtTNtjyKMBog=="
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
@@ -17625,6 +17639,14 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "idb-keyval": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.0.3.tgz",
+      "integrity": "sha512-yh8V7CnE6EQMu9YDwQXhRxwZh4nv+8xm/HV4ZqK4IiYFJBWYGjJuykADJbSP+F/GDXUBwCSSNn/14IpGL81TuA==",
+      "requires": {
+        "safari-14-idb-fix": "^3.0.0"
+      }
+    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -20351,6 +20373,11 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
+    },
+    "safari-14-idb-fix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-3.0.0.tgz",
+      "integrity": "sha512-eBNFLob4PMq8JA1dGyFn6G97q3/WzNtFK4RnzT1fnLq+9RyrGknzYiM/9B12MnKAxuj1IXr7UKYtTNtjyKMBog=="
     },
     "safe-buffer": {
       "version": "5.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,7 @@
         "d3-dispatch": "^2.0.0",
         "d3-fetch": "^2.0.0",
         "d3-format": "^2.0.0",
-        "d3-scale": "^3.2.3",
-        "idb-keyval": "^6.0.3"
+        "d3-scale": "^3.2.3"
       },
       "bin": {
         "ideogram": "cli/ideo-cli.js"
@@ -6287,14 +6286,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/idb-keyval": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.0.3.tgz",
-      "integrity": "sha512-yh8V7CnE6EQMu9YDwQXhRxwZh4nv+8xm/HV4ZqK4IiYFJBWYGjJuykADJbSP+F/GDXUBwCSSNn/14IpGL81TuA==",
-      "dependencies": {
-        "safari-14-idb-fix": "^3.0.0"
-      }
-    },
     "node_modules/ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -9670,11 +9661,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
-    },
-    "node_modules/safari-14-idb-fix": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-3.0.0.tgz",
-      "integrity": "sha512-eBNFLob4PMq8JA1dGyFn6G97q3/WzNtFK4RnzT1fnLq+9RyrGknzYiM/9B12MnKAxuj1IXr7UKYtTNtjyKMBog=="
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
@@ -17639,14 +17625,6 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "idb-keyval": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.0.3.tgz",
-      "integrity": "sha512-yh8V7CnE6EQMu9YDwQXhRxwZh4nv+8xm/HV4ZqK4IiYFJBWYGjJuykADJbSP+F/GDXUBwCSSNn/14IpGL81TuA==",
-      "requires": {
-        "safari-14-idb-fix": "^3.0.0"
-      }
-    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -20373,11 +20351,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
-    },
-    "safari-14-idb-fix": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-3.0.0.tgz",
-      "integrity": "sha512-eBNFLob4PMq8JA1dGyFn6G97q3/WzNtFK4RnzT1fnLq+9RyrGknzYiM/9B12MnKAxuj1IXr7UKYtTNtjyKMBog=="
     },
     "safe-buffer": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
     "d3-dispatch": "^2.0.0",
     "d3-fetch": "^2.0.0",
     "d3-format": "^2.0.0",
-    "d3-scale": "^3.2.3",
-    "idb-keyval": "^6.0.3"
+    "d3-scale": "^3.2.3"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -50,19 +50,20 @@
     "d3-dispatch": "^2.0.0",
     "d3-fetch": "^2.0.0",
     "d3-format": "^2.0.0",
-    "d3-scale": "^3.2.3"
+    "d3-scale": "^3.2.3",
+    "idb-keyval": "^6.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",
     "@babel/eslint-parser": "^7.16.3",
     "@babel/preset-env": "^7.16.0",
     "babel-loader": "^8.2.3",
+    "babel-plugin-istanbul": "^6.1.1",
     "chai": "^4.2.0",
     "coveralls": "^3.1.0",
     "eslint": "^7.32.0",
     "eslint-config-google": "^0.14.0",
     "husky": "^4.2.5",
-    "babel-plugin-istanbul": "^6.1.1",
     "karma": "^6.3.8",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^3.1.0",

--- a/src/js/gene-cache.js
+++ b/src/js/gene-cache.js
@@ -148,7 +148,7 @@ export default async function initGeneCache(orgName, ideo, cacheDir=null) {
 
   perfTimes = {};
 
-  // Skip initialization if cache doesn't exist
+  // Skip initialization if files needed to make cache don't exist
   if (!hasGeneCache(orgName)) return;
 
   // Skip initialization if cache is already populated

--- a/src/js/gene-cache.js
+++ b/src/js/gene-cache.js
@@ -129,7 +129,7 @@ function parseOrgMetadata(orgName) {
 /** Reports if current organism has a gene cache */
 function hasGeneCache(orgName) {
   const metadata = parseOrgMetadata(orgName);
-  return ('hasGeneCache' in metadata && metadata.hasGeneCache === true);
+  return (metadata?.hasGeneCache === true);
 }
 
 async function cacheFetch(url) {

--- a/src/js/kit/analyze-related-genes.js
+++ b/src/js/kit/analyze-related-genes.js
@@ -22,9 +22,9 @@ function getRelatedGenesByType() {
   const related = Object.values(relatedGenes).slice();
 
   const paralogous = related.filter(r => r.type?.includes('paralogous'));
-  const interacting = related.filter(r => r.type.includes('interacting gene'));
+  const interacting = related.filter(r => r.type?.includes('interacting gene'));
   const searched = Object.entries(relatedGenes)
-    .filter((entry) => entry[1].type.includes('searched gene'))[0][0];
+    .filter((entry) => entry[1].type?.includes('searched gene'))[0][0];
 
   return {related, paralogous, interacting, searched};
 }

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -244,6 +244,12 @@ function describeInteractions(gene, ixns, searchedGene) {
   return descriptionObj;
 }
 
+/** Throw error when searched gene (e.g. "Foo") isn't found */
+function throwGeneNotFound(geneSymbol, ideo) {
+    const organism = ideo.organismScientificName;
+    throw Error(`"${geneSymbol}" is not a known gene in ${organism}`);
+}
+
 /**
  * Fetch genes from cache
  * Construct objects that match format of MyGene.info API response
@@ -255,6 +261,9 @@ function fetchGenesFromCache(names, type, ideo) {
   const nameMap = isSymbol ? cache.idsByName : cache.namesById;
 
   const hits = names.map(name => {
+
+    if (!locusMap[name]) throwGeneNotFound(name, ideo);
+
     const locus = locusMap[name];
     const symbol = isSymbol ? name : nameMap[name];
     const ensemblId = isSymbol ? nameMap[name] : name;
@@ -706,11 +715,7 @@ async function plotRelatedGenes(geneSymbol=null) {
   // Fetch positon of searched gene
   const annot = await processSearchedGene(geneSymbol, ideo);
 
-  if (typeof annot === 'undefined') {
-    // E.g. when searched gene is "Foo"
-    const organism = ideo.organismScientificName;
-    throw Error(`"${geneSymbol}" is not a known gene in ${organism}`);
-  }
+  if (typeof annot === 'undefined') throwGeneNotFound(geneSymbol, ideo);
 
   ideo.config.legend = relatedLegend;
   writeLegend(ideo);

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -272,12 +272,12 @@ function fetchGenesFromCache(names, type, ideo) {
       symbol,
       name: '',
       source: 'cache',
-      genomic_pos: [{
+      genomic_pos: {
         chr: locus[0],
         start: locus[1],
         end: locus[2],
         ensemblgene: ensemblId
-      }]
+      }
     };
 
     return hit;

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -597,7 +597,7 @@ async function processSearchedGene(geneSymbol, ideo) {
   if (data.hits.length === 0) {
     return;
   }
-  const gene = data.hits[0];
+  const gene = data.hits.find(hit => hit.genomic_pos?.ensemblgene);
   const ensemblId = gene.genomic_pos.ensemblgene;
 
   // Assign tooltip content.  Much of the content is often retrieved from

--- a/src/js/parsers/expression-matrix-parser.js
+++ b/src/js/parsers/expression-matrix-parser.js
@@ -51,11 +51,11 @@ export class ExpressionMatrixParser {
       return new Promise(function(resolve) {
         ideo.fetch(ensemblData, 'text').then(function(data) {
           // eslint-disable-next-line no-unused-vars
-          var tsvLines, i, start, stop, gene, chr, length, geneType;
+          var tsvLines, i, start, stop, gene, chr, length;
 
           tsvLines = data.split(/\r\n|\n/).slice(1);
           for (i = 0; i < tsvLines.length; i++) {
-            [start, stop, gene, geneType, chr] = tsvLines[i].split(/\s/g);
+            [start, stop, gene, , chr] = tsvLines[i].split(/\s/g);
             start = parseInt(start);
             stop = parseInt(stop);
             length = stop - start;

--- a/test/offline/color.test.js
+++ b/test/offline/color.test.js
@@ -27,7 +27,7 @@ describe('Color support includes', function() {
     }
     config.chrFillColor = 'green';
     config.onLoad = callback;
-    const ideogram = new Ideogram(config);
+    new Ideogram(config);
   });
 
   it('chrFillColor as object', done => {
@@ -42,6 +42,6 @@ describe('Color support includes', function() {
     }
     config.chrFillColor = {arm: '#AEA', centromere: '#EEA'};
     config.onLoad = callback;
-    const ideogram = new Ideogram(config);
+    new Ideogram(config);
   });
 });


### PR DESCRIPTION
This makes gene search for in the related genes kit.  All searches after the first now use gene cache data (previously described in #284).  This lets downstream requests start sooner, speeding up the 2nd, 3rd, etc. gene searches by around 200 ms each.

In uncached network flow, note the big gap between the first and second request in the circled area.  
<img width="1438" alt="Slow_uncached_gene_search__Ideogram_2021-11-18" src="https://user-images.githubusercontent.com/1334561/142516239-db748f96-c5e6-4574-94b0-341b5de8e291.png">

That still applies for the very first search.  However, as seen below, that time gap is eliminated for subsequent searches.
<img width="1440" alt="Fast_cached_gene_search__Ideogram_2021-11-18" src="https://user-images.githubusercontent.com/1334561/142516375-3cbd60da-9b80-4ba1-93e9-48c252dd34a3.png">

Clients can also initialize the gene cache before search, if they're savvy, to get the 200 ms savings for initial gene search. 
 But the optimizations for non-initial search shown above apply by default, out of the box.

(A brief experiment using IndexedDB and [idb-keyval](https://github.com/jakearchibald/idb-keyval) revealed that [`Cache`](https://developer.mozilla.org/en-US/docs/Web/API/Cache) is 12% faster for this use case.  Structured cloning might be a main cause of slowness in IndexedDB.)