### PR TITLE
Smooth exploration: hide tooltip after clicking annotation

### DIFF
--- a/src/js/annotations/events.js
+++ b/src/js/annotations/events.js
@@ -46,7 +46,7 @@ function startHideAnnotTooltipTimeout() {
     ideo.isTooltipCooling = true;
     ideo.hideAnnotTooltipCounter = window.setTimeout(function() {
       ideo.isTooltipCooling = false;
-    }, 250);
+    }, 500);
   // }
 }
 

--- a/src/js/annotations/events.js
+++ b/src/js/annotations/events.js
@@ -42,12 +42,10 @@ function startHideAnnotTooltipTimeout() {
     hideAnnotTooltip();
   }, 250);
 
-  // if ('isTooltipCooling' in ideo && ideo.isTooltipCooling === false) {
-    ideo.isTooltipCooling = true;
-    ideo.hideAnnotTooltipCounter = window.setTimeout(function() {
-      ideo.isTooltipCooling = false;
-    }, 500);
-  // }
+  ideo.isTooltipCooling = true;
+  ideo.hideAnnotTooltipCounter = window.setTimeout(function() {
+    ideo.isTooltipCooling = false;
+  }, 500);
 }
 
 function renderTooltip(tooltip, content, matrix, yOffset, ideo) {

--- a/src/js/annotations/events.js
+++ b/src/js/annotations/events.js
@@ -15,6 +15,13 @@ function onDrawAnnots() {
   call(this.onDrawAnnotsCallback);
 }
 
+function hideAnnotTooltip() {
+  d3.select('._ideogramTooltip').transition()
+    .duration(500) // fade out for half second
+    .style('opacity', 0)
+    .style('pointer-events', 'none');
+}
+
 /**
  * Starts a timer that, upon expiring, hides the annotation tooltip.
  *
@@ -25,17 +32,22 @@ function onDrawAnnots() {
  * then the timer is cleared.
  */
 function startHideAnnotTooltipTimeout() {
+  const ideo = this;
 
-  if (this.config.showAnnotTooltip === false) {
+  if (ideo.config.showAnnotTooltip === false) {
     return;
   }
 
-  this.hideAnnotTooltipTimeout = window.setTimeout(function() {
-    d3.select('._ideogramTooltip').transition()
-      .duration(500) // fade out for half second
-      .style('opacity', 0)
-      .style('pointer-events', 'none');
+  ideo.hideAnnotTooltipTimeout = window.setTimeout(function() {
+    hideAnnotTooltip();
   }, 250);
+
+  // if ('isTooltipCooling' in ideo && ideo.isTooltipCooling === false) {
+    ideo.isTooltipCooling = true;
+    ideo.hideAnnotTooltipCounter = window.setTimeout(function() {
+      ideo.isTooltipCooling = false;
+    }, 250);
+  // }
 }
 
 function renderTooltip(tooltip, content, matrix, yOffset, ideo) {
@@ -84,6 +96,7 @@ function onWillShowAnnotTooltip(annot) {
  * Optional callback, invoked on clicking annotation
  */
 function onClickAnnot(annot) {
+  this.prevClickedAnnot = annot;
   this.onClickAnnotCallback(annot);
 }
 
@@ -141,6 +154,14 @@ function showAnnotTooltip(annot, context) {
   if (ideo.onWillShowAnnotTooltipCallback) {
     annot = ideo.onWillShowAnnotTooltipCallback(annot);
   }
+
+  // Enable onWillShowAnnotTooltipCallback to cancel showing tooltip
+  if (annot === null) {
+    hideAnnotTooltip();
+    return;
+  }
+
+  ideo.prevTooltipAnnotName = annot.name;
 
   tooltip = d3.select('._ideogramTooltip');
   tooltip.interrupt(); // Stop any in-progress disapperance

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -1116,7 +1116,7 @@ const relatedLegend = [{
   ]
 }];
 
-let legendPathwayName = ''
+let legendPathwayName = '';
 
 const pathwayLegend = [{
   name: `

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -1012,28 +1012,6 @@ function getAnnotByName(annotName, ideo) {
 }
 
 /**
- * Handles click within annotation tooltip
- *
- * Makes clicking link in tooltip behave same as clicking annotation
- */
-function handleTooltipClick(ideo) {
-  const tooltip = document.querySelector('._ideogramTooltip');
-  if (!ideo.addedTooltipClickHandler) {
-    tooltip.addEventListener('click', () => {
-      const geneDom = document.querySelector('#ideo-related-gene');
-      const annotName = geneDom.textContent;
-      const annot = getAnnotByName(annotName, ideo);
-      ideo.onClickAnnot(annot);
-    });
-
-    // Ensures handler isn't added redundantly.  This is used because
-    // addEventListener options like {once: true} don't suffice
-    ideo.addedTooltipClickHandler = true;
-  }
-}
-
-
-/**
  * Manage click on pathway links in annotation tooltips
  */
 function managePathwayClickHandlers(searchedGene, ideo) {
@@ -1063,6 +1041,15 @@ function managePathwayClickHandlers(searchedGene, ideo) {
  */
 function decorateRelatedGene(annot) {
   const ideo = this;
+
+  if (
+    annot.name === ideo.prevClickedAnnot?.name &&
+    ideo.isTooltipCooling
+  ) {
+    // Cancels showing tooltip immediately after clicking gene
+    return null;
+  }
+
   const descObj = ideo.annotDescriptions.annots[annot.name];
 
   if ('type' in descObj && descObj.type.includes('interacting gene')) {


### PR DESCRIPTION
This hides the tooltip immediately after clicking an annotation.  It improves glanceability of related genes kit results.

Old -- tooltip shown after clicking gene, hiding some results (e.g. ATM) until cursor is moved:

https://user-images.githubusercontent.com/1334561/161046995-30010f93-d50d-4daf-8f3f-05383ef694c0.mov


New -- tooltip _hidden_ after clicking gene, showing all results without need to move cursor:

https://user-images.githubusercontent.com/1334561/161046980-f729b791-6320-468b-a177-f4835524c18d.mov