### PR TITLE
Refine interaction detail, fix misdirected group interactions, test

### DIFF
--- a/src/js/annotations/labels.js
+++ b/src/js/annotations/labels.js
@@ -264,8 +264,12 @@ function fillAnnotLabels(sortedAnnots=[]) {
     spacedLayouts.push(layout);
   });
 
-
-  spacedAnnots = applyRankCutoff(spacedAnnots, 10, ideo);
+  let numLabels = 10;
+  const config = ideo.config;
+  if ('relatedGenesMode' in config && config.relatedGenesMode === 'hints') {
+    numLabels = 20;
+  }
+  spacedAnnots = applyRankCutoff(spacedAnnots, numLabels, ideo);
 
   // Ensure highest-ranked annots are ordered last in SVG,
   // to ensure the are written before lower-ranked annots

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -865,7 +865,7 @@ function decorateRelatedGene(annot) {
     `<br/>`;
 
   annot.displayName = originalDisplay;
-  if (descObj.type.includes('interacting gene')) {
+  if ('type' in descObj && descObj.type.includes('interacting gene')) {
     descObj.originalDisplay = originalDisplay;
     descObj.description = description;
     decorateInteraction(annot, descObj, ideo);
@@ -938,7 +938,8 @@ function _initRelatedGenes(config, annotsInList) {
     onWillShowAnnotTooltip: decorateRelatedGene,
     annotsInList: annotsInList,
     showTools: true,
-    showAnnotLabels: true
+    showAnnotLabels: true,
+    relatedGenesMode: 'related'
   };
 
   if ('onWillShowAnnotTooltip' in config) {
@@ -1041,7 +1042,8 @@ function _initGeneHints(config, annotsInList) {
     showTools: true,
     showAnnotLabels: true,
     onDrawAnnots: plotGeneHints,
-    annotationsPath: annotsPath
+    annotationsPath: annotsPath,
+    relatedGenesMode: 'hints'
   };
 
   if ('onWillShowAnnotTooltip' in config) {

--- a/src/js/kit/wikipathways.js
+++ b/src/js/kit/wikipathways.js
@@ -3,20 +3,20 @@
 // See also: https://discover.nci.nih.gov/mim/formal_mim_spec.pdf
 const interactionArrowMap = {
   'Arrow': ['acts on', 'acted on by'],
-  'TBar': ['inhibits', 'is inhibited by'],
+  'TBar': ['inhibits', 'inhibited by'],
   'mim-binding': ['binds', 'binds'],
   'mim-catalysis': ['catalyzes', 'catalyzed by'],
   'mim-cleavage': ['cleaves', 'cleaved by'],
   'mim-conversion': ['converts', 'converted by'],
   // 'mim-covalent-bond': ['covalently binds',
   // 'mim-gap': 'MimGap',
-  'mim-inhibition': ['inhibits', 'is inhibited by'],
-  'mim-modification': ['modifies', 'is modified by'],
+  'mim-inhibition': ['inhibits', 'inhibited by'],
+  'mim-modification': ['modifies', 'modified by'],
   'mim-necessary-stimulation':
-    ['necessarily stimulates', 'is necessarily stimulated by'],
-  'mim-stimulation': ['stimulates', 'is stimulated by'],
+    ['necessarily stimulates', 'necessarily stimulated by'],
+  'mim-stimulation': ['stimulates', 'stimulated by'],
   'mim-transcription-translation':
-    ['transcribes / translates', 'is transcribed / translated by']
+    ['transcribes / translates', 'transcribed / translated by']
 };
 
 /**

--- a/src/js/kit/wikipathways.js
+++ b/src/js/kit/wikipathways.js
@@ -70,7 +70,7 @@ function getMatchingIds(gpml, label) {
 }
 
 /**
- * Request GPML data from WikiPathways API e.g.:
+ * Request GPML data from WikiPathways API, e.g.:
  * https://webservice.wikipathways.org/getPathway?pwId=WP3982&format=json
  *
  * For more easily readable versions, see also:

--- a/test/online/related-genes.test.js
+++ b/test/online/related-genes.test.js
@@ -30,19 +30,26 @@ describe('Ideogram related genes kit', function() {
       rad54lLabel.dispatchEvent(new Event('mouseover'));
       let relatedGene = document.querySelector('#ideo-related-gene');
       assert.equal(relatedGene.textContent, 'RAD54L');
-      rad54lLabel.dispatchEvent(new Event('mouseout'));
 
-      const brca2Annot = document.querySelector('#chr13-9606 .annot path');
-      brca2Annot.dispatchEvent(new Event('mouseover'));
+      // Wait a second to account for fetching interaction details
+      setTimeout(function() {
+        const tooltip = document.querySelector('#_ideogramTooltip');
+        assert.include(tooltip.textContent, 'Stimulated by RAD51 in');
 
-      relatedGene = document.querySelector('#ideo-related-gene');
+        rad54lLabel.dispatchEvent(new Event('mouseout'));
 
-      assert.equal(relatedGene.textContent, 'BRCA2');
+        const brca2Annot = document.querySelector('#chr13-9606 .annot path');
+        brca2Annot.dispatchEvent(new Event('mouseover'));
 
-      const click = new MouseEvent('click', {view: window, bubbles: true});
-      relatedGene.dispatchEvent(click);
+        relatedGene = document.querySelector('#ideo-related-gene');
 
-      done();
+        assert.equal(relatedGene.textContent, 'BRCA2');
+
+        const click = new MouseEvent('click', {view: window, bubbles: true});
+        relatedGene.dispatchEvent(click);
+
+        done();
+      }, 1000);
     }
 
     function onClickAnnot(annot) {


### PR DESCRIPTION
This refines the related genes kit, fixes two bugs, and adds more automated testing.

Previously, the tooltip would often say e.g. "is inhibited by FOO".  Now the phrasing is trimmed, e.g. "inhibited by FOO".

The directionality of the reported interaction was also incorrect when the interacting gene was part of a group, i.e. when WikiPathways represented is as part of a complex or paralogous set.  The direction is now fixed, and verified with an automated test.

The default Gene Hints view had also unintentional left some genes unlabeled.  Now all 20 genes are labeled in that default view, while still labeling only up to 10 genes in the related view shown after searching a gene.