### PR TITLE
Fix legend name placement

### DIFF
--- a/src/js/annotations/legend.js
+++ b/src/js/annotations/legend.js
@@ -79,10 +79,16 @@ function writeLegend(ideo) {
 
   for (i = 0; i < legend.length; i++) {
     list = legend[i];
-    const nameHeight = list.nameHeight ? list.nameHeight : 0;
-    const heightCss = (nameHeight) ? ` style="height: ${nameHeight}px;"` : '';
+    const nameHeight = list?.nameHeight || lineHeight;
+    let nameStyle = '';
+    if (nameHeight) {
+      nameStyle =
+        `style="height: ${nameHeight}px; ` +
+        `position: relative; ` +
+        `left: -${nameHeight - 5}px;"`;
+    }
     if ('name' in list) {
-      labels = `<div${heightCss}>` + list.name + `</div>`;
+      labels = `<div ${nameStyle}>` + list.name + `</div>`;
     }
     svg = '<svg id="_ideogramLegendSvg" width="' + lineHeight + '">';
     [labels, svg] = getListItems(labels, svg, list, nameHeight, ideo);

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -813,7 +813,7 @@ const legendHeaderStyle =
   `font-size: 14px; font-weight: bold; font-color: #333;`;
 const relatedLegend = [{
   name: `
-    <div style="position: relative; left: -15px;">
+    <div style="position: relative; left: 30px;">
       <div style="${legendHeaderStyle}">Related genes</div>
       <i>Click gene to search</i>
     </div>
@@ -828,7 +828,7 @@ const relatedLegend = [{
 
 const citedLegend = [{
   name: `
-    <div style="position: relative; left: -15px;">
+    <div style="position: relative; left: 30px;">
       <div style="${legendHeaderStyle}">Highly cited genes</div>
       <i>Click gene to search</i>
     </div>

--- a/test/offline/core.test.js
+++ b/test/offline/core.test.js
@@ -168,6 +168,12 @@ describe('Ideogram', function() {
       assert.equal(numAnnots, 1000);
       var numLegendRows = document.querySelectorAll('#_ideogramLegend li').length;
       assert.equal(numLegendRows, 3);
+
+      var legendNameDom = document.querySelector('#_ideogramLegend div');
+      assert.equal(
+        legendNameDom.style.height, '19.12px',
+        'Broke fix for https://github.com/eweitz/ideogram/issues/283'
+      );
       done();
     }
 

--- a/test/offline/core.test.js
+++ b/test/offline/core.test.js
@@ -170,8 +170,13 @@ describe('Ideogram', function() {
       assert.equal(numLegendRows, 3);
 
       var legendNameDom = document.querySelector('#_ideogramLegend div');
-      assert.equal(
-        legendNameDom.style.height, '19.12px',
+      const height = parseFloat(legendNameDom.style.height.replace('px', ''));
+      const expectedHeight = 19.12;
+      const heightDiff = Math.abs(expectedHeight - height);
+
+      // Account for differences between local and CI environments
+      assert.isAtMost(
+        heightDiff, 2,
         'Broke fix for https://github.com/eweitz/ideogram/issues/283'
       );
       done();


### PR DESCRIPTION
This fixes a layout bug causing various positional offset problems with legends, as depicted in #283.  The bug had been introduced by customizations to support the special legend in the related genes kit.

A new automated test has been added to prevent this bug from recurring.

Below is how the two kinds of legend look after this fix.

<img width="1424" alt="Legend_layouts__Ideogram_2021-11-26" src="https://user-images.githubusercontent.com/1334561/143586930-9a11f116-3017-4487-8ad3-d63db9a2df46.png">
