### PR TITLE
Animate splicing gene transcripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1681,6 +1681,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz",
@@ -1777,6 +1786,64 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.16",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.16.tgz",
+      "integrity": "sha512-LCQ+NeThyJ4k1W2d+vIKdxuSt9R3pQSZ4P92m7EakaYuXcVWbHuT5bjNcqLd4Rdgi6xYWYDvBJZJLZSLanjDcA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2484,9 +2551,9 @@
       }
     },
     "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.14"
@@ -2890,14 +2957,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001279",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
-      "integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ==",
+      "version": "1.0.30001418",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001418.tgz",
+      "integrity": "sha512-oIs7+JL3K9JRQ3jPZjlH6qyYDp+nBTCais7hjh0s+fuBwufc7uZ7hPYMXrDOJhV360KGMTcczMRObk0/iMqZRg==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/caseless": {
       "version": "0.12.0",
@@ -3073,15 +3146,6 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
       "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
       "dev": true
-    },
-    "node_modules/colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -3466,14 +3530,14 @@
       }
     },
     "node_modules/d3-scale": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
-      "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
       "dependencies": {
         "d3-array": "^2.3.0",
         "d3-format": "1 - 2",
         "d3-interpolate": "1.2.0 - 2",
-        "d3-time": "1 - 2",
+        "d3-time": "^2.1.1",
         "d3-time-format": "2 - 3"
       }
     },
@@ -3483,9 +3547,12 @@
       "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA=="
     },
     "node_modules/d3-time": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.0.0.tgz",
