### PR TITLE
Summarize interactions by direction 

### DIFF
--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -31,7 +31,7 @@ import {getAnnotDomId} from '../annotations/process';
 import {applyRankCutoff} from '../annotations/labels';
 import {getDir} from '../lib';
 import initGeneCache from '../gene-cache';
-import {detailAllInteractions} from './wikipathways';
+import {summarizeInteractions} from './wikipathways';
 
 /** Sets DOM IDs for ideo.relatedAnnots; needed to associate labels */
 function setRelatedAnnotDomIds(ideo) {
@@ -822,28 +822,21 @@ function decorateInteraction(annot, descObj, ideo) {
   const pathwayIds = descObj.pathwayIds;
   annot.displayName = annot.displayName.replace(description, '');
 
-  detailAllInteractions(annot.name, pathwayIds, ideo).then(ixnsByPwid => {
+  summarizeInteractions(annot.name, pathwayIds, ideo).then(summary => {
+    // Begin setting up new HTML for interaction section of tooltip
     const oldHtml = document.querySelector('#_ideogramTooltip').innerHTML;
     const coords = oldHtml.match(/<br\/?>chr.*/)[0];
-
-    const ixns = ixnsByPwid[pathwayIds[0]];
-    if (typeof ixns === 'undefined') return;
-
     const trimmedOriginal =
       originalDisplay.replaceAll(/(<br\/?>){3,}/g, '<br/><br/>');
     let newHtml = trimmedOriginal + coords;
 
-    const isConsistent = ixns.every(ixn => {
-      return ixn.ixnType === ixns[0].ixnType;
-    });
-    if (ixns.length > 0 && isConsistent) {
-      const ixnType = ixns[0].ixnType;
-      const oldIxn = 'Interacts with';
-      const newIxn = ixnType;
-      const newDesc = trimmedOriginal.replace(oldIxn, newIxn);
-      newHtml = newDesc + coords;
+    if (summary !== null) {
+      const oldSummary = 'Interacts with';
+      const newDisplay = trimmedOriginal.replace(oldSummary, summary);
+      newHtml = newDisplay + coords;
     }
     document.querySelector('#_ideogramTooltip').innerHTML = newHtml;
+
   });
 }
 

--- a/src/js/kit/wikipathways.js
+++ b/src/js/kit/wikipathways.js
@@ -50,9 +50,9 @@ function determineIxnsInPathwayAreSame(ixns, ixnTypeReference) {
 
   if (ixns.length === 0) return {isRefMatch, thisIsSame};
 
-  const thisIxnTypeReference = ixns[0].ixnType;
+  const thisIxnTypeReference = ixns[0].ixnType.toLowerCase();
   ixns.forEach(ixn => {
-    const ixnType = ixn.ixnType;
+    const ixnType = ixn.ixnType.toLowerCase();
     if (ixnType !== ixnTypeReference) {
       isRefMatch = false;
     }
@@ -69,7 +69,7 @@ function determineIxnsInPathwayAreSame(ixns, ixnTypeReference) {
 function getIxnTypeReference(ixnsByPwid) {
   const ixnTypeReference = Object.values(ixnsByPwid).find(ixns => {
     return ixns.length > 0 && 'ixnType' in ixns[0];
-  }).ixnType;
+  })[0].ixnType.toLowerCase();
 
   return ixnTypeReference;
 }
@@ -86,7 +86,7 @@ function setIsSame(enrichedIxns) {
   Object.entries(ixnsByPwid).map(([pwid, ixns]) => {
     const {isRefMatch, thisIsSame} =
       determineIxnsInPathwayAreSame(ixns, ixnTypeReference);
-    if (!thisIsSame || isRefMatch) {
+    if (!thisIsSame || !isRefMatch) {
       isSame = false;
     }
     enrichedIxns.isSameByPwid[pwid] = thisIsSame;
@@ -222,6 +222,7 @@ export async function detailAllInteractions(gene, pathwayIds, ideo) {
   await Promise.all(
     pathwayIds.map(async pathwayId => {
       const ixns = await detailInteractions(gene, pathwayId, ideo);
+
       ixnsByPwid[pathwayId] = ixns;
     })
   );

--- a/test/online/related-genes.test.js
+++ b/test/online/related-genes.test.js
@@ -21,7 +21,7 @@ describe('Ideogram related genes kit', function() {
     return window.getComputedStyle(element).getPropertyValue('font-family');
   }
 
-  it('handles searched gene, annotation click, and font', done => {
+  it('handles searched gene, click, font, interaction summaries', done => {
 
     async function callback() {
       await ideogram.plotRelatedGenes('RAD51');
@@ -32,7 +32,10 @@ describe('Ideogram related genes kit', function() {
       assert.equal(relatedGene.textContent, 'RAD54L');
 
       // Wait a second to account for fetching interaction details
-      setTimeout(function() {
+      setTimeout(async function() {
+
+        // Test interaction gene summary processing, where one gene
+        // is part of a WikiPathways group
         let tooltip = document.querySelector('#_ideogramTooltip');
         assert.include(tooltip.textContent, 'Stimulated by RAD51 in');
 
@@ -40,18 +43,38 @@ describe('Ideogram related genes kit', function() {
 
         const brca2Annot = document.querySelector('#chr13-9606 .annot path');
         brca2Annot.dispatchEvent(new Event('mouseover'));
-        setTimeout(function() {
+        setTimeout(async function() {
           relatedGene = document.querySelector('#ideo-related-gene');
 
           assert.equal(relatedGene.textContent, 'BRCA2');
 
+          // Test interacting gene summary processing, where interactions
+          // *are not* directionally the same
           tooltip = document.querySelector('#_ideogramTooltip');
-          assert.include(tooltip.textContent, 'Interacts with RAD51 in');
+          assert.include(tooltip.textContent, 'Acts on RAD51 in');
 
-          const click = new MouseEvent('click', {view: window, bubbles: true});
-          relatedGene.dispatchEvent(click);
+          ideogram.plotRelatedGenes('ABL1');
 
-          done();
+          setTimeout(function() {
+            const atmLabel = document.querySelector('#ideogramLabel__c10_a0');
+            atmLabel.dispatchEvent(new Event('mouseover'));
+
+            setTimeout(function() {
+              // Test interacting gene summary processing, where interactions
+              // *are* directionally the same, though not identical in type
+              tooltip = document.querySelector('#_ideogramTooltip');
+              assert.include(tooltip.textContent, 'Acts on ABL1 in');
+
+              relatedGene = document.querySelector('#ideo-related-gene');
+              const click = new MouseEvent('click', {
+                view: window, bubbles: true
+              });
+              relatedGene.dispatchEvent(click);
+
+              done();
+            }, 4000);
+
+          }, 1000);
         }, 1000);
       }, 1000);
     }

--- a/test/online/related-genes.test.js
+++ b/test/online/related-genes.test.js
@@ -33,22 +33,26 @@ describe('Ideogram related genes kit', function() {
 
       // Wait a second to account for fetching interaction details
       setTimeout(function() {
-        const tooltip = document.querySelector('#_ideogramTooltip');
+        let tooltip = document.querySelector('#_ideogramTooltip');
         assert.include(tooltip.textContent, 'Stimulated by RAD51 in');
 
         rad54lLabel.dispatchEvent(new Event('mouseout'));
 
         const brca2Annot = document.querySelector('#chr13-9606 .annot path');
         brca2Annot.dispatchEvent(new Event('mouseover'));
+        setTimeout(function() {
+          relatedGene = document.querySelector('#ideo-related-gene');
 
-        relatedGene = document.querySelector('#ideo-related-gene');
+          assert.equal(relatedGene.textContent, 'BRCA2');
 
-        assert.equal(relatedGene.textContent, 'BRCA2');
+          tooltip = document.querySelector('#_ideogramTooltip');
+          assert.include(tooltip.textContent, 'Interacts with RAD51 in');
 
-        const click = new MouseEvent('click', {view: window, bubbles: true});
-        relatedGene.dispatchEvent(click);
+          const click = new MouseEvent('click', {view: window, bubbles: true});
+          relatedGene.dispatchEvent(click);
 
-        done();
+          done();
+        }, 1000);
       }, 1000);
     }
 


### PR DESCRIPTION
This refines how relationships are described when a gene pair interacts in multiple pathways.

Previously, unless the gene pair interactions were exactly the same across pathways, the genes were said to merely "interact" with each other.  Now, if the _direction_ of interactions is the same across pathways, they are described slightly more specifically.  

For example, say you search ABL1, and hover over the interacting gene ATM to learn more.  Using data from WikiPathways, Ideogram knows that ATM interacts with ABL1 in two pathways; it "acts on" ABL1 in one pathway, and "stimulates" ABL1 in the other.  

Previously, the related genes kit would see those two non-identical types of interaction and report ATM "Interacts with ABL1".    Now, the kit more intelligently realizes that path "acts on" and "stimulates" are directionally equivalent, and reports ATM "acts on ABL1".  It's more informative than before.

Before: direction not preserved ("Interacts with")
<img width="757" alt="ATM_interacts_with_ABL1_crude_summary__Ideogram_2022-01-22" src="https://user-images.githubusercontent.com/1334561/150656070-f4de8953-fc00-40da-a55b-940133eeab8c.png">

Now: direction preserved ("Acts on")
<img width="757" alt="ATM_acts_on_ABL1_refined_summary__Ideogram_2022-01-22" src="https://user-images.githubusercontent.com/1334561/150656076-53a825c1-f54f-403c-96d3-61034555878c.png">
