### PR TITLE
Refine annotation labels: better algorithms for sorting and overlap

### DIFF
--- a/src/js/annotations/annotations.js
+++ b/src/js/annotations/annotations.js
@@ -271,6 +271,43 @@ function fillAnnots(annots) {
   return filledAnnots;
 }
 
+export function applyRankCutoff(annots, cutoff, ideo) {
+  const rankedAnnots = sortAnnotsByRank(annots, ideo);
+
+  // Take the top N ranked genes, where N is `cutoff`
+  annots = rankedAnnots.slice(0, cutoff);
+
+  return annots;
+}
+
+export function setAnnotRanks(annots, ideo) {
+  if ('geneCache' in ideo === false) return annots;
+
+  const ranks = ideo.geneCache.interestingNames;
+
+  return annots.map(annot => {
+    annot.rank = ranks.indexOf(annot.name) || 1E10;
+    return annot;
+  });
+}
+
+export function sortAnnotsByRank(annots, ideo) {
+
+  if (ideo) {
+    annots = setAnnotRanks(annots, ideo);
+  }
+  // Ranks annots by popularity
+  return annots.sort((a, b) => {
+
+    // // Search gene is most important, regardless of popularity
+    // if (a.color === 'red') return -1;
+    // if (b.color === 'red') return 1;
+
+    // Rank 3 is more important than rank 30
+    return a.rank - b.rank;
+  });
+}
+
 export {
   onLoadAnnots, onDrawAnnots, processAnnotData, restoreDefaultTracks,
   updateDisplayedTracks, initAnnotSettings, fetchAnnots, drawAnnots,

--- a/src/js/annotations/annotations.js
+++ b/src/js/annotations/annotations.js
@@ -286,7 +286,11 @@ export function setAnnotRanks(annots, ideo) {
   const ranks = ideo.geneCache.interestingNames;
 
   return annots.map(annot => {
-    annot.rank = ranks.indexOf(annot.name) || 1E10;
+    if (ranks.includes(annot.name)) {
+      annot.rank = ranks.indexOf(annot.name) + 1;
+    } else {
+      annot.rank = 1E10;
+    }
     return annot;
   });
 }

--- a/src/js/annotations/labels.js
+++ b/src/js/annotations/labels.js
@@ -1,4 +1,6 @@
-import {d3, getFont, getTextSize} from '../lib';
+import {d3, getFont, getTextSize, deepCopy} from '../lib';
+
+import {sortAnnotsByRank} from './annotations';
 
 const allLabelStyle = `
   <style>
@@ -92,6 +94,10 @@ function renderLabel(annot, style, ideo) {
 
   const fill = annot.color === 'pink' ? '#CF406B' : annot.color;
 
+  if (annot.name === 'RAD51' || annot.name === 'RAD51B') {
+    console.log(annot.name + ' style:', style)
+  }
+
   d3.select('#_ideogram').append('text')
     .attr('id', id)
     .attr('class', '_ideogramLabel')
@@ -146,7 +152,6 @@ function getAnnotLabelLayout(annot, ideo) {
   width += pad;
 
   const labelSize = config.annotLabelSize ? config.annotLabelSize : 13;
-  // console.log('height, labelSize', height, labelSize);
 
   // Accounts for 1px top border, 1px bottom border as set in renderLabel
   height = labelSize;
@@ -155,8 +160,9 @@ function getAnnotLabelLayout(annot, ideo) {
   bottom = top + height;
   left = annotRect.left - ideoRect.left - width;
   right = left + width;
+  name = annot.name;
 
-  return {top, bottom, right, left, width, height};
+  return {top, bottom, right, left, width, height, name};
 }
 
 /**
@@ -180,46 +186,182 @@ function addAnnotLabel(annotName, backgroundColor, borderColor) {
   renderLabel(annot, style, ideo);
 }
 
-export function sortAnnotsByRank(annots, ideo) {
-  if ('geneCache' in ideo === false) return annots;
-
-  const ranks = ideo.geneCache.interestingNames;
-
-  annots = annots.map(annot => {
-    annot.rank = ranks.indexOf(annot.name) || 1E10;
-    return annot;
-  });
-
-  // Ranks annots by popularity
-  const rankedAnnots = annots.sort((a, b) => {
-
-    // Search gene is most important, regardless of popularity
-    if (a.color === 'red') return -1;
-    if (b.color === 'red') return 1;
-
-    // Rank 3 is more important than rank 30
-    return a.rank - b.rank;
-  });
-
-  return rankedAnnots;
+function getIsXOverlap(o, n, p) {
+  const oLeft = o.left - p;
+  const nLeft = n.left - p;
+  const oRight = o.right + p;
+  const nRight = n.right + p;
+  // A) oLeft < nLeft && oLeft < nRight && oRight < nRight && oRight > nLeft
+  // o     o
+  // o     o
+  // o     o
+  //
+  //    n      n
+  //    n      n
+  //    n      n
+  //
+  // B) oLeft > nLeft && oLeft < nRight && oRight > nRight && oRight > nLeft
+  //    o     o
+  //    o     o
+  //    o     o
+  //
+  // n     n
+  // n     n
+  // n     n
+  //
+  // C) oLeft < nLeft && oLeft < nRight && oRight > nRight && oRight > nLeft
+  // o         o
+  // o         o
+  // o         o
+  //
+  //    n   n
+  //    n   n
+  //
+  // D) oLeft > nLeft && oLeft < nRight && oRight > nLeft && oRight < nRight
+  //    o   o
+  //    o   o
+  //    o   o
+  //
+  // n         n
+  // n         n
+  // n         n
+  return (
+    (oLeft <= nLeft && oLeft <= nRight && oRight <= nRight && oRight >= nLeft) ||
+    (oLeft >= nLeft && oLeft <= nRight && oRight >= nRight && oRight >= nLeft) ||
+    (oLeft <= nLeft && oLeft <= nRight && oRight >= nRight && oRight >= nLeft) ||
+    (oLeft >= nLeft && oLeft <= nRight && oRight >= nLeft && oRight <= nRight)
+  )
 }
 
-export function applyRankCutoff(annots, cutoff, ideo) {
-  const rankedAnnots = sortAnnotsByRank(annots, ideo);
+function getIsYOverlap(o, n, p) {
+    const oTop = o.top - p;
+    const nTop = n.top - p;
+    const oBottom = o.bottom + p;
+    const nBottom = n.bottom + p;
+    // Top of old annot (o) is above bottom of new annot (n),
+    // and bottom of old annot is below top of new annot
+    //
+    //  A) yOverlap = true
+    //      o.top < n.top && o.top < n.bottom && o.bottom < n.bottom && o.bottom > n.top
+    //    ooooo
+    //            nnnnn
+    //
+    //    ooooo
+    //            nnnnn
+    //
+    //  A.2)
+    //
+    //    ppppp
+    //    ppppp
+    //    ooooo
+    //
+    //            ppppp
+    //    ooooo   ppppp
+    //    ppppp   nnnnn
+    //    ppppp
+    //
+    //            nnnnn
+    //            ppppp
+    //            ppppp
+    //
+    //  B) yOverlap = true
+    //     o.top > n.top && o.top < n.bottom && o.bottom > n.bottom && o.bottom > n.top
+    //            nnnnn
+    //    ooooo
+    //
+    //            nnnnn
+    //    ooooo
+    //
+    //   B.2)
+    //
+    //            ppppp
+    //    ppppp   ppppp
+    //    ppppp   nnnnn
+    //    ooooo
+    //
+    //            nnnnn
+    //    ooooo   ppppp
+    //    ppppp   ppppp
+    //    ppppp
+    //
+    //
+    //  C) yOverlap = false
+    //     old.top < new.top && old.bottom < new.top
+    //    ooooo
+    //
+    //
+    //    ooooo
+    //
+    //          nnnnn
+    //
+    //
+    //          nnnnn
+    //
+    //  D) yOverlap = false
+    //          nnnnn
+    //
+    //
+    //          nnnnn
+    //
+    //    ooooo
+    //
+    //
+    //    ooooo
+    // sl.top - p < layout.bottom && sl.bottom > layout.top - p ||
+    // layout.top - p < sl.bottom && layout.bottom > sl.bottom
 
-  // Take the top N ranked genes, where N is `cutoff`
-  annots = rankedAnnots.slice(0, cutoff);
+    // XY overlap
+    // A)
+    //
+    //  ooooooo
+    //  o     o
+    //  o    nonnnnn
+    //  ooooooo    n
+    //       n     n
+    //       nnnnnnn
+    //
+    //
+    //  B)
+    //       ooooooo
+    //       o     o
+    //  nnnnnnn    o
+    //  n    onooooo
+    //  n     n
+    //  nnnnnnn
+    //
+    //  C)
+    //
+    //  ooooooo   nnnnnnn
+    //  o     o   n     n
+    //  o     o   n     n
+    //  ooooooo   nnnnnnn
+    //
+    //  D)
+    //
+    //  ooooooo
+    //  o     o
+    //  o     o
+    //  ooooooo
+    //
+    //  nnnnnnn
+    //  n     n
+    //  n     n
+    //  nnnnnnn
+    return (
+      // false
+      (oTop <= nTop && oTop <= nBottom && oBottom <= nBottom && oBottom >= nTop) ||
+      (oTop >= nTop && oTop <= nBottom && oBottom >= nBottom && oBottom >= nTop)
+    );
 
-  // console.log(annots.map(annot => {return annot.name + ' ' + annot.rank }));
-
-  return annots;
+    // (sl.top - p < layout.bottom || sl.bottom > layout.top - p) &&
+    // (layout.top - p < sl.bottom || layout.bottom > sl.bottom)
 }
 
 /** Label as many annotations as possible, without overlap */
 function fillAnnotLabels(sortedAnnots=[]) {
   const ideo = this;
 
-  sortedAnnots = sortedAnnots.slice(); // copy by value
+  sortedAnnots = deepCopy(sortedAnnots); // copy by value
 
   // Remove any pre-existing annotation labels, to avoid duplicates
   ideo.clearAnnotLabels();
@@ -227,40 +369,55 @@ function fillAnnotLabels(sortedAnnots=[]) {
   let spacedAnnots = [];
   const spacedLayouts = [];
 
+  // sortedAnnots = applyRankCutoff(sortedAnnots, 100, ideo);
+
+  // sortedAnnots = sortedAnnots.sort(ideo.annotSortFunction);
+
   if (sortedAnnots.length === 0) {
     sortedAnnots = ideo.flattenAnnots();
   }
 
-  const m = 3; // padding
+  const strokeWidth = 3; // like padding
 
   sortedAnnots.forEach((annot, i) => {
     const layout = getAnnotLabelLayout(annot, ideo);
 
-    if (layout === null) return;
+    if (layout === null) {
+      console.log(annot.name + ' has null layout')
+      return;
+    }
 
     const hasOverlap =
-      spacedLayouts.length > 1 && spacedLayouts.some((sl, j) => {
+      spacedLayouts.length > 0 && spacedLayouts.some((sl, j) => {
+        const xOverlap = getIsXOverlap(sl, layout, strokeWidth);
+        const yOverlap = getIsYOverlap(sl, layout, strokeWidth);
 
-        const xOverlap = (
-          sl.left - m <= layout.right &&
-          sl.right >= layout.left - m
-        );
-        const yOverlap =
-          (
-            sl.top - m < layout.bottom && sl.bottom > layout.top - m ||
-            layout.top - m < sl.bottom && layout.bottom > sl.bottom
-          );
-
-        // if (annot.name === 'TP73') {
+        // if (annot.name === 'PTK2' || annot.name === 'XRCC3') {
         //   const spacedAnnot = spacedAnnots[j].name;
-        //   console.log(
-        //     'xOverlap, yOverlap, annot.name, layout, spacedAnnot, sl'
-        //   );
-        //   console.log(
-        //     xOverlap, yOverlap, annot.name, layout, spacedAnnot, sl
-        //   );
+        //   if (spacedAnnot === 'ABL1' || spacedAnnot === 'RAD51') {
+        //   // if (xOverlap && yOverlap) {
+        //     // console.log('sl.top - strokeWidth', sl.top - strokeWidth)
+        //     // console.log('sl.top - strokeWidth < layout.bottom')
+        //     // console.log(sl.top - strokeWidth < layout.bottom)
+        //     // console.log('sl.bottom > layout.top - strokeWidth')
+        //     // console.log(sl.bottom > layout.top - strokeWidth)
+        //     // console.log('layout.top - strokeWidth < sl.bottom')
+        //     // console.log(layout.top - strokeWidth < sl.bottom)
+        //     // console.log('layout.bottom > sl.bottom')
+        //     // console.log(layout.bottom > sl.bottom)
+        //     console.log(
+        //       'xOverlap, yOverlap, spacedAnnot, sl, annot.name, layout'
+        //     );
+        //     console.log(
+        //       xOverlap, yOverlap, spacedAnnot, sl, annot.name, layout
+        //     );
+        //   }
         // }
 
+        // if (xOverlap && yOverlap) {
+        //   console.log('overlap! annot');
+        //   console.log(annot.name, annot.chr, annot.color);
+        // }
         return xOverlap && yOverlap;
       });
 
@@ -275,7 +432,9 @@ function fillAnnotLabels(sortedAnnots=[]) {
   if ('relatedGenesMode' in config && config.relatedGenesMode === 'hints') {
     numLabels = 20;
   }
-  spacedAnnots = applyRankCutoff(spacedAnnots, numLabels, ideo);
+  // spacedAnnots = applyRankCutoff(spacedAnnots, numLabels, ideo);
+  spacedAnnots = spacedAnnots.sort(ideo.annotSortFunction).slice(0, numLabels)
+
 
   // Ensure highest-ranked annots are ordered last in SVG,
   // to ensure the are written before lower-ranked annots

--- a/src/js/annotations/labels.js
+++ b/src/js/annotations/labels.js
@@ -94,10 +94,6 @@ function renderLabel(annot, style, ideo) {
 
   const fill = annot.color === 'pink' ? '#CF406B' : annot.color;
 
-  if (annot.name === 'RAD51' || annot.name === 'RAD51B') {
-    console.log(annot.name + ' style:', style)
-  }
-
   d3.select('#_ideogram').append('text')
     .attr('id', id)
     .attr('class', '_ideogramLabel')
@@ -377,7 +373,7 @@ function fillAnnotLabels(sortedAnnots=[]) {
     sortedAnnots = ideo.flattenAnnots();
   }
 
-  const strokeWidth = 3; // like padding
+  const strokeWidth = 1; // like padding
 
   sortedAnnots.forEach((annot, i) => {
     const layout = getAnnotLabelLayout(annot, ideo);
@@ -392,9 +388,9 @@ function fillAnnotLabels(sortedAnnots=[]) {
         const xOverlap = getIsXOverlap(sl, layout, strokeWidth);
         const yOverlap = getIsYOverlap(sl, layout, strokeWidth);
 
-        // if (annot.name === 'PTK2' || annot.name === 'XRCC3') {
+        // if (annot.name === 'AKT1' || annot.name === 'XRCC3') {
         //   const spacedAnnot = spacedAnnots[j].name;
-        //   if (spacedAnnot === 'ABL1' || spacedAnnot === 'RAD51') {
+        //   if (spacedAnnot === 'HIF1A' || spacedAnnot === 'RAD51') {
         //   // if (xOverlap && yOverlap) {
         //     // console.log('sl.top - strokeWidth', sl.top - strokeWidth)
         //     // console.log('sl.top - strokeWidth < layout.bottom')

--- a/src/js/annotations/labels.js
+++ b/src/js/annotations/labels.js
@@ -373,7 +373,7 @@ function fillAnnotLabels(sortedAnnots=[]) {
     sortedAnnots = ideo.flattenAnnots();
   }
 
-  const strokeWidth = 1; // like padding
+  const strokeWidth = 0; // like padding
 
   sortedAnnots.forEach((annot, i) => {
     const layout = getAnnotLabelLayout(annot, ideo);

--- a/src/js/annotations/process.js
+++ b/src/js/annotations/process.js
@@ -1,4 +1,5 @@
 import {add2dAnnotsForChr} from './heatmap-2d';
+import {setAnnotRanks} from './annotations';
 
 // Default colors for tracks of annotations
 var colorMap = [
@@ -131,18 +132,6 @@ function addAnnotsForChr(annots, omittedAnnots, annotsByChr, chrModel,
     ideo.config.annotationsLayout === 'tracks'
   );
 
-  if (shouldAssignDomId) {
-    if (ideo.annotSortFunction) {
-      annotsByChr.annots.sort((a, b) => {
-        // Reverse-sort, so first annots are drawn last, and thus at top layer
-        return -ideo.annotSortFunction(a, b);
-      });
-    } else {
-      // Sort by genomic position, in ascending order
-      annotsByChr.annots.sort((a, b) => a[1] - b[1]);
-    }
-  }
-
   for (j = 0; j < annotsByChr.annots.length; j++) {
     ra = annotsByChr.annots[j];
     annot = {};
@@ -162,6 +151,23 @@ function addAnnotsForChr(annots, omittedAnnots, annotsByChr, chrModel,
 
     [annots, omittedAnnots] =
       addAnnot(annot, keys, ra, omittedAnnots, annots, m, ideo);
+  }
+
+  if (shouldAssignDomId) {
+    if (ideo.annotSortFunction) {
+      annots[m].annots = setAnnotRanks(annots[m].annots, ideo);
+      annots[m].annots.sort((a, b) => {
+        // Reverse-sort, so first annots are drawn last, and thus at top layer
+        return -ideo.annotSortFunction(a, b);
+      });
+    } else {
+      // Sort by genomic position, in ascending order
+      annots[m].annots.sort((a, b) => a[1] - b[1]);
+    }
+
+    for (j = 0; j < annots[m].annots.length; j++) {
+      annots[m].annots[j].domId = getAnnotDomId(m, j);
+    }
   }
 
   return [annots, omittedAnnots];

--- a/src/js/gene-cache.js
+++ b/src/js/gene-cache.js
@@ -135,7 +135,7 @@ function parseCache(rawTsv, orgName) {
 /** Get organism's metadata fields */
 function parseOrgMetadata(orgName) {
   const taxid = getEarlyTaxid(orgName);
-  return organismMetadata[taxid];
+  return organismMetadata[taxid] || {};
 }
 
 /** Reports if current organism has a gene cache */

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -74,6 +74,8 @@ function setRelatedAnnotDomIds(ideo) {
   const relevanceSortedAnnotsNamesByChr = {};
   Object.entries(annotsByChr).map(([chr, annots]) => {
 
+    annots = setAnnotRanks(annots, ideo);
+
     // Sort so first annots are drawn last, and thus at top layer
     annots.sort((a, b) => -ideo.annotSortFunction(a, b));
 
@@ -911,9 +913,15 @@ function decorateRelatedGene(annot) {
   const fullName = descObj.name;
   const style = 'style="color: #0366d6; cursor: pointer;"';
 
+  let fullNameAndRank = fullName;
+  if ('rank' in annot) {
+    const rank = 'Ranked ' + annot.rank + ' in general or scholarly interest';
+    fullNameAndRank = `<span title="${rank}">${fullName}</span>`;
+  }
+
   const originalDisplay =
     `<span id="ideo-related-gene" ${style}>${annot.name}</span><br/>` +
-    `${fullName}<br/>` +
+    `${fullNameAndRank}<br/>` +
     `${description}` +
     `<br/>`;
 

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -351,10 +351,15 @@ function getTextSize(text, ideo) {
   return {width, height};
 }
 
+/** Clone a nested array */
+function deepCopy(array) {
+  return JSON.parse(JSON.stringify(array));
+}
+
 export {
   assemblyIsAccession, hasNonGenBankAssembly, hasGenBankAssembly, getDataDir,
   getDir, round, onDidRotate, getSvg, d3, getEarlyTaxid, getTaxid,
   getCommonName, getScientificName, slug, isRoman, parseRoman, downloadPng,
-  fetchWithRetry, getTextSize, getFont,
+  fetchWithRetry, getTextSize, getFont, deepCopy,
   fetchWithAuth as fetch
 };


### PR DESCRIPTION
This refines layout algorithm for annotation labels, for more relevant sorting and more precise overlap calculations.  It builds on #295.  Examples below highlight how this enriches the [related genes](https://eweitz.github.io/ideogram/related-genes?q=APOE&org=homo-sapiens) kit.

## Example
Unrefined label sorting: RAD52 is obscure compared to BRCA2.

<img width="878" alt="0_Unrefined_label_sorting_RAD51__Ideogram_2022-03-09" src="https://user-images.githubusercontent.com/1334561/157575346-01ba5c90-3a14-4962-8f54-e92528e976ae.png">

Refined label sorting: BRCA2 is much more popular than RAD52.

<img width="881" alt="1_Refined_label_sorting_RAD51__Ideogram_2022-03-09" src="https://user-images.githubusercontent.com/1334561/157575350-c2e31014-b66d-42e4-8615-949bdbb5e977.png">

Hovering over the tooltip shows the gene's rank, using gene cache popularity data from Gene Hints.

<img width="874" alt="2_Gene_interest_rank_BRCA2__Ideogram_2022-03-09" src="https://user-images.githubusercontent.com/1334561/157575349-41c4f247-05ad-4634-b34e-006659a64242.png">

## Another example
Excessive padding in overlap calculations hid important genes.  Now, nearby genes like LDLR can be shown without colliding.

<img width="877" alt="3_Unrefined_label_sorting_APOE__Ideogram_2022-03-09" src="https://user-images.githubusercontent.com/1334561/157575348-bd4f6df6-8a23-411f-929e-dc4505b95e59.png">
<img width="871" alt="4_Refined_label_sorting_APOE__Ideogram_2022-03-09" src="https://user-images.githubusercontent.com/1334561/157575347-a95fb01a-ba36-48ef-99f2-bfcca53583cc.png">
