### PR TITLE
Detail pathway interactions in related genes kit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "d3-dispatch": "^2.0.0",
         "d3-fetch": "^2.0.0",
         "d3-format": "^2.0.0",
-        "d3-scale": "^3.2.3"
+        "d3-scale": "^3.2.3",
+        "d3-zoom": "^3.0.0"
       },
       "bin": {
         "ideogram": "cli/ideo-cli.js"
@@ -3386,6 +3387,21 @@
         "d3-ease": "1 - 2",
         "d3-interpolate": "1 - 2",
         "d3-timer": "1 - 2"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/dashdash": {
@@ -12499,6 +12515,18 @@
         "d3-ease": "1 - 2",
         "d3-interpolate": "1 - 2",
         "d3-timer": "1 - 2"
+      }
+    },
+    "d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "requires": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
       }
     },
     "dashdash": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "d3-dispatch": "^2.0.0",
     "d3-fetch": "^2.0.0",
     "d3-format": "^2.0.0",
-    "d3-scale": "^3.2.3"
+    "d3-scale": "^3.2.3",
+    "d3-zoom": "^3.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/src/js/annotations/events.js
+++ b/src/js/annotations/events.js
@@ -30,12 +30,12 @@ function startHideAnnotTooltipTimeout() {
     return;
   }
 
-  this.hideAnnotTooltipTimeout = window.setTimeout(function() {
-    d3.select('._ideogramTooltip').transition()
-      .duration(500) // fade out for half second
-      .style('opacity', 0)
-      .style('pointer-events', 'none');
-  }, 250);
+  // this.hideAnnotTooltipTimeout = window.setTimeout(function() {
+  //   d3.select('._ideogramTooltip').transition()
+  //     .duration(500) // fade out for half second
+  //     .style('opacity', 0)
+  //     .style('pointer-events', 'none');
+  // }, 250);
 }
 
 function renderTooltip(tooltip, content, matrix, yOffset, ideo) {

--- a/src/js/annotations/events.js
+++ b/src/js/annotations/events.js
@@ -30,12 +30,12 @@ function startHideAnnotTooltipTimeout() {
     return;
   }
 
-  // this.hideAnnotTooltipTimeout = window.setTimeout(function() {
-  //   d3.select('._ideogramTooltip').transition()
-  //     .duration(500) // fade out for half second
-  //     .style('opacity', 0)
-  //     .style('pointer-events', 'none');
-  // }, 250);
+  this.hideAnnotTooltipTimeout = window.setTimeout(function() {
+    d3.select('._ideogramTooltip').transition()
+      .duration(500) // fade out for half second
+      .style('opacity', 0)
+      .style('pointer-events', 'none');
+  }, 250);
 }
 
 function renderTooltip(tooltip, content, matrix, yOffset, ideo) {

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -31,7 +31,7 @@ import {getAnnotDomId} from '../annotations/process';
 import {applyRankCutoff} from '../annotations/labels';
 import {getDir} from '../lib';
 import initGeneCache from '../gene-cache';
-import {fetchInteractionDiagram, findGpmlConnections} from './wikipathways';
+import {detailAllInteractions} from './wikipathways';
 
 /** Sets DOM IDs for ideo.relatedAnnots; needed to associate labels */
 function setRelatedAnnotDomIds(ideo) {
@@ -565,7 +565,7 @@ function mergeDescriptions(annot, desc, ideo) {
       }
     });
     // Object.assign({}, descriptions[annot.name]);