-      "integrity": "sha512-2mvhstTFcMvwStWd9Tj3e6CEqtOivtD8AUiHT8ido/xmzrI9ijrUUihZ6nHuf/vsScRBonagOdj0Vv+SEL5G3Q=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "dependencies": {
+        "d3-array": "2"
+      }
     },
     "node_modules/d3-time-format": {
       "version": "3.0.0",
@@ -4773,9 +4840,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "dev": true,
       "funding": [
         {
@@ -4972,7 +5039,7 @@
     "node_modules/glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "integrity": "sha512-ab1S1g1EbO7YzauaJLkgLp7DZVAqj9M/dvKlTt8DkXA2tiOIcSMrlVI2J1RZyB5iJVccEscjGn+kpOG9788MHA==",
       "dev": true,
       "dependencies": {
         "glob-parent": "^2.0.0",
@@ -4985,7 +5052,7 @@
     "node_modules/glob-base/node_modules/glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "integrity": "sha512-JDYOvfxio/t42HKdxkAYaCiBN7oYiuxykOxKxdaUW5Qn0zaYN3gRQWolrwdnf0shM9/EP0ebuuTmyoXNr1cC5w==",
       "dev": true,
       "dependencies": {
         "is-glob": "^2.0.0"
@@ -5027,7 +5094,7 @@
     "node_modules/glob-stream": {
       "version": "5.3.5",
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
-      "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+      "integrity": "sha512-piN8XVAO2sNxwVLokL4PswgJvK/uQ6+awwXUVRTGF+rRfgCZpn4hOqxiRuTEbU/k3qgKl0DACYQ/0Sge54UMQg==",
       "dev": true,
       "dependencies": {
         "extend": "^3.0.0",
@@ -5046,7 +5113,7 @@
     "node_modules/glob-stream/node_modules/braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "integrity": "sha512-xU7bpz2ytJl1bH9cgIurjpg/n8Gohy9GTw81heDYLJQ4RU60dlyJsa+atVF2pI0yMMvKxI9HkKwjePCj5XI1hw==",
       "dev": true,
       "dependencies": {
         "expand-range": "^1.8.1",
@@ -5076,7 +5143,7 @@
     "node_modules/glob-stream/node_modules/glob-parent": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
       "dev": true,
       "dependencies": {
         "is-glob": "^3.1.0",
@@ -5116,7 +5183,7 @@
     "node_modules/glob-stream/node_modules/micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "integrity": "sha512-LnU2XFEk9xxSJ6rfgAry/ty5qwUTyHYOBU0g4R6tIw5ljwgGIBmiKhRWLw5NpMOnrgUNcDJ4WMp8rl3sYVHLNA==",
       "dev": true,
       "dependencies": {
         "arr-diff": "^2.0.0",
@@ -6309,15 +6376,15 @@
       }
     },
     "node_modules/karma": {
-      "version": "6.3.8",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.8.tgz",
-      "integrity": "sha512-10wBBU9S0lBHhbCNfmmbWQaY5C1bXlKdnvzN2QKThujCI/+DKaezrI08l6bfTlpJ92VsEboq3zYKpXwK6DOi3A==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.1.tgz",
+      "integrity": "sha512-Cj57NKOskK7wtFWSlMvZf459iX+kpYIPXmkNUzP2WAFcA7nhr/ALn5R7sw3w+1udFDcpMx/tuB8d5amgm3ijaA==",
       "dev": true,
       "dependencies": {
+        "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
         "braces": "^3.0.2",
         "chokidar": "^3.5.1",
-        "colors": "^1.4.0",
         "connect": "^3.7.0",
         "di": "^0.0.1",
         "dom-serialize": "^2.2.1",
@@ -6326,13 +6393,14 @@
         "http-proxy": "^1.18.1",
         "isbinaryfile": "^4.0.8",
         "lodash": "^4.17.21",
-        "log4js": "^6.3.0",
+        "log4js": "^6.4.1",
         "mime": "^2.5.2",
         "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.5",
         "qjobs": "^1.2.0",
         "range-parser": "^1.2.1",
         "rimraf": "^3.0.2",
-        "socket.io": "^4.2.0",
+        "socket.io": "^4.4.1",
         "source-map": "^0.6.1",
         "tmp": "^0.2.1",
         "ua-parser-js": "^0.7.30",
@@ -6961,10 +7029,13 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mkdirp": {
       "version": "0.5.5",
@@ -7216,9 +7287,9 @@
       "dev": true
     },
     "node_modules/node-forge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
-      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "dev": true,
       "engines": {
         "node": ">= 6.13.0"
@@ -7517,7 +7588,7 @@
     "node_modules/parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "integrity": "sha512-FC5TeK0AwXzq3tUBFtH74naWkPQCEWs4K+xMxWZBlKDWu0bVHXGZa+KKqxKidd7xwhdZ19ZNuF2uO1M/r196HA==",
       "dev": true,
       "dependencies": {
         "glob-base": "^0.3.0",
@@ -7632,9 +7703,9 @@
       }
     },
     "node_modules/pathval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -8243,9 +8314,9 @@
       "dev": true
     },
     "node_modules/semver-regex": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.3.tgz",
-      "integrity": "sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
+      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -8858,6 +8929,24 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
     },
+    "node_modules/terser": {
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
+      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/terser-webpack-plugin": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.5.tgz",
@@ -8892,20 +8981,6 @@
         }
       }
     },
-    "node_modules/terser-webpack-plugin/node_modules/acorn": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
-      "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
@@ -8933,38 +9008,16 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/terser-webpack-plugin/node_modules/terser": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",
-      "integrity": "sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==",
+    "node_modules/terser/node_modules/acorn": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
       "dev": true,
-      "dependencies": {
-        "commander": "^2.20.0",
-        "source-map": "~0.7.2",
-        "source-map-support": "~0.5.20"
-      },
       "bin": {
-        "terser": "bin/terser"
+        "acorn": "bin/acorn"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "acorn": "^8.5.0"
-      },
-      "peerDependenciesMeta": {
-        "acorn": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/terser/node_modules/source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
+        "node": ">=0.4.0"
       }
     },
     "node_modules/test-exclude": {
@@ -9323,7 +9376,7 @@
     "node_modules/vinyl-fs": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
-      "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+      "integrity": "sha512-lxMlQW/Wxk/pwhooY3Ut0Q11OH5ZvZfV0Gg1c306fBNWznQ6ZeQaCdE7XX0O/PpGSqgAsHMBxwFgcGxiYW3hZg==",
       "dev": true,
       "dependencies": {
         "duplexify": "^3.2.0",
@@ -11236,6 +11289,12 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true
+    },
     "@discoveryjs/json-ext": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz",
@@ -11313,6 +11372,55 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
+    },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true
+    },
+    "@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.16",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.16.tgz",
+      "integrity": "sha512-LCQ+NeThyJ4k1W2d+vIKdxuSt9R3pQSZ4P92m7EakaYuXcVWbHuT5bjNcqLd4Rdgi6xYWYDvBJZJLZSLanjDcA==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
+      }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -11925,9 +12033,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.14"
@@ -12250,9 +12358,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001279",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
-      "integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ==",
+      "version": "1.0.30001418",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001418.tgz",
+      "integrity": "sha512-oIs7+JL3K9JRQ3jPZjlH6qyYDp+nBTCais7hjh0s+fuBwufc7uZ7hPYMXrDOJhV360KGMTcczMRObk0/iMqZRg==",
       "dev": true
     },
     "caseless": {
@@ -12391,12 +12499,6 @@
       "version": "2.0.16",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
       "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
-      "dev": true
-    },
-    "colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true
     },
     "combined-stream": {
@@ -12724,14 +12826,14 @@
       }
     },
     "d3-scale": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
-      "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
       "requires": {
         "d3-array": "^2.3.0",
         "d3-format": "1 - 2",
         "d3-interpolate": "1.2.0 - 2",
-        "d3-time": "1 - 2",
+        "d3-time": "^2.1.1",
         "d3-time-format": "2 - 3"
       }
     },
@@ -12741,9 +12843,12 @@
       "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA=="
     },
     "d3-time": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.0.0.tgz",
-      "integrity": "sha512-2mvhstTFcMvwStWd9Tj3e6CEqtOivtD8AUiHT8ido/xmzrI9ijrUUihZ6nHuf/vsScRBonagOdj0Vv+SEL5G3Q=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "requires": {
+        "d3-array": "2"
+      }
     },
     "d3-time-format": {
       "version": "3.0.0",
@@ -13773,9 +13878,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "dev": true
     },
     "for-in": {
@@ -13913,7 +14018,7 @@
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "integrity": "sha512-ab1S1g1EbO7YzauaJLkgLp7DZVAqj9M/dvKlTt8DkXA2tiOIcSMrlVI2J1RZyB5iJVccEscjGn+kpOG9788MHA==",
       "dev": true,
       "requires": {
         "glob-parent": "^2.0.0",
@@ -13923,7 +14028,7 @@
         "glob-parent": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "integrity": "sha512-JDYOvfxio/t42HKdxkAYaCiBN7oYiuxykOxKxdaUW5Qn0zaYN3gRQWolrwdnf0shM9/EP0ebuuTmyoXNr1cC5w==",
           "dev": true,
           "requires": {
             "is-glob": "^2.0.0"
@@ -13958,7 +14063,7 @@
     "glob-stream": {
       "version": "5.3.5",
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
-      "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+      "integrity": "sha512-piN8XVAO2sNxwVLokL4PswgJvK/uQ6+awwXUVRTGF+rRfgCZpn4hOqxiRuTEbU/k3qgKl0DACYQ/0Sge54UMQg==",
       "dev": true,
       "requires": {
         "extend": "^3.0.0",
@@ -13974,7 +14079,7 @@
         "braces": {
           "version": "1.8.5",
           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "integrity": "sha512-xU7bpz2ytJl1bH9cgIurjpg/n8Gohy9GTw81heDYLJQ4RU60dlyJsa+atVF2pI0yMMvKxI9HkKwjePCj5XI1hw==",
           "dev": true,
           "requires": {
             "expand-range": "^1.8.1",
@@ -13998,7 +14103,7 @@
         "glob-parent": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
           "dev": true,
           "requires": {
             "is-glob": "^3.1.0",
@@ -14032,7 +14137,7 @@
         "micromatch": {
           "version": "2.3.11",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "integrity": "sha512-LnU2XFEk9xxSJ6rfgAry/ty5qwUTyHYOBU0g4R6tIw5ljwgGIBmiKhRWLw5NpMOnrgUNcDJ4WMp8rl3sYVHLNA==",
           "dev": true,
           "requires": {
             "arr-diff": "^2.0.0",
@@ -14935,15 +15040,15 @@
       }
     },
     "karma": {
-      "version": "6.3.8",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.8.tgz",
-      "integrity": "sha512-10wBBU9S0lBHhbCNfmmbWQaY5C1bXlKdnvzN2QKThujCI/+DKaezrI08l6bfTlpJ92VsEboq3zYKpXwK6DOi3A==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.1.tgz",
+      "integrity": "sha512-Cj57NKOskK7wtFWSlMvZf459iX+kpYIPXmkNUzP2WAFcA7nhr/ALn5R7sw3w+1udFDcpMx/tuB8d5amgm3ijaA==",
       "dev": true,
       "requires": {
+        "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
         "braces": "^3.0.2",
         "chokidar": "^3.5.1",
-        "colors": "^1.4.0",
         "connect": "^3.7.0",
         "di": "^0.0.1",
         "dom-serialize": "^2.2.1",
@@ -14952,13 +15057,14 @@
         "http-proxy": "^1.18.1",
         "isbinaryfile": "^4.0.8",
         "lodash": "^4.17.21",
-        "log4js": "^6.3.0",
+        "log4js": "^6.4.1",
         "mime": "^2.5.2",
         "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.5",
         "qjobs": "^1.2.0",
         "range-parser": "^1.2.1",
         "rimraf": "^3.0.2",
-        "socket.io": "^4.2.0",
+        "socket.io": "^4.4.1",
         "source-map": "^0.6.1",
         "tmp": "^0.2.1",
         "ua-parser-js": "^0.7.30",
@@ -15448,9 +15554,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
       "dev": true
     },
     "mkdirp": {
@@ -15631,9 +15737,9 @@
       "dev": true
     },
     "node-forge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
-      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "dev": true
     },
     "node-releases": {
@@ -15856,7 +15962,7 @@
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "integrity": "sha512-FC5TeK0AwXzq3tUBFtH74naWkPQCEWs4K+xMxWZBlKDWu0bVHXGZa+KKqxKidd7xwhdZ19ZNuF2uO1M/r196HA==",
       "dev": true,
       "requires": {
         "glob-base": "^0.3.0",
@@ -15943,9 +16049,9 @@
       "dev": true
     },
     "pathval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true
     },
     "performance-now": {
@@ -16414,9 +16520,9 @@
       "dev": true
     },
     "semver-regex": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.3.tgz",
-      "integrity": "sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
+      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
       "dev": true
     },
     "send": {
@@ -16923,6 +17029,26 @@
         }
       }
     },
+    "terser": {
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
+      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.8.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+          "dev": true
+        }
+      }
+    },
     "terser-webpack-plugin": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.5.tgz",
@@ -16936,14 +17062,6 @@
         "terser": "^5.7.2"
       },
       "dependencies": {
-        "acorn": {
-          "version": "8.6.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
-          "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
         "schema-utils": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
@@ -16960,25 +17078,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
-        },
-        "terser": {
-          "version": "5.10.0",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",
-          "integrity": "sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==",
-          "dev": true,
-          "requires": {
-            "commander": "^2.20.0",
-            "source-map": "~0.7.2",
-            "source-map-support": "~0.5.20"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.7.3",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-              "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-              "dev": true
-            }
-          }
         }
       }
     },
@@ -17255,7 +17354,7 @@
     "vinyl-fs": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
-      "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+      "integrity": "sha512-lxMlQW/Wxk/pwhooY3Ut0Q11OH5ZvZfV0Gg1c306fBNWznQ6ZeQaCdE7XX0O/PpGSqgAsHMBxwFgcGxiYW3hZg==",
       "dev": true,
       "requires": {
         "duplexify": "^3.2.0",

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -260,7 +260,6 @@ function addSubpartHoverListener(subpartDOM, ideo) {
   // On hovering over subpart, highlight it and show details
   subpart.addEventListener('mouseenter', event => {
     removeHighlights();
-
     // Highlight hovered subpart, adding an aura around it
     event.target.classList.add('_ideoHoveredSubpart');
 
@@ -478,13 +477,16 @@ function toggleSplice(ideo) {
       const nameDOM =
         document.querySelector('._ideoGeneStructureContainerName');
       const toggleDOM = document.querySelector('._ideoSpliceToggle');
-      [nameDOM, toggleDOM].forEach(el => el.classList.remove('pre-mRNA'));
-      if (!spliceExons) {
-        [nameDOM, toggleDOM].forEach(el => el.classList.add('pre-mRNA'));
+
+      if (nameDOM && toggleDOM) {
+        [nameDOM, toggleDOM].forEach(el => el.classList.remove('pre-mRNA'));
+        if (!spliceExons) {
+          [nameDOM, toggleDOM].forEach(el => el.classList.add('pre-mRNA'));
+        }
+        const {title, name} = getSpliceStateText(spliceExons);
+        nameDOM.textContent = name;
+        nameDOM.title = title;
       }
-      const {title, name} = getSpliceStateText(spliceExons);
-      nameDOM.textContent = name;
-      nameDOM.title = title;
     });
 }
 

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -404,20 +404,23 @@ function getSpliceStateText(spliceExons) {
   return {title, name};
 }
 
+
 /** Draw introns in initial splice toggle from mRNA to pre-mRNA */
-function drawIntrons(prelimSubparts) {
+function drawIntrons(prelimSubparts, matureSubparts) {
+  // Hypothetical example data, in shorthand
+  // pres = [u5_1, e1, i1, e2, i2, e3, i3, e4, i4, e5, i5, e6, u3_1]
+  // mats = [u5_1, e1, e2, e3, e4, e5, e6, u3_1]
+
   let numInserted = 0;
   const subpartEls = document.querySelectorAll('.subpart');
-  document.querySelectorAll('.subpart').forEach((subpartEl, i) => {
-    if (i >= prelimSubparts.length - 1) return;
-    const nextPos = prelimSubparts[i + 1];
-    if (nextPos[0] === 'intron') {
-      // const posAttrs = `x="${nextPos.x}" width="${nextPos.width}"`;
+  prelimSubparts.forEach((prelimSubpart, i) => {
+    const matureIndex = i - numInserted;
+    const matureSubpart = matureSubparts[matureIndex];
+    if (matureSubpart[0] !== prelimSubpart[0]) {
       const otherAttrs = 'y="15" height="20" fill="#FFFFFF00"';
       const intronRect =
-        // `<rect class="subpart intron" ${posAttrs} ${otherAttrs} />`;
         `<rect class="subpart intron" ${otherAttrs} />`;
-      subpartEls[i - numInserted].insertAdjacentHTML('afterend', intronRect);
+      subpartEls[matureIndex].insertAdjacentHTML('beforebegin', intronRect);
       numInserted += 1;
     }
   });
@@ -433,7 +436,7 @@ function toggleSplice(ideo) {
 
   const addedIntrons = document.querySelectorAll('.intron').length > 0;
   if (!spliceExons && !addedIntrons) {
-    drawIntrons(prelimSubparts);
+    drawIntrons(prelimSubparts, matureSubparts);
   } else {
     document.querySelectorAll('.intron').forEach(el => el.remove());
   }

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -22,6 +22,40 @@ const lineColors = {
   "3'-UTR": '#90C0B9'
 };
 
+const css =
+  `<style>
+  ._ideoGeneStructureContainerName {
+    margin-left: 81px;
+  }
+  ._ideoGeneStructureContainerName.pre-mRNA {
+    margin-left: 69px;
+  }
+  ._ideoGeneStructureContainer rect:hover + line {
+    visibility: hidden;
+  }
+  ._ideoGeneStructureContainer {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+  }
+  ._ideoGeneStructureContainer:hover ._ideoSpliceToggle {
+    visibility: visible;
+  }
+  ._ideoGeneStructureContainer ._ideoSpliceToggle {
+    visibility: hidden;
+  }
+  ._ideoSpliceToggle {
+    margin-left: 53px; background-color: #EEE;
+  }
+  ._ideoSpliceToggle.pre-mRNA {
+    margin-left: 43px; background-color: #F8F8F8;
+  }
+  ._ideoHoveredSubpart {
+    stroke: #D0D0DD !important; stroke-width: 3px;
+  }
+  </style>`;
+
 
 function toggleSpliceByKeyboard(event) {
   if (event.key === 's') {
@@ -414,12 +448,15 @@ function toggleSplice(ideo) {
     .attr('width', (d, i) => subparts[i][3].width)
     .on('end', (d, i) => {
       if (i !== subparts.length - 1) return;
+
+      // Restore subpart boundary lines
       document.querySelectorAll('.subpart').forEach((subpartDOM, i) => {
         const subpart = subparts[i];
         const line = getSubpartBorderLine(subpart);
         subpartDOM.insertAdjacentHTML('afterend', line);
       });
 
+      // Update title for gene structure diagram
       const nameDOM =
         document.querySelector('._ideoGeneStructureContainerName');
       const toggleDOM = document.querySelector('._ideoSpliceToggle');
@@ -638,38 +675,7 @@ export function getGeneStructureHtml(annot, ideo, isParalogNeighborhood) {
       const spanAttrs = `${spanClass} title="${title}"`;
       geneStructureHtml =
         '<br/><br/>' +
-        '<style>' +
-          '._ideoGeneStructureContainerName {' +
-            'margin-left: 81px;' +
-          '}' +
-          '._ideoGeneStructureContainerName.pre-mRNA {' +
-            'margin-left: 69px;' +
-          '}' +
-          '._ideoGeneStructureContainer rect:hover + line {' +
-            'visibility: hidden;' +
-          '}' +
-          '._ideoGeneStructureContainer {' +
-            'display: flex;' +
-            'justify-content: center;' +
-            'align-items: center;' +
-            'flex-direction: column;' +
-          '}' +
-          '._ideoGeneStructureContainer:hover ._ideoSpliceToggle {' +
-            'visibility: visible;' +
-          '} ' +
-          '._ideoGeneStructureContainer ._ideoSpliceToggle {' +
-            'visibility: hidden;' +
-          '}' +
-          '._ideoSpliceToggle {' +
-            'margin-left: 53px; background-color: #EEE;' +
-          '}' +
-          '._ideoSpliceToggle.pre-mRNA {' +
-            'margin-left: 43px; background-color: #F8F8F8;' +
-          '}' +
-          '._ideoHoveredSubpart {' +
-            'stroke: #D0D0DD !important; stroke-width: 3px;' +
-          '}' +
-          '</style>' +
+        css +
         `<div ${cls}>` +
         `<div><span ${spanAttrs}>${name}</span>${toggle}</div>` +
         `${geneStructureSvg}` +

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -1,5 +1,28 @@
 import {d3} from '../lib';
 
+const y = 15;
+
+const heights = {
+  "5'-UTR": 20,
+  'exon': 20,
+  'intron': 20,
+  "3'-UTR": 20
+};
+
+const colors = {
+  "5'-UTR": '#155069',
+  'exon': '#DAA521',
+  "intron": '#FFFFFF00',
+  "3'-UTR": '#357089'
+};
+
+const lineColors = {
+  "5'-UTR": '#70A099',
+  'exon': '#BA8501',
+  "3'-UTR": '#90C0B9'
+};
+
+
 function toggleSpliceByKeyboard(event) {
   if (event.key === 's') {
     const spliceToggle = document.querySelector('._ideoSpliceToggle input');
@@ -380,6 +403,7 @@ function toggleSplice(ideo) {
   } else {
     document.querySelectorAll('.intron').forEach(el => el.remove());
   }
+  document.querySelectorAll('.subpart-line').forEach(el => el.remove());
 
   const subparts = spliceExons ? matureSubparts : prelimSubparts;
 
@@ -390,7 +414,11 @@ function toggleSplice(ideo) {
     .attr('width', (d, i) => subparts[i][3].width)
     .on('end', (d, i) => {
       if (i !== subparts.length - 1) return;
-      // document.querySelector('._ideoGeneStructure').innerHTML = svg;
+      document.querySelectorAll('.subpart').forEach((subpartDOM, i) => {
+        const subpart = subparts[i];
+        const line = getSubpartBorderLine(subpart);
+        subpartDOM.insertAdjacentHTML('afterend', line);
+      });
 
       const nameDOM =
         document.querySelector('._ideoGeneStructureContainerName');
@@ -429,7 +457,15 @@ function addPositions(subparts) {
 }
 
 function getSubpartBorderLine(subpart) {
-
+  const subpartType = subpart[0];
+  // Define subpart border
+  const x = subpart[3].x;
+  const height = heights[subpartType];
+  const lineHeight = y + height;
+  const lineStroke = `stroke="${lineColors[subpartType]}"`;
+  const lineAttrs = // "";
+    `x1="${x}" x2="${x}" y1="${y}" y2="${lineHeight}" ${lineStroke}`;
+  return `<line class="subpart-line" ${lineAttrs} />`;
 }
 
 function getGeneStructureSvg(gene, ideo, spliceExons=false) {
@@ -466,29 +502,8 @@ function getGeneStructureSvg(gene, ideo, spliceExons=false) {
 
   const featureLengthPx = 250;
 
-  const y = 15;
   const intronHeight = 1;
   const intronColor = 'black';
-  const heights = {
-    "5'-UTR": 20,
-    'exon': 20,
-    'intron': 20,
-    "3'-UTR": 20
-  };
-
-  const colors = {
-    "5'-UTR": '#155069',
-    'exon': '#DAA521',
-    "intron": '#FFFFFF00',
-    "3'-UTR": '#357089',
-  };
-
-  const lineColors = {
-    "5'-UTR": '#70A099',
-    'exon': '#BA8501',
-    "3'-UTR": '#90C0B9'
-  };
-
   const geneStructureArray = [];
 
   const intronPosAttrs =
@@ -504,19 +519,19 @@ function getGeneStructureSvg(gene, ideo, spliceExons=false) {
     'exon': 0,
     'intron': 0,
     "3'-UTR": 0
-  }
+  };
   const totalBySubpart = {
     "5'-UTR": 0,
     'exon': 0,
     'intron': 0,
     "3'-UTR": 0
-  }
+  };
   const classes = {
     "5'-UTR": 'five-prime-utr',
     'exon': 'exon',
     "3'-UTR": 'three-prime-utr',
     'intron': 'intron'
-  }
+  };
 
   // Subtle visual delimiter; separates horizontally adjacent fields in UI
   const pipe = `<span style='color: #CCC'>|</span>`;
@@ -551,11 +566,8 @@ function getGeneStructureSvg(gene, ideo, spliceExons=false) {
     if (subpartType in colors) {
       color = colors[subpartType];
     }
-    let height = intronHeight;
-    // const y = subpartType === 'exon' ? 0 : 2.5;
-    if (subpartType in heights) {
-      height = heights[subpartType];
-    }
+
+    const height = heights[subpartType];
 
     // Define subpart position, tooltip footer
     const lengthBp = subpart[2];
@@ -577,15 +589,9 @@ function getGeneStructureSvg(gene, ideo, spliceExons=false) {
       data = `data-subpart="${html}"`;
     }
 
-    // Define subpart border
-    const lineHeight = y + height;
-    const lineStroke = `stroke="${lineColors[subpartType]}"`;
-    const lineAttrs = // "";
-      `x1="${x}" x2="${x}" y1="${y}" y2="${lineHeight}" ${lineStroke}`;
-
     const subpartSvg = (
       `<rect ${cls} rx="1.5" fill="${color}" ${pos} ${data}/>` +
-      `<line ${lineAttrs} />`
+      getSubpartBorderLine(subpart)
     );
     geneStructureArray.push(subpartSvg);
   }

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -438,7 +438,7 @@ function drawIntrons(prelimSubparts, matureSubparts, ideo) {
 
   document.querySelectorAll('.intron').forEach(subpartDOM => {
     addSubpartHoverListener(subpartDOM, ideo);
-  })
+  });
 }
 
 function toggleSplice(ideo) {
@@ -532,7 +532,7 @@ function getGeneStructureSvg(gene, ideo, spliceExons=false) {
     'geneStructureCache' in ideo === false ||
     gene in ideo.geneStructureCache === false
   ) {
-    return null;
+    return [null];
   }
 
   const geneStructure = ideo.geneStructureCache[gene];

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -1438,7 +1438,7 @@ function setRelatedDecorPad(kitConfig) {
   return kitConfig;
 }
 
-let kitDefaults = {
+const globalKitDefaults = {
   chrWidth: 9,
   chrHeight: 100,
   chrLabelSize: 12,
@@ -1500,12 +1500,12 @@ function _initRelatedGenes(config, annotsInList) {
     delete config.relatedGenesMode;
   };
 
-  kitDefaults = Object.assign(kitDefaults, {
+  const kitDefaults = Object.assign({
     showParalogNeighborhoods: isHuman,
     relatedGenesMode: 'related',
     useCache: true,
     awaitCache: true
-  });
+  }, globalKitDefaults);
 
   return initSearchIdeogram(kitDefaults, config, annotsInList);
 }
@@ -1526,14 +1526,14 @@ function _initGeneHints(config, annotsInList) {
 
   config.legend = citedLegend;
 
-  kitDefaults = Object.assign(kitDefaults, {
+  const kitDefaults = Object.assign({
     relatedGenesMode: 'hints',
     chrMargin: -4,
     annotationsPath: getDir('cache/homo-sapiens-top-genes.tsv'),
     // annotationsPath: getDir('annotations/gene_leads.tsv'),
     onDrawAnnots: plotGeneHints,
     useCache: true
-  });
+  }, globalKitDefaults);
 
   return initSearchIdeogram(kitDefaults, config, annotsInList);
 }
@@ -1554,14 +1554,14 @@ function _initGeneHints(config, annotsInList) {
 
   config.legend = citedLegend;
 
-  kitDefaults = Object.assign(kitDefaults, {
+  const kitDefaults = Object.assign({
     relatedGenesMode: 'leads',
     chrMargin: -4,
     // annotationsPath: getDir('cache/homo-sapiens-top-genes.tsv'),
     annotationsPath: getDir('annotations/gene_leads.tsv'),
     onDrawAnnots: plotGeneHints,
     useCache: true
-  });
+  }, globalKitDefaults);
 
   return initSearchIdeogram(kitDefaults, config, annotsInList);
 }

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -275,32 +275,32 @@ function parseNameAndEnsemblIdFromMgiGene(gene) {
   return {name, ensemblId};
 }
 
-/**
- * Summarizes genes in a pathway
- *
- * This comprises most of the content for tooltips for pathway genes.
- */
- function describePathwayGene(pathwayGene, searchedGene, pathway, summary) {
-  let ixnsDescription = '';
+// /**
+//  * Summarizes genes in a pathway
+//  *
+//  * This comprises most of the content for tooltips for pathway genes.
+//  */
+//  function describePathwayGene(pathwayGene, searchedGene, pathway, summary) {
+//   let ixnsDescription = '';
 
-  const pathwaysBase = 'https://www.wikipathways.org/index.php/Pathway:';
-  const url = `${pathwaysBase}${pathway.id}`;
-  const attrs =
-    `href="${url}" ` +
-    `target="_blank" ` +
-    `title="See pathway diagram in WikiPathways"`;
-  ixnsDescription =
-    `${summary} ${searchedGene.name} in:</br/>` +
-    `<a ${attrs}>${pathway.name}</a>`;
+//   const pathwaysBase = 'https://www.wikipathways.org/index.php/Pathway:';
+//   const url = `${pathwaysBase}${pathway.id}`;
+//   const attrs =
+//     `href="${url}" ` +
+//     `target="_blank" ` +
+//     `title="See pathway diagram in WikiPathways"`;
+//   ixnsDescription =
+//     `${summary} ${searchedGene.name} in:</br/>` +
+//     `<a ${attrs}>${pathway.name}</a>`;
 
-  const {name, ensemblId} = parseNameAndEnsemblIdFromMgiGene(pathwayGene);
-  const type = 'pathway gene';
-  const descriptionObj = {
-    description: ixnsDescription,
-    ixnsDescription, ensemblId, name, type
-  };
-  return descriptionObj;
-}
+//   const {name, ensemblId} = parseNameAndEnsemblIdFromMgiGene(pathwayGene);
+//   const type = 'pathway gene';
+//   const descriptionObj = {
+//     description: ixnsDescription,
+//     ixnsDescription, ensemblId, name, type
+//   };
+//   return descriptionObj;
+// }
 
 /**
  * Summarizes interactions for a gene
@@ -1013,20 +1013,20 @@ function adjustPlaceAndVisibility(ideo) {
   }
 }
 
-function sortByPathwayIxn(a, b) {
-  const aColor = a.color;
-  const bColor = b.color;
+// function sortByPathwayIxn(a, b) {
+//   const aColor = a.color;
+//   const bColor = b.color;
 
-  // Rank red (searched gene) highest
-  if (aColor === 'red') return -1;
-  if (bColor === 'red') return 1;
+//   // Rank red (searched gene) highest
+//   if (aColor === 'red') return -1;
+//   if (bColor === 'red') return 1;
 
-  // Rank not grey above grey
-  if (aColor === 'grey' && bColor !== 'grey') return 1;
-  if (bColor === 'grey' && aColor !== 'grey') return -1;
+//   // Rank not grey above grey
+//   if (aColor === 'grey' && bColor !== 'grey') return 1;
+//   if (bColor === 'grey' && aColor !== 'grey') return -1;
 
-  return a.rank - b.rank;
-}
+//   return a.rank - b.rank;
+// }
 
 // async function fetchPathwayGeneAnnots(searchedGene, pathway, ideo) {
 //   const annots = [];

--- a/test/offline/gene-structure.test.js
+++ b/test/offline/gene-structure.test.js
@@ -47,8 +47,6 @@ describe('Ideogram gene structure functionality', function() {
 
   it('supports mouse-highlighting and keyboard-navigating subparts', done => {
     async function callback() {
-      console.log('this.onDrawAnnots')
-      console.log(this.onDrawAnnots)
 
       // Positive-stranded gene
       await ideogram.plotRelatedGenes('APOE');
@@ -129,20 +127,17 @@ describe('Ideogram gene structure functionality', function() {
     async function callback() {
       await ideogram.plotRelatedGenes('APOE');
       setTimeout(async function() {
-        const apoelLabel = document.querySelector('#ideogramLabel__c18_a1');
-        apoelLabel.dispatchEvent(new Event('mouseover'));
+        const apoeLabel = document.querySelector('#ideogramLabel__c18_a1');
+        apoeLabel.dispatchEvent(new Event('mouseover'));
 
         // Press "s" key, to toggle exon splicing
         const sKeydown = new KeyboardEvent('keydown', {key: 's'});
         document.dispatchEvent(sKeydown);
         const subparts = document.querySelectorAll('rect.subpart');
         assert.equal(subparts.length, 10); // includes introns
+
         done();
       }, 500);
-    }
-
-    function onClickAnnot(annot) {
-      ideogram.plotRelatedGenes(annot.name);
     }
 
     var config = {
@@ -150,7 +145,6 @@ describe('Ideogram gene structure functionality', function() {
       onLoad: callback,
       dataDir: '/dist/data/bands/native/',
       cacheDir: '/dist/data/cache/',
-      onClickAnnot,
       showGeneStructureInTooltip: true,
       showParalogNeighborhoods: true
     };

--- a/test/offline/gene-structure.test.js
+++ b/test/offline/gene-structure.test.js
@@ -47,6 +47,8 @@ describe('Ideogram gene structure functionality', function() {
 
   it('supports mouse-highlighting and keyboard-navigating subparts', done => {
     async function callback() {
+      console.log('this.onDrawAnnots')
+      console.log(this.onDrawAnnots)
 
       // Positive-stranded gene
       await ideogram.plotRelatedGenes('APOE');

--- a/test/online/related-genes.test.js
+++ b/test/online/related-genes.test.js
@@ -11,7 +11,6 @@ describe('Ideogram related genes kit', function() {
   d3 = Ideogram.d3;
 
   beforeEach(function() {
-
     delete window.chrBands;
     d3.selectAll('div').remove();
   });
@@ -27,7 +26,7 @@ describe('Ideogram related genes kit', function() {
     async function callback() {
       const ideo = this;
 
-      await ideogram.plotRelatedGenes('BRCA2');
+      await ideo.plotRelatedGenes('BRCA2');
 
       const related = ideo.getRelatedGenesByType();
 
@@ -36,23 +35,17 @@ describe('Ideogram related genes kit', function() {
 
       assert.isAtLeast(numInteractingGenes, 1);
       assert.equal(numParalogs, 0);
-
       done();
     }
 
-    function onClickAnnot(annot) {
-      ideogram.plotRelatedGenes(annot.name);
-    }
-
-    var config = {
+    const config = {
       organism: 'Homo sapiens',
       onLoad: callback,
       dataDir: '/dist/data/bands/native/',
-      cacheDir: '/dist/data/cache/',
-      onClickAnnot
+      cacheDir: '/dist/data/cache/'
     };
 
-    const ideogram = Ideogram.initRelatedGenes(config);
+    Ideogram.initRelatedGenes(config);
   });
 
   it('handles searched gene, click, font, interaction summaries', done => {
@@ -366,7 +359,7 @@ describe('Ideogram related genes kit', function() {
 
   it('handles default display of highly cited genes', done => {
 
-    async function callback() {
+    function callback() {
       const ideo = this;
 
       const annots = ideo.flattenAnnots();
@@ -377,14 +370,10 @@ describe('Ideogram related genes kit', function() {
       done();
     }
 
-    function onClickAnnot(annot) {
-      ideogram.plotRelatedGenes(annot.name);
-    }
-
     const annotsPath =
       '/dist/data/cache/homo-sapiens-top-genes.tsv';
 
-    var config = {
+    const config = {
       organism: 'Homo sapiens',
       chrWidth: 8,
       chrHeight: 90,
@@ -392,11 +381,10 @@ describe('Ideogram related genes kit', function() {
       annotationHeight: 5,
       onDrawAnnots: callback,
       dataDir: '/dist/data/bands/native/',
-      annotationsPath: annotsPath,
-      onClickAnnot
+      annotationsPath: annotsPath
     };
 
-    const ideogram = Ideogram.initGeneHints(config);
+    Ideogram.initGeneHints(config);
   });
 
 });


### PR DESCRIPTION
This splices transcripts _smoothly_, letting users track where exons, introns and UTRs end up, and their relative size change.

By having a brief, gradual change rather than an instant change, users can often visually follow how the location and proportional length of individual transcript subparts evolve between spliced and unspliced states.  This extends previous work in #313 and #318.

This genomic animation technique might be adapted for future gene-scoped features.

Here's how it looks:


https://user-images.githubusercontent.com/1334561/195850058-52785718-4a1d-4fe1-b2bf-7b331f1371d9.mp4



