### PR TITLE
Reduce label noise, omit accessions, fix search bug in Gene Hints

### DIFF
--- a/src/js/annotations/labels.js
+++ b/src/js/annotations/labels.js
@@ -225,7 +225,7 @@ function fillAnnotLabels(sortedAnnots=[]) {
     sortedAnnots = ideo.flattenAnnots();
   }
 
-  const m = 5; // padding
+  const m = 3; // padding
 
   sortedAnnots.forEach((annot, i) => {
     const layout = getAnnotLabelLayout(annot, ideo);
@@ -265,7 +265,7 @@ function fillAnnotLabels(sortedAnnots=[]) {
   });
 
 
-  spacedAnnots = applyRankCutoff(spacedAnnots, 20, ideo);
+  spacedAnnots = applyRankCutoff(spacedAnnots, 10, ideo);
 
   // Ensure highest-ranked annots are ordered last in SVG,
   // to ensure the are written before lower-ranked annots

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -430,7 +430,7 @@ async function fetchParalogs(annot, ideo) {
   // Omit genes named like "AC113554.1", which is an "accession.version".
   // Such accVers are raw and poorly suited here.
   annots = annots.filter(annot => {
-    const isAccVer = annot.name.match(/AC[0-9.]+$/);
+    const isAccVer = annot.name.match(/^AC[0-9.]+$/);
     return !isAccVer;
   });
 
@@ -1046,6 +1046,8 @@ function _initGeneHints(config, annotsInList) {
   ideogram.annotSortFunction = sortAnnotsByRelatedStatus;
 
   initAnalyzeRelatedGenes(ideogram);
+
+  initGeneCache(ideogram.config.organism, ideogram);
 
   return ideogram;
 }

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -424,8 +424,15 @@ async function fetchParalogs(annot, ideo) {
   const homologs = ensemblHomologs.data[0].homologies;
 
   // Fetch positions of paralogs
-  const annots =
+  let annots =
     await fetchParalogPositionsFromMyGeneInfo(homologs, annot, ideo);
+
+  // Omit genes named like "AC113554.1", which is an "accession.version".
+  // Such accVers are raw and poorly suited here.
+  annots = annots.filter(annot => {
+    const isAccVer = annot.name.match(/AC[0-9.]+$/);
+    return !isAccVer;
+  });
 
   return annots;
 }


### PR DESCRIPTION
This refines the related genes kit.  

It reduces the label-padding and the number of labels.  This ensures interesting genes aren't unduly unlabeled due to spacing certains, while also reducing the overall number of less interesting genes that are labeled.

It also omits paralogs that are accessions.  These are raw, little-known genes that are not the best input for exploration.

Finally, it fixes a bug in the default Gene Hints UI, in which the first search returned _all_ interacting genes, not just the top ranked ones.  That overcrowded things. 