### PR TITLE
Show paralog neighborhoods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ideogram
 
-[![Build Status](https://travis-ci.org/eweitz/ideogram.svg?branch=master)](https://travis-ci.org/eweitz/ideogram)
+[![Build Status](https://api.travis-ci.com/eweitz/ideogram.svg?branch=master)](https://app.travis-ci.com/github/eweitz/ideogram)
 [![Coverage Status](https://coveralls.io/repos/github/eweitz/ideogram/badge.svg)](https://coveralls.io/github/eweitz/ideogram)
 
 [Ideogram.js](https://eweitz.github.io/ideogram/) is a JavaScript library for [chromosome visualization](https://speakerdeck.com/eweitz/designing-genome-visualizations-with-ideogramjs). 

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -310,7 +310,7 @@
       // fontFamily: "'Montserrat', sans-serif",
       onLoad: plotGeneFromUrl,
       onPlotRelatedGenes: reportRelatedGenes,
-      showAnnotLabels: true,
+      showParalogNeighborhoods: true,
       onClickAnnot
     }
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,9 +16,9 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       'src/js/index.js',
-      // 'test/offline/**.test.js',
-      // 'test/online/**.test.js',
-      'test/online/related-genes.test.js',
+      'test/offline/**.test.js',
+      'test/online/**.test.js',
+      // 'test/online/related-genes.test.js',
       {pattern: 'dist/data/**', watched: false, included: false, served: true, nocache: false}
     ],
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,9 +16,9 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       'src/js/index.js',
-      'test/offline/**.test.js',
-      'test/online/**.test.js',
-      // 'test/online/related-genes.test.js',
+      // 'test/offline/**.test.js',
+      // 'test/online/**.test.js',
+      'test/online/related-genes.test.js',
       {pattern: 'dist/data/**', watched: false, included: false, served: true, nocache: false}
     ],
 

--- a/src/js/annotations/draw.js
+++ b/src/js/annotations/draw.js
@@ -40,7 +40,7 @@ function parseFriendlyKeys(friendlyAnnots) {
 /**
  * Draws annotations defined by user
  */
-function drawAnnots(friendlyAnnots) {
+function drawAnnots(friendlyAnnots, layout, keepPrior=false) {
   var keys, chr,
     rawAnnots = [],
     ideo = this,
@@ -50,7 +50,7 @@ function drawAnnots(friendlyAnnots) {
     'annots' in friendlyAnnots[0] || // When filtering
     'values' in friendlyAnnots[0] // When drawing cached expression matrices
   ) {
-    return ideo.drawProcessedAnnots(friendlyAnnots);
+    return ideo.drawProcessedAnnots(friendlyAnnots, layout);
   }
 
   for (chr in chrs) {
@@ -63,7 +63,7 @@ function drawAnnots(friendlyAnnots) {
   ideo.rawAnnots = {keys: keys, annots: rawAnnots};
   ideo.annots = ideo.processAnnotData(ideo.rawAnnots);
 
-  ideo.drawProcessedAnnots(ideo.annots);
+  ideo.drawProcessedAnnots(ideo.annots, layout, keepPrior);
 }
 
 function getShapes(annotHeight) {
@@ -195,6 +195,8 @@ function drawAnnotsByLayoutType(layout, annots, ideo) {
   if (layout === 'tracks') {
     writeTrackAnnots(chrAnnot, ideo);
   } else if (layout === 'overlay') {
+    console.log('writing overlay annots, chrAnnot:')
+    console.log(chrAnnot)
     writeOverlayAnnots(chrAnnot, ideo);
   } else if (layout === 'histogram') {
     writeHistogramAnnots(chrAnnot, ideo);
@@ -207,13 +209,14 @@ function drawAnnotsByLayoutType(layout, annots, ideo) {
  * on a chromosome, or along one or more "tracks"
  * running parallel to each chromosome.
  */
-function drawProcessedAnnots(annots) {
-  var layout,
-    ideo = this;
+function drawProcessedAnnots(annots, layout, keepPrior=false) {
+  var ideo = this;
 
-  d3.selectAll(ideo.selector + ' .annot').remove();
+  if (!keepPrior) {
+    d3.selectAll(ideo.selector + ' .annot').remove();
+  }
 
-  layout = 'tracks';
+  if (layout === undefined) layout = 'tracks';
   if (ideo.config.annotationsLayout) layout = ideo.config.annotationsLayout;
 
   if ('legend' in ideo.config) writeLegend(ideo);

--- a/src/js/annotations/draw.js
+++ b/src/js/annotations/draw.js
@@ -40,7 +40,7 @@ function parseFriendlyKeys(friendlyAnnots) {
 /**
  * Draws annotations defined by user
  */
-function drawAnnots(friendlyAnnots, layout, keepPrior=false) {
+function drawAnnots(friendlyAnnots, layout, keep=false, isOtherLayout=false) {
   var keys, chr,
     rawAnnots = [],
     ideo = this,
@@ -61,9 +61,15 @@ function drawAnnots(friendlyAnnots, layout, keepPrior=false) {
   keys = parseFriendlyKeys(friendlyAnnots);
 
   ideo.rawAnnots = {keys: keys, annots: rawAnnots};
-  ideo.annots = ideo.processAnnotData(ideo.rawAnnots);
 
-  ideo.drawProcessedAnnots(ideo.annots, layout, keepPrior);
+  const processedAnnots = ideo.processAnnotData(ideo.rawAnnots);
+  if (!isOtherLayout) {
+    ideo.annots = processedAnnots;
+  } else {
+    ideo.annotsOther = processedAnnots;
+  }
+
+  ideo.drawProcessedAnnots(processedAnnots, layout, keep);
 }
 
 function getShapes(annotHeight) {
@@ -195,8 +201,6 @@ function drawAnnotsByLayoutType(layout, annots, ideo) {
   if (layout === 'tracks') {
     writeTrackAnnots(chrAnnot, ideo);
   } else if (layout === 'overlay') {
-    console.log('writing overlay annots, chrAnnot:')
-    console.log(chrAnnot)
     writeOverlayAnnots(chrAnnot, ideo);
   } else if (layout === 'histogram') {
     writeHistogramAnnots(chrAnnot, ideo);
@@ -209,10 +213,10 @@ function drawAnnotsByLayoutType(layout, annots, ideo) {
  * on a chromosome, or along one or more "tracks"
  * running parallel to each chromosome.
  */
-function drawProcessedAnnots(annots, layout, keepPrior=false) {
+function drawProcessedAnnots(annots, layout, keep=false) {
   var ideo = this;
 
-  if (!keepPrior) {
+  if (!keep) {
     d3.selectAll(ideo.selector + ' .annot').remove();
   }
 

--- a/src/js/annotations/events.js
+++ b/src/js/annotations/events.js
@@ -67,7 +67,9 @@ function getContentAndYOffset(annot) {
   var content, yOffset, range, displayName;
 
   range = 'chr' + annot.chr + ':' + annot.start.toLocaleString();
-  if (annot.length > 0) {
+  if (annot.displayCoordinates) {
+    range = annot.displayCoordinates;
+  } else if (annot.length > 0) {
     // Only show range if stop differs from start
     range += '-' + annot.stop.toLocaleString();
   }

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -619,7 +619,7 @@ function overplotParalogs(annots, ideo) {
         chr,
         start: annotStart,
         stop: annotStop,
-        color: 'green',
+        color: 'pink',
         description,
         paralogs,
         type: 'paralog neighborhood',
@@ -1270,20 +1270,22 @@ function decorateRelatedGene(annot) {
       'Paralog neighborhood<br/>' +
       '<br/>' +
       descObj.description + ':<br/>' +
-      `${descObj.paralogs.map(paralog => {
-        let title = '';
-        if (paralog.fullName) title = paralog.fullName;
-        if (paralog.rank) {
-          const rank = paralog.rank;
-          title += `&#013;Ranked ${rank} in general or scholarly interest`;
-        }
-        if (title !== '') title = `title="${title}"`;
-        return (
-          `<span class="ideo-paralog-neighbor" ${title} ${style}'>${
-            paralog.name
-          }</span>`
-        );
-      }).join('<br/>')}` +
+      `${descObj.paralogs
+        .sort((a, b) => a.rank - b.rank) // Rank 1st highest
+        .map(paralog => {
+          let title = '';
+          if (paralog.fullName) title = paralog.fullName;
+          if (paralog.rank) {
+            const rank = paralog.rank;
+            title += `&#013;Ranked ${rank} in general or scholarly interest`;
+          }
+          if (title !== '') title = `title="${title}"`;
+          return (
+            `<span class="ideo-paralog-neighbor" ${title} ${style}'>${
+              paralog.name
+            }</span>`
+          );
+        }).join('<br/>')}` +
       '<br/>';
     annot.displayCoordinates = descObj.displayCoordinates;
   }
@@ -1377,6 +1379,7 @@ function _initRelatedGenes(config, annotsInList) {
     annotsInList: annotsInList,
     showTools: true,
     showAnnotLabels: true,
+    chrFillColor: {centromere: '#EABBBB'},
     relatedGenesMode: 'related'
   };
 

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -566,16 +566,11 @@ function overplotParalogs(annots, ideo) {
     }
   }
 
-  // console.log('neighborhoods')
-  // console.log(neighborhoods)
-
   // Big enough to see and hover
   const overlayAnnotLength = 15_000_000;
 
-
   const searchedGene = getSearchedFromDescriptions(ideo);
 
-  console.log('paralogs in neighborhood')
   const neighborhoodAnnots =
     Object.entries(neighborhoods).map(([chr, neighborhood], index) => {
       const start = parseInt(Object.keys(neighborhood)[0]);
@@ -631,8 +626,8 @@ function overplotParalogs(annots, ideo) {
     }).filter(n => n.paralogs.length > 1);
 
   if (neighborhoodAnnots.length > 0) {
-    console.log('neighborhoodAnnots')
-    console.log(neighborhoodAnnots.map(na => na));
+    // console.log('neighborhoodAnnots')
+    // console.log(neighborhoodAnnots.map(na => na));
     ideo.drawAnnots(neighborhoodAnnots, 'overlay', true, true);
     moveLegend();
   }

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -189,9 +189,6 @@ async function fetchInteractions(gene, ideo) {
     }
   }
 
-  // console.log('data')
-  // console.log(data)
-
   // For each interaction, get nodes immediately upstream and downstream.
   // Filter out pathway nodes that are definitely not gene symbols, then
   // group pathways by gene symbol. Each interacting gene can have
@@ -530,6 +527,7 @@ async function fetchParalogPositionsFromMyGeneInfo(
 }
 
 function overplotParalogs(annots, ideo) {
+  if (!ideo.config.showParalogNeighborhoods) return;
 
   if (annots.length < 2) return;
 
@@ -551,10 +549,6 @@ function overplotParalogs(annots, ideo) {
       for (let j = 0; j < starts.length; j++) {
         const startJInt = parseInt(starts[j]);
         if (Math.abs(start - startJInt) < windowInt) {
-          // console.log('neighborhoods[chr]')
-          // console.log(neighborhoods[chr])
-          // console.log('neighborhoods[chr][startJInt]')
-          // console.log(neighborhoods[chr][startJInt])
           neighborhoods[chr][startJInt].push(annot);
         } else {
           neighborhoods[chr][start] = [annot];
@@ -1155,11 +1149,9 @@ function getAnnotByName(annotName, ideo) {
       }
     });
   });
-  console.log('annotName', annotName)
-  console.log('annotByName', annotByName)
+
   if (annotByName === null) {
-    console.log('ideo.annotsOther', ideo.annotsOther)
-    annotByName = ideo.annotDescriptions.annots[annotName]
+    annotByName = ideo.annotDescriptions.annots[annotName];
   }
   return annotByName;
 }
@@ -1404,6 +1396,7 @@ function _initRelatedGenes(config, annotsInList) {
     annotsInList: annotsInList,
     showTools: true,
     showAnnotLabels: true,
+    showParalogNeighborhoods: true,
     chrFillColor: {centromere: '#DAAAAA'},
     relatedGenesMode: 'related'
   };
@@ -1511,6 +1504,7 @@ function _initGeneHints(config, annotsInList) {
     annotsInList: annotsInList,
     showTools: true,
     showAnnotLabels: true,
+    showParalogNeighborhoods: true,
     onDrawAnnots: plotGeneHints,
     annotationsPath: annotsPath,
     relatedGenesMode: 'hints'

--- a/test/online/related-genes.test.js
+++ b/test/online/related-genes.test.js
@@ -240,6 +240,34 @@ describe('Ideogram related genes kit', function() {
   //   const ideogram = Ideogram.initRelatedGenes(config);
   // });
 
+  it('handles gene with paralog neighborhoods', done => {
+
+    async function callback() {
+      const ideo = this;
+
+      await ideo.plotRelatedGenes('LPL');
+
+      const chr10ParalogNeighborhoods = ideo.annotsOther['9'].annots;
+      assert.equal(chr10ParalogNeighborhoods.length, 1);
+
+      done();
+    }
+
+    function onClickAnnot(annot) {
+      ideogram.plotRelatedGenes(annot.name);
+    }
+
+    var config = {
+      organism: 'Homo sapiens', // Also tests standard, non-slugged name
+      onLoad: callback,
+      dataDir: '/dist/data/bands/native/',
+      cacheDir: '/dist/data/cache/',
+      onClickAnnot
+    };
+
+    const ideogram = Ideogram.initRelatedGenes(config);
+  });
+
   it('handles gene with no interacting genes and no paralogs', done => {
 
     async function callback() {


### PR DESCRIPTION
This enables showing "paralog neighborhoods", paralogs near each other in the genome.  These are often otherwise hidden.

The related genes kit now groups paralogs that are within 2 mega-basepairs (2 Mbp) of each other, and displays them with an overlay annotation.  Clicking a paralog in the resulting tooltip searches it.

Here's how it looks:

https://user-images.githubusercontent.com/1334561/170846733-2aeb192a-7f73-445b-a28a-c8250774b198.mov