-    console.log('mergedDesc', mergedDesc)
+    // console.log('mergedDesc', mergedDesc)
     mergedDesc.type += ', ' + otherDesc.type;
     mergedDesc.description += `<br/><br/>${otherDesc.description}`;
   } else {
@@ -807,6 +807,40 @@ function handleTooltipClick(ideo) {
 }
 
 /**
+ * Enhance description of interaction, e.g. "Interacts with" -> "Inhibits"
+ */
+function decorateInteraction(annot, descObj, ideo) {
+  const {description, originalDisplay} = descObj;
+
+  const pathwayIds = descObj.pathwayIds;
+  annot.displayName = annot.displayName.replace(description, '');
+
+  detailAllInteractions(annot.name, pathwayIds, ideo).then(ixnsByPwid => {
+    const oldHtml = document.querySelector('#_ideogramTooltip').innerHTML;
+    const coords = oldHtml.match(/<br\/?>chr.*/)[0];
+
+    const ixns = ixnsByPwid[pathwayIds[0]];
+    if (typeof ixns === 'undefined') return;
+
+    const trimmedOriginal =
+      originalDisplay.replaceAll(/(<br\/?>){3,}/g, '<br/><br/>');
+    let newHtml = trimmedOriginal + coords;
+
+    const isConsistent = ixns.every(ixn => {
+      return ixn.ixnType === ixns[0].ixnType;
+    });
+    if (ixns.length > 0 && isConsistent) {
+      const ixnType = ixns[0].ixnType;
+      const oldIxn = 'Interacts with';
+      const newIxn = ixnType;
+      const newDesc = trimmedOriginal.replace(oldIxn, newIxn);
+      newHtml = newDesc + coords;
+    }
+    document.querySelector('#_ideogramTooltip').innerHTML = newHtml;
+  });
+}
+
+/**
  * Enhance tooltip shown on hovering over gene annotation
  */
 function decorateRelatedGene(annot) {
@@ -817,31 +851,17 @@ function decorateRelatedGene(annot) {
   const fullName = descObj.name;
   const style = 'style="color: #0366d6; cursor: pointer;"';
 
-  annot.displayName =
+  const originalDisplay =
     `<span id="ideo-related-gene" ${style}>${annot.name}</span><br/>` +
     `${fullName}<br/>` +
     `${description}` +
     `<br/>`;
-  console.log('descObj', descObj)
+
+  annot.displayName = originalDisplay;
   if (descObj.type.includes('interacting gene')) {
-    // fetchInteractionDiagram(annot, descObj, ideo);
-    annot.displayName = annot.displayName.replace(description, '');
-    const searchedGene =
-      Object.entries(ideo.annotDescriptions.annots)
-        .find(([k, v]) => v.type === 'searched gene')[0];
-    const genes = [searchedGene, annot.name];
-    const pathwayId = descObj.pathwayIds[0];
-    findGpmlConnections(genes, pathwayId).then(cxns => {
-      if (cxns.length === 1) {
-        const ixnType = cxns[0].ixnType;
-        const oldSummary = 'Interacts with ' + searchedGene;
-        const newSummary = ixnType + ' ' + searchedGene;
-        const newDesc = description.replace(oldSummary, newSummary);
-        annot.displayName = annot.displayName + newDesc;
-        document.querySelector('#_ideogramTooltip')
-          .innerHTML = annot.displayName;
-      }
-    });
+    descObj.originalDisplay = originalDisplay;
+    descObj.description = description;
+    decorateInteraction(annot, descObj, ideo);
   }
 
   handleTooltipClick(ideo);

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -798,6 +798,21 @@ function handleTooltipClick(ideo) {
   }
 }
 
+async function fetchInteractionDiagram(annot, descObj) {
+  // Fetch raw SVG for pathway diagram
+  const pathwayId = descObj.pathwayIds[0];
+  const baseUrl = 'https://eweitz.github.io/cachome/wikipathways/';
+  const diagramUrl = baseUrl + pathwayId + '.svg';
+  const response = await fetch(diagramUrl);
+  const rawDiagram = await response.text();
+
+  const pathwayDiagram = `<div class="pathway-diagram">${rawDiagram}</div>`;
+
+  annot.displayName = pathwayDiagram + annot.displayName;
+
+  document.querySelector('#_ideogramTooltip').innerHTML = annot.displayName;
+}
+
 /**
  * Enhance tooltip shown on hovering over gene annotation
  */
@@ -814,6 +829,10 @@ function decorateRelatedGene(annot) {
     `${fullName}<br/>` +
     `${description}` +
     `<br/>`;
+
+  if (descObj.type === 'interacting gene') {
+    fetchInteractionDiagram(annot, descObj);
+  }
 
   handleTooltipClick(ideo);
 

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -801,16 +801,28 @@ function handleTooltipClick(ideo) {
 async function fetchInteractionDiagram(annot, descObj) {
   // Fetch raw SVG for pathway diagram
   const pathwayId = descObj.pathwayIds[0];
-  const baseUrl = 'https://eweitz.github.io/cachome/wikipathways/';
+  const baseUrl = 'https://cachome.github.io/wikipathways/';
   const diagramUrl = baseUrl + pathwayId + '.svg';
   const response = await fetch(diagramUrl);
-  const rawDiagram = await response.text();
+  if (response.ok) {
+    const rawDiagram = await response.text();
 
-  const pathwayDiagram = `<div class="pathway-diagram">${rawDiagram}</div>`;
+    const pathwayDiagram = `<div class="pathway-diagram">${rawDiagram}</div>`;
 
-  annot.displayName = pathwayDiagram + annot.displayName;
+    annot.displayName += pathwayDiagram;
 
-  document.querySelector('#_ideogramTooltip').innerHTML = annot.displayName;
+    document.querySelector('#_ideogramTooltip').innerHTML = annot.displayName;
+
+    Ideogram.d3.select('svg.Diagram').attr('width', null);
+    Ideogram.d3.select('svg.Diagram').attr('height', 300);
+    const m = document.querySelector('[name="' + annot.name + '"]').getCTM();
+    document
+      .querySelector('svg.Diagram')
+      .setAttribute(
+        'viewBox',
+        (m.e/m.a - 150) + ' ' + (m.f/m.d - 150) + ' 350 300'
+      );
+    }
 }
 
 /**

--- a/src/js/kit/wikipathways.js
+++ b/src/js/kit/wikipathways.js
@@ -20,6 +20,20 @@ const interactionArrowMap = {
 };
 
 /**
+ * Get detailInteractions results for multiple pathways
+ */
+export async function detailAllInteractions(gene, pathwayIds, ideo) {
+  const ixnsByPwid = {};
+  await Promise.all(
+    pathwayIds.map(async pathwayId => {
+      const ixns = await detailInteractions(gene, pathwayId, ideo);
+      ixnsByPwid[pathwayId] = ixns;
+    })
+  );
+  return ixnsByPwid;
+}
+
+/**
  * Fetch GPML for pathway and find ID of Interaction between two genes,
  * and the ID of the two DataNodes for each of those interactions.
  *
@@ -28,23 +42,26 @@ const interactionArrowMap = {
  * fetches augmented GPML data for the pathway, and queries it to get only
  * interactions between the two genes.
  */
- export async function findGpmlConnections(interactingGenes, pathwayId) {
-  const [searchedGene, interactingGene] = interactingGenes;
+ export async function detailInteractions(interactingGene, pathwayId, ideo) {
+
+  // Fetch GPML data
   const wpBaseUrl = 'https://webservice.wikipathways.org/';
   const pathwayUrl = wpBaseUrl + `getPathway?pwId=${pathwayId}&format=json`;
   const wpResponse = await fetch(pathwayUrl);
   const wpData = await wpResponse.json();
-  // console.log('wpData', wpData)
   const rawGpml = wpData.pathway.gpml;
-  // console.log('rawGpml', rawGpml)
   const gpml = new DOMParser().parseFromString(rawGpml, 'text/xml');
+
+  const searchedGene =
+    Object.entries(ideo.annotDescriptions.annots)
+      .find(([k, v]) => v.type === 'searched gene')[0];
+
   const nodes = gpml.querySelectorAll(
     `DataNode[TextLabel="${searchedGene}"],` +
     `DataNode[TextLabel="${interactingGene}"]`
   );
 
   const genes = Array.from(nodes).map(node => {
-    // console.log('node.innerHTML', node.innerHTML);
     return {
       textLabel: node.getAttribute('TextLabel'),
       graphId: node.getAttribute('GraphId'),
@@ -52,16 +69,12 @@ const interactionArrowMap = {
     };
   });
 
-  // console.log('genes', genes)
-
+  // Get group identifiers
   const geneGraphIds = genes.map(g => g.graphId);
   const geneGroupRefs = genes.map(g => g.groupRef);
-  // console.log('geneGroupRefs', geneGroupRefs)
   const groupSelectors =
     geneGroupRefs.map(ggr => `Group[GroupId="${ggr}"]`).join(',');
-  // console.log('groupSelectors', groupSelectors)
   const groups = gpml.querySelectorAll(groupSelectors);
-  // console.log('groups', groups)
   const geneGroups = Array.from(groups).map(group => {
     return {
       graphId: group.getAttribute('GraphId'),
@@ -70,32 +83,23 @@ const interactionArrowMap = {
   });
 
   const geneGroupGraphIds = geneGroups.map(g => g.graphId);
-  // console.log('geneGroupGraphIds', geneGroupGraphIds)
-
   const matchingGraphIds = geneGraphIds.concat(geneGroupGraphIds);
 
-  // console.log('matchingGraphIds', matchingGraphIds)
-  // console.log('geneGroupRefs', geneGroupRefs)
-  const connections = [];
+  const interactions = [];
 
   const graphicsXml = gpml.querySelectorAll('Interaction Graphics');
   Array.from(graphicsXml).forEach(graphics => {
     const endGraphRefs = [];
     let numMatchingPoints = 0;
     let ixnType = null;
-    // console.log('graphics', graphics)
     let searchedGeneIndex = null;
+
     Array.from(graphics.children).forEach(child => {
-      if (child.nodeName !== 'Point') {
-        // console.log('child.nodeName', child.nodeName);
-        return;
-      }
+      if (child.nodeName !== 'Point') return;
       const point = child;
       const graphRef = point.getAttribute('GraphRef');
-      // const group = point.getAttribute('GraphRef');
-
       if (graphRef === null) return;
-      // console.log('graphRef', graphRef)
+
       if (matchingGraphIds.includes(graphRef)) {
         numMatchingPoints += 1;
         endGraphRefs.push(graphRef);
@@ -106,22 +110,17 @@ const interactionArrowMap = {
           if (searchedGeneIndex === null) {
             searchedGeneIndex = isStart ? 0 : 1;
           }
-          // console.log('pointLabel', pointLabel)
-          // console.log('searchedGene', searchedGene)
           ixnType = interactionArrowMap[arrowHead][isStart ? 0 : 1];
         }
       }
-      // if (numMatchingPoints > 0) {
-      //   console.log('graphics.parentNode', graphics.parentNode)
-      // }
     });
-    // console.log('numMatchingPoints', numMatchingPoints)
+
     if (numMatchingPoints >= 2) {
       if (searchedGeneIndex === null) {
         const gi = genes.indexOf(genes.find(g => g.textLabel = searchedGene));
         searchedGeneIndex = gi;
         ixnType = 'interacts with';
-        console.log('searchedGeneIndex', searchedGeneIndex)
+        // console.log('searchedGeneIndex', searchedGeneIndex)
       }
       ixnType = ixnType[0].toUpperCase() + ixnType.slice(1);
       const interactionGraphId = graphics.parentNode.getAttribute('GraphId');
@@ -132,136 +131,133 @@ const interactionArrowMap = {
         genes,
         searchedGeneIndex // Whether searched gene is at start or end
       };
-      connections.push(connection);
+      interactions.push(connection);
     }
   });
 
-  console.log('connections', connections)
-  // console.log('genes', genes)
+  // console.log('interactions', interactions)
 
-  return connections;
+  return interactions;
 }
 
-export async function fetchInteractionDiagram(annot, descObj, ideo) {
-  // Fetch raw SVG for pathway diagram
-  const pathwayId = descObj.pathwayIds[0];
-  // const baseUrl = 'https://eweitz.github.io/cachome/wikipathways/';
-  const baseUrl = 'https://cachome.github.io/wikipathways/';
-  // const baseUrl = 'http://localhost/wikipathways/data/';
-  const diagramUrl = baseUrl + pathwayId + '.svg';
-  const response = await fetch(diagramUrl);
-  if (response.ok) {
+// export async function fetchInteractionDiagram(annot, descObj, ideo) {
+//   // Fetch raw SVG for pathway diagram
+//   const pathwayId = descObj.pathwayIds[0];
+//   // const baseUrl = 'https://eweitz.github.io/cachome/wikipathways/';
+//   const baseUrl = 'https://cachome.github.io/wikipathways/';
+//   // const baseUrl = 'http://localhost/wikipathways/data/';
+//   const diagramUrl = baseUrl + pathwayId + '.svg';
+//   const response = await fetch(diagramUrl);
+//   if (response.ok) {
 
-    const searchedGene =
-      Object.entries(ideo.annotDescriptions.annots)
-        .find(([k, v]) => v.type === 'searched gene')[0];
-    // console.log('searchedGene', searchedGene)
-    const genes = [searchedGene, annot.name]
-    const cxns = await findGpmlConnections(genes, pathwayId);
+//     // console.log('searchedGene', searchedGene)
 
-    let selectors = `[name=${annot.name}]`;
-    let searchedGeneIndex = 0;
-    let interactingGeneIndex;
-    if (cxns.length > 0) {
-      selectors = cxns[0].endIds.map(id => '#' + id).join(',');
-      searchedGeneIndex = cxns[0].searchedGeneIndex;
-      interactingGeneIndex = (searchedGeneIndex === 0) ? 1 : 0;
-    }
-    // https://webservice.wikipathways.org/findInteractions?query=ACE2&format=json
+//     const ixns = await detailInteractions(annot.name, pathwayId, ideo);
 
-    const rawDiagram = await response.text();
+//     let selectors = `[name=${annot.name}]`;
+//     let searchedGeneIndex = 0;
+//     let interactingGeneIndex;
+//     if (ixns.length > 0) {
+//       selectors = ixns[0].endIds.map(id => '#' + id).join(',');
+//       searchedGeneIndex = ixns[0].searchedGeneIndex;
+//       interactingGeneIndex = (searchedGeneIndex === 0) ? 1 : 0;
+//     }
+//     // https://webservice.wikipathways.org/findInteractions?query=ACE2&format=json
 
-    const pathwayDiagram = `<div class="pathway-diagram">${rawDiagram}</div>`;
+//     const rawDiagram = await response.text();
 
-    annot.displayName += pathwayDiagram;
+//     const pathwayDiagram =
+//       `<div class="pathway-diagram">${rawDiagram}</div>`;
 
-    document.querySelector('#_ideogramTooltip').innerHTML = annot.displayName;
+//     annot.displayName += pathwayDiagram;
 
-    Ideogram.d3.select('svg.Diagram')
-      .attr('width', 350)
-      .attr('height', 300);
+//     document.querySelector('#_ideogramTooltip').innerHTML =
+//       annot.displayName;
 
-    const viewport = document.querySelector('.svg-pan-zoom_viewport');
-    viewport.removeAttribute('style');
-    viewport.removeAttribute('transform');
+//     Ideogram.d3.select('svg.Diagram')
+//       .attr('width', 350)
+//       .attr('height', 300);
 
-    const matches = document.querySelectorAll(selectors);
-    console.log('matches', matches)
-    const match0 = matches[searchedGeneIndex]
-    const m0 = match0.getCTM();
-    const m0Rect = match0.getBoundingClientRect();
-    const m0Box = match0.getBBox();
-    const m0MinX = m0.e/m0.a;
-    const m0MinY = m0.f/m0.d;
+//     const viewport = document.querySelector('.svg-pan-zoom_viewport');
+//     viewport.removeAttribute('style');
+//     viewport.removeAttribute('transform');
 
-    let minX = m0MinX;
-    let minY = m0MinY;
-    let width;
-    let height;
+//     const matches = document.querySelectorAll(selectors);
+//     console.log('matches', matches)
+//     const match0 = matches[searchedGeneIndex]
+//     const m0 = match0.getCTM();
+//     const m0Rect = match0.getBoundingClientRect();
+//     const m0Box = match0.getBBox();
+//     const m0MinX = m0.e/m0.a;
+//     const m0MinY = m0.f/m0.d;
 
-    width = 350;
-    height = 300;
+//     let minX = m0MinX;
+//     let minY = m0MinY;
+//     let width;
+//     let height;
 
-    // matches[0].children[0].setAttribute('fill', '#F55');
-    // console.log('matches[0].children[0].style', matches[0].children[0].style)
-    match0.children[0].style.fill = '#f55';
+//     width = 350;
+//     height = 300;
 
-    if (matches.length > 1) {
-      // console.log('matches.length > 1')
-      // matches[1].children[0].setAttribute('fill', '#C4C');
-      const match1 = matches[interactingGeneIndex];
-      // console.log('match1')
-      // console.log(match1)
-      match1.children[0].style.fill = '#c4c';
-      const m1 = matches[1].getCTM();
-      const m1Rect = matches[1].getBoundingClientRect();
-      const m1Box = matches[1].getBBox();
-      console.log('m0', m0)
-      console.log('m1', m1)
-      const m1MinX = m1.e/m1.a;
-      const m1MinY = m1.f/m1.d;
-      // const m1MinX = m1.e/m1.a + m1Rect.width;
-      // const m1MinY = m1.f/m1.d - m1Rect.height;
-      if (m1MinX < m0MinX) minX = m1MinX;
-      if (m1MinY < m0MinY) minY = m1MinY;
+//     // matches[0].children[0].setAttribute('fill', '#F55');
+//     match0.children[0].style.fill = '#f55';
 
-      let pairWidth = 0;
-      if (m0Rect.left < m1Rect.left) {
-        // pairWidth = m1Rect.right - m0Rect.left;
-        width += m1Box.width + 40;
-      }
+//     if (matches.length > 1) {
+//       // console.log('matches.length > 1')
+//       // matches[1].children[0].setAttribute('fill', '#C4C');
+//       const match1 = matches[interactingGeneIndex];
+//       // console.log('match1')
+//       // console.log(match1)
+//       match1.children[0].style.fill = '#c4c';
+//       const m1 = matches[1].getCTM();
+//       const m1Rect = matches[1].getBoundingClientRect();
+//       const m1Box = matches[1].getBBox();
+//       console.log('m0', m0)
+//       console.log('m1', m1)
+//       const m1MinX = m1.e/m1.a;
+//       const m1MinY = m1.f/m1.d;
+//       // const m1MinX = m1.e/m1.a + m1Rect.width;
+//       // const m1MinY = m1.f/m1.d - m1Rect.height;
+//       if (m1MinX < m0MinX) minX = m1MinX;
+//       if (m1MinY < m0MinY) minY = m1MinY;
 
-      // width += pairWidth;
+//       let pairWidth = 0;
+//       if (m0Rect.left < m1Rect.left) {
+//         // pairWidth = m1Rect.right - m0Rect.left;
+//         width += m1Box.width + 40;
+//       }
 
-      // console.log('m0Rect', m0Rect)
-      // console.log('m1Rect', m1Rect)
-      // console.log('m1MinX', m1MinX)
-      // console.log('m0MinX', m0MinX)
-      // console.log('m1MinY', m1MinY)
-      // console.log('m0MinY', m0MinY)
-      // console.log('pairWidth', pairWidth)
-      // console.log('width', width)
-      // width += Math.abs(m1MinX - m0MinX);
-      // height += Math.abs(m1MinY - m0MinY);
+//       // width += pairWidth;
 
-      // minX -= 100;
-      // minY -= 100;
+//       // console.log('m0Rect', m0Rect)
+//       // console.log('m1Rect', m1Rect)
+//       // console.log('m1MinX', m1MinX)
+//       // console.log('m0MinX', m0MinX)
+//       // console.log('m1MinY', m1MinY)
+//       // console.log('m0MinY', m0MinY)
+//       // console.log('pairWidth', pairWidth)
+//       // console.log('width', width)
+//       // width += Math.abs(m1MinX - m0MinX);
+//       // height += Math.abs(m1MinY - m0MinY);
 
-      // minX -= 150;
-      // minY -= 150;
-    } else {
-      minX -= 150;
-      minY -= 150;
-    }
+//       // minX -= 100;
+//       // minY -= 100;
 
-    minX = Math.round(minX);
-    minY = Math.round(minY);
-    width = Math.round(width);
-    height = Math.round(height);
+//       // minX -= 150;
+//       // minY -= 150;
+//     } else {
+//       minX -= 150;
+//       minY -= 150;
+//     }
 
-    const viewBox = `${minX} ${minY} ${width} ${height}`;
-    console.log('viewBox', viewBox);
-    document.querySelector('svg.Diagram').setAttribute('viewBox', viewBox);
+//     minX = Math.round(minX);
+//     minY = Math.round(minY);
+//     width = Math.round(width);
+//     height = Math.round(height);
 
-  }
-}
+//     const viewBox = `${minX} ${minY} ${width} ${height}`;
+//     console.log('viewBox', viewBox);
+//     document.querySelector('svg.Diagram').setAttribute('viewBox', viewBox);
+
+//   }
+// }

--- a/src/js/kit/wikipathways.js
+++ b/src/js/kit/wikipathways.js
@@ -1,3 +1,23 @@
+// Definitions for ArrowHead values in WikiPathways GPML
+//
+// See also: https://discover.nci.nih.gov/mim/formal_mim_spec.pdf
+const interactionArrowMap = {
+  'Arrow': ['acts on', 'acted on by'],
+  'TBar': ['inhibits', 'is inhibited by'],
+  'mim-binding': ['binds', 'binds'],
+  'mim-catalysis': ['catalyzes', 'catalyzed by'],
+  'mim-cleavage': ['cleaves', 'cleaved by'],
+  'mim-conversion': ['converts', 'converted by'],
+  // 'mim-covalent-bond': ['covalently binds',
+  // 'mim-gap': 'MimGap',
+  'mim-inhibition': ['inhibits', 'is inhibited by'],
+  'mim-modification': ['modifies', 'is modified by'],
+  'mim-necessary-stimulation':
+    ['necessarily stimulates', 'is necessarily stimulated by'],
+  'mim-stimulation': ['stimulates', 'is stimulated by'],
+  'mim-transcription-translation':
+    ['transcribes / translates', 'is transcribed / translated by']
+};
 
 /**
  * Fetch GPML for pathway and find ID of Interaction between two genes,
@@ -8,7 +28,7 @@
  * fetches augmented GPML data for the pathway, and queries it to get only
  * interactions between the two genes.
  */
- async function findGpmlConnections(gene1, gene2, pathwayId) {
+ async function findGpmlConnections(searchedGene, interactingGene, pathwayId) {
   const wpBaseUrl = 'https://webservice.wikipathways.org/';
   const pathwayUrl = wpBaseUrl + `getPathway?pwId=${pathwayId}&format=json`;
   const wpResponse = await fetch(pathwayUrl);
@@ -20,11 +40,12 @@
   // console.log('gpml', gpml)
   // console.log('gene1', gene1)
   const nodes = gpml.querySelectorAll(
-    `DataNode[TextLabel="${gene1}"],` +
-    `DataNode[TextLabel="${gene2}"]`
+    `DataNode[TextLabel="${searchedGene}"],` +
+    `DataNode[TextLabel="${interactingGene}"]`
   );
 
   const genes = Array.from(nodes).map(node => {
+    console.log('node.innerHTML', node.innerHTML);
     return {
       textLabel: node.getAttribute('TextLabel'),
       graphId: node.getAttribute('GraphId'),
@@ -62,8 +83,14 @@
   Array.from(graphicsXml).forEach(graphics => {
     const endGraphRefs = [];
     let numMatchingPoints = 0;
+    let ixnType = null;
+    // console.log('graphics', graphics)
+    let searchedGeneIndex = null;
     Array.from(graphics.children).forEach(child => {
-      if (child.nodeName !== 'Point') return;
+      if (child.nodeName !== 'Point') {
+        console.log('child.nodeName', child.nodeName);
+        return;
+      }
       const point = child;
       const graphRef = point.getAttribute('GraphRef');
       // const group = point.getAttribute('GraphRef');
@@ -73,6 +100,17 @@
       if (matchingGraphIds.includes(graphRef)) {
         numMatchingPoints += 1;
         endGraphRefs.push(graphRef);
+        if (point.getAttribute('ArrowHead')) {
+          const arrowHead = point.getAttribute('ArrowHead');
+          const pointLabel = genes.find(g => g.graphId = graphRef).textLabel;
+          const isStart = pointLabel === searchedGene;
+          if (searchedGeneIndex === null) {
+            searchedGeneIndex = isStart ? 0 : 1;
+          }
+          console.log('pointLabel', pointLabel)
+          console.log('searchedGene', searchedGene)
+          ixnType = interactionArrowMap[arrowHead][isStart ? 0 : 1];
+        }
       }
       // if (numMatchingPoints > 0) {
       //   console.log('graphics.parentNode', graphics.parentNode)
@@ -80,10 +118,19 @@
     });
     // console.log('numMatchingPoints', numMatchingPoints)
     if (numMatchingPoints >= 2) {
+      if (searchedGeneIndex === null) {
+        const gi = genes.indexOf(genes.find(g => g.textLabel = searchedGene));
+        searchedGeneIndex = gi;
+        ixnType = 'interacts with';
+        console.log('searchedGeneIndex', searchedGeneIndex)
+      }
       const interactionGraphId = graphics.parentNode.getAttribute('GraphId');
       const connection = {
         'interactionId': interactionGraphId,
-        'endIds': endGraphRefs
+        'endIds': endGraphRefs,
+        ixnType,
+        genes,
+        searchedGeneIndex // Whether searched gene is at start or end
       };
       connections.push(connection);
     }
@@ -98,7 +145,9 @@
 export async function fetchInteractionDiagram(annot, descObj, ideo) {
   // Fetch raw SVG for pathway diagram
   const pathwayId = descObj.pathwayIds[0];
+  // const baseUrl = 'https://eweitz.github.io/cachome/wikipathways/';
   const baseUrl = 'https://cachome.github.io/wikipathways/';
+  // const baseUrl = 'http://localhost/wikipathways/data/';
   const diagramUrl = baseUrl + pathwayId + '.svg';
   const response = await fetch(diagramUrl);
   if (response.ok) {
@@ -107,11 +156,15 @@ export async function fetchInteractionDiagram(annot, descObj, ideo) {
       Object.entries(ideo.annotDescriptions.annots)
         .find(([k, v]) => v.type === 'searched gene')[0];
     // console.log('searchedGene', searchedGene)
-    const cxns = await findGpmlConnections(annot.name, searchedGene, pathwayId);
+    const cxns = await findGpmlConnections(searchedGene, annot.name, pathwayId);
 
     let selectors = `[name=${annot.name}]`;
+    let searchedGeneIndex = 0;
+    let interactingGeneIndex;
     if (cxns.length > 0) {
       selectors = cxns[0].endIds.map(id => '#' + id).join(',');
+      searchedGeneIndex = cxns[0].searchedGeneIndex;
+      interactingGeneIndex = (searchedGeneIndex === 0) ? 1 : 0;
     }
     // https://webservice.wikipathways.org/findInteractions?query=ACE2&format=json
 
@@ -127,11 +180,16 @@ export async function fetchInteractionDiagram(annot, descObj, ideo) {
       .attr('width', 350)
       .attr('height', 300);
 
+    const viewport = document.querySelector('.svg-pan-zoom_viewport');
+    viewport.removeAttribute('style');
+    viewport.removeAttribute('transform');
+
     const matches = document.querySelectorAll(selectors);
     console.log('matches', matches)
-    const m0 = matches[0].getCTM();
-    const m0Rect = matches[0].getBoundingClientRect();
-    const m0Box = matches[0].getBBox();
+    const match0 = matches[searchedGeneIndex]
+    const m0 = match0.getCTM();
+    const m0Rect = match0.getBoundingClientRect();
+    const m0Box = match0.getBBox();
     const m0MinX = m0.e/m0.a;
     const m0MinY = m0.f/m0.d;
 
@@ -143,29 +201,36 @@ export async function fetchInteractionDiagram(annot, descObj, ideo) {
     width = 350;
     height = 300;
 
-    matches[0].children[0].setAttribute('fill', '#F55');
+    // matches[0].children[0].setAttribute('fill', '#F55');
+    // console.log('matches[0].children[0].style', matches[0].children[0].style)
+    match0.children[0].style.fill = '#f55';
 
     if (matches.length > 1) {
-      matches[1].children[0].setAttribute('fill', '#C4C');
-      // const m1 = matches[1].getCTM();
-      // const m1Rect = matches[1].getBoundingClientRect();
-      // const m1Box = matches[1].getBBox();
-      // console.log('m0', m0)
-      // console.log('m1', m1)
-      // const m1MinX = m1.e/m1.a;
-      // const m1MinY = m1.f/m1.d;
-      // // const m1MinX = m1.e/m1.a + m1Rect.width;
-      // // const m1MinY = m1.f/m1.d - m1Rect.height;
-      // if (m1MinX < m0MinX) minX = m1MinX;
-      // if (m1MinY < m0MinY) minY = m1MinY;
+      // console.log('matches.length > 1')
+      // matches[1].children[0].setAttribute('fill', '#C4C');
+      const match1 = matches[interactingGeneIndex];
+      // console.log('match1')
+      // console.log(match1)
+      match1.children[0].style.fill = '#c4c';
+      const m1 = matches[1].getCTM();
+      const m1Rect = matches[1].getBoundingClientRect();
+      const m1Box = matches[1].getBBox();
+      console.log('m0', m0)
+      console.log('m1', m1)
+      const m1MinX = m1.e/m1.a;
+      const m1MinY = m1.f/m1.d;
+      // const m1MinX = m1.e/m1.a + m1Rect.width;
+      // const m1MinY = m1.f/m1.d - m1Rect.height;
+      if (m1MinX < m0MinX) minX = m1MinX;
+      if (m1MinY < m0MinY) minY = m1MinY;
 
-      // let pairWidth = 0;
-      // if (m0Rect.left < m1Rect.left) {
-      //   // pairWidth = m1Rect.right - m0Rect.left;
-      //   width += m1Box.width + 40;
-      // }
+      let pairWidth = 0;
+      if (m0Rect.left < m1Rect.left) {
+        // pairWidth = m1Rect.right - m0Rect.left;
+        width += m1Box.width + 40;
+      }
 
-      // // width += pairWidth;
+      // width += pairWidth;
 
       // console.log('m0Rect', m0Rect)
       // console.log('m1Rect', m1Rect)
@@ -175,18 +240,23 @@ export async function fetchInteractionDiagram(annot, descObj, ideo) {
       // console.log('m0MinY', m0MinY)
       // console.log('pairWidth', pairWidth)
       // console.log('width', width)
-      // // width += Math.abs(m1MinX - m0MinX);
-      // // height += Math.abs(m1MinY - m0MinY);
+      // width += Math.abs(m1MinX - m0MinX);
+      // height += Math.abs(m1MinY - m0MinY);
 
       // minX -= 100;
       // minY -= 100;
 
-      minX -= 150;
-      minY -= 150;
+      // minX -= 150;
+      // minY -= 150;
     } else {
       minX -= 150;
       minY -= 150;
     }
+
+    minX = Math.round(minX);
+    minY = Math.round(minY);
+    width = Math.round(width);
+    height = Math.round(height);
 
     const viewBox = `${minX} ${minY} ${width} ${height}`;
     console.log('viewBox', viewBox);

--- a/src/js/kit/wikipathways.js
+++ b/src/js/kit/wikipathways.js
@@ -1,0 +1,196 @@
+
+/**
+ * Fetch GPML for pathway and find ID of Interaction between two genes,
+ * and the ID of the two DataNodes for each of those interactions.
+ *
+ * WikiPathways SVG isn't detailed enough to reliably determine the specific
+ * interaction elements relating two genes, given only the gene symbols.  This
+ * fetches augmented GPML data for the pathway, and queries it to get only
+ * interactions between the two genes.
+ */
+ async function findGpmlConnections(gene1, gene2, pathwayId) {
+  const wpBaseUrl = 'https://webservice.wikipathways.org/';
+  const pathwayUrl = wpBaseUrl + `getPathway?pwId=${pathwayId}&format=json`;
+  const wpResponse = await fetch(pathwayUrl);
+  const wpData = await wpResponse.json();
+  // console.log('wpData', wpData)
+  const rawGpml = wpData.pathway.gpml;
+  console.log('rawGpml', rawGpml)
+  const gpml = new DOMParser().parseFromString(rawGpml, 'text/xml');
+  // console.log('gpml', gpml)
+  // console.log('gene1', gene1)
+  const nodes = gpml.querySelectorAll(
+    `DataNode[TextLabel="${gene1}"],` +
+    `DataNode[TextLabel="${gene2}"]`
+  );
+
+  const genes = Array.from(nodes).map(node => {
+    return {
+      textLabel: node.getAttribute('TextLabel'),
+      graphId: node.getAttribute('GraphId'),
+      groupRef: node.getAttribute('GroupRef')
+    };
+  });
+
+  // console.log('genes', genes)
+
+  const geneGraphIds = genes.map(g => g.graphId);
+  const geneGroupRefs = genes.map(g => g.groupRef);
+  // console.log('geneGroupRefs', geneGroupRefs)
+  const groupSelectors =
+    geneGroupRefs.map(ggr => `Group[GroupId="${ggr}"]`).join(',');
+  // console.log('groupSelectors', groupSelectors)
+  const groups = gpml.querySelectorAll(groupSelectors);
+  // console.log('groups', groups)
+  const geneGroups = Array.from(groups).map(group => {
+    return {
+      graphId: group.getAttribute('GraphId'),
+      groupId: group.getAttribute('GroupId')
+    };
+  });
+
+  const geneGroupGraphIds = geneGroups.map(g => g.graphId);
+  // console.log('geneGroupGraphIds', geneGroupGraphIds)
+
+  const matchingGraphIds = geneGraphIds.concat(geneGroupGraphIds);
+
+  // console.log('matchingGraphIds', matchingGraphIds)
+  // console.log('geneGroupRefs', geneGroupRefs)
+  const connections = [];
+
+  const graphicsXml = gpml.querySelectorAll('Interaction Graphics');
+  Array.from(graphicsXml).forEach(graphics => {
+    const endGraphRefs = [];
+    let numMatchingPoints = 0;
+    Array.from(graphics.children).forEach(child => {
+      if (child.nodeName !== 'Point') return;
+      const point = child;
+      const graphRef = point.getAttribute('GraphRef');
+      // const group = point.getAttribute('GraphRef');
+
+      if (graphRef === null) return;
+      // console.log('graphRef', graphRef)
+      if (matchingGraphIds.includes(graphRef)) {
+        numMatchingPoints += 1;
+        endGraphRefs.push(graphRef);
+      }
+      // if (numMatchingPoints > 0) {
+      //   console.log('graphics.parentNode', graphics.parentNode)
+      // }
+    });
+    // console.log('numMatchingPoints', numMatchingPoints)
+    if (numMatchingPoints >= 2) {
+      const interactionGraphId = graphics.parentNode.getAttribute('GraphId');
+      const connection = {
+        'interactionId': interactionGraphId,
+        'endIds': endGraphRefs
+      };
+      connections.push(connection);
+    }
+  });
+
+  console.log('connections', connections)
+  // console.log('genes', genes)
+
+  return connections;
+}
+
+export async function fetchInteractionDiagram(annot, descObj, ideo) {
+  // Fetch raw SVG for pathway diagram
+  const pathwayId = descObj.pathwayIds[0];
+  const baseUrl = 'https://cachome.github.io/wikipathways/';
+  const diagramUrl = baseUrl + pathwayId + '.svg';
+  const response = await fetch(diagramUrl);
+  if (response.ok) {
+
+    const searchedGene =
+      Object.entries(ideo.annotDescriptions.annots)
+        .find(([k, v]) => v.type === 'searched gene')[0];
+    // console.log('searchedGene', searchedGene)
+    const cxns = await findGpmlConnections(annot.name, searchedGene, pathwayId);
+
+    let selectors = `[name=${annot.name}]`;
+    if (cxns.length > 0) {
+      selectors = cxns[0].endIds.map(id => '#' + id).join(',');
+    }
+    // https://webservice.wikipathways.org/findInteractions?query=ACE2&format=json
+
+    const rawDiagram = await response.text();
+
+    const pathwayDiagram = `<div class="pathway-diagram">${rawDiagram}</div>`;
+
+    annot.displayName += pathwayDiagram;
+
+    document.querySelector('#_ideogramTooltip').innerHTML = annot.displayName;
+
+    Ideogram.d3.select('svg.Diagram')
+      .attr('width', 350)
+      .attr('height', 300);
+
+    const matches = document.querySelectorAll(selectors);
+    console.log('matches', matches)
+    const m0 = matches[0].getCTM();
+    const m0Rect = matches[0].getBoundingClientRect();
+    const m0Box = matches[0].getBBox();
+    const m0MinX = m0.e/m0.a;
+    const m0MinY = m0.f/m0.d;
+
+    let minX = m0MinX;
+    let minY = m0MinY;
+    let width;
+    let height;
+
+    width = 350;
+    height = 300;
+
+    matches[0].children[0].setAttribute('fill', '#F55');
+
+    if (matches.length > 1) {
+      matches[1].children[0].setAttribute('fill', '#C4C');
+      // const m1 = matches[1].getCTM();
+      // const m1Rect = matches[1].getBoundingClientRect();
+      // const m1Box = matches[1].getBBox();
+      // console.log('m0', m0)
+      // console.log('m1', m1)
+      // const m1MinX = m1.e/m1.a;
+      // const m1MinY = m1.f/m1.d;
+      // // const m1MinX = m1.e/m1.a + m1Rect.width;
+      // // const m1MinY = m1.f/m1.d - m1Rect.height;
+      // if (m1MinX < m0MinX) minX = m1MinX;
+      // if (m1MinY < m0MinY) minY = m1MinY;
+
+      // let pairWidth = 0;
+      // if (m0Rect.left < m1Rect.left) {
+      //   // pairWidth = m1Rect.right - m0Rect.left;
+      //   width += m1Box.width + 40;
+      // }
+
+      // // width += pairWidth;
+
+      // console.log('m0Rect', m0Rect)
+      // console.log('m1Rect', m1Rect)
+      // console.log('m1MinX', m1MinX)
+      // console.log('m0MinX', m0MinX)
+      // console.log('m1MinY', m1MinY)
+      // console.log('m0MinY', m0MinY)
+      // console.log('pairWidth', pairWidth)
+      // console.log('width', width)
+      // // width += Math.abs(m1MinX - m0MinX);
+      // // height += Math.abs(m1MinY - m0MinY);
+
+      // minX -= 100;
+      // minY -= 100;
+
+      minX -= 150;
+      minY -= 150;
+    } else {
+      minX -= 150;
+      minY -= 150;
+    }
+
+    const viewBox = `${minX} ${minY} ${width} ${height}`;
+    console.log('viewBox', viewBox);
+    document.querySelector('svg.Diagram').setAttribute('viewBox', viewBox);
+
+  }
+}

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -7,6 +7,7 @@ import * as d3fetch from 'd3-fetch';
 import * as d3brush from 'd3-brush';
 import * as d3dispatch from 'd3-dispatch';
 import * as d3format from 'd3-format';
+import * as d3zoom from 'd3-zoom';
 import {scaleLinear} from 'd3-scale';
 import {max} from 'd3-array';
 import {easeExpIn} from 'd3-ease';
@@ -14,7 +15,7 @@ import {easeExpIn} from 'd3-ease';
 import {organismMetadata} from './init/organism-metadata';
 
 var d3 = Object.assign(
-  {}, d3fetch, d3brush, d3dispatch, d3format
+  {}, d3fetch, d3brush, d3dispatch, d3format, d3zoom
 );
 
 d3.select = select;


### PR DESCRIPTION
This refines pathway interaction descriptions in the related genes kit.  It gives more scientific insight at a glance.

Previously, all interactions would be summarized as "interacts with Foo", where "Foo" was the searched gene.  Now, these descriptions are often more specific.  Instead of merely knowing gene A "interacts with" gene B, we can know it "stimulates" or "inhibits" or several other more granular types of interactions.  In addition to finer types of interactions, their directionality is also indicated, e.g. "inhibits" vs. "is inhibited by".

The refined interaction data is encoded in WikiPathways GPML files, and fetched via the WIkiPathways API.

Below is a comparison showing the old (top) and new (bottom) descriptions

https://user-images.githubusercontent.com/1334561/148144073-256f829b-00ef-43d9-9735-644f7fbf7385.mov

