### PR TITLE
Fix CDS size when on same exon as 3'-UTR

### DIFF
--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -370,7 +370,7 @@ function spliceOut(subparts) {
     // e.g. 5'-UTRs of OXTR
     const isOtherOverlap = i > 0 && start === prevRawStart;
 
-    // e.g. 3'-UTR of CD44
+    // e.g. 3'-UTR of LDLR, or 3'-UTR of CD44
     const isOther3UTROverlap = i > 0 && start <= prevRawStart + prevRawLength;
 
     let splicedStart;

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -362,13 +362,25 @@ function spliceOut(subparts) {
     const subpart = subparts[i];
     const [subpartType, start, length] = subpart;
     const isSpliceOverlap = start === prevStart;
-    const isOtherOverlap = i > 0 && start === subparts[i - 1][1];
+    let prevRawStart, prevRawLength;
+    if (i > 0) {
+      [, prevRawStart, prevRawLength] = subparts[i - 1];
+    }
+
+    // e.g. 5'-UTRs of OXTR
+    const isOtherOverlap = i > 0 && start === prevRawStart;
+
+    // e.g. 3'-UTR of CD44
+    const isOther3UTROverlap = i > 0 && start <= prevRawStart + prevRawLength;
+
     let splicedStart;
     if (isSpliceOverlap) {
       splicedStart = start;
     } else if (isOtherOverlap) {
       // e.g. 5'-UTRs of OXTR
       splicedStart = prevStart;
+    } else if (isOther3UTROverlap) {
+      splicedStart = prevStart + prevRawLength - length;
     } else {
       splicedStart = prevEnd;
     }

--- a/test/offline/gene-structure.test.js
+++ b/test/offline/gene-structure.test.js
@@ -136,6 +136,25 @@ describe('Ideogram gene structure functionality', function() {
         const subparts = document.querySelectorAll('rect.subpart');
         assert.equal(subparts.length, 10); // includes introns
 
+        setTimeout(async function() {
+          // The last exon of gene LDLR includes both CDS and 3'-UTR
+          // There was a bug (see commit 7a43ba0) that caused drastically
+          // longer apparent CDS in these cases, whereas correct display
+          // has a relatively very small CDS compared to 3'-UTR.
+          const ldlrLabel = document.querySelector('#ideogramLabel__c18_a0');
+          ldlrLabel.dispatchEvent(new Event('mouseover'));
+
+          const lastExon = subparts[18];
+          const threePrimeUtr = subparts[19];
+
+          assert.equal(Math.round(lastExon.x.baseVal.value), 127);
+          assert.equal(Math.round(lastExon.width.baseVal.value), 123);
+
+          assert.equal(Math.round(threePrimeUtr.x.baseVal.value), 129);
+          assert.equal(Math.round(threePrimeUtr.width.baseVal.value), 121);
+
+        }, 500);
+
         done();
       }, 500);
     }


### PR DESCRIPTION
This fixes a bug where some coding sequences (CDS) appeared much too long.  This happened when a CDS (yellow part) and 3'-UTR (teal part at right) were on the same exon.  It affected mature mRNA diagrams for LDLR, CD44, and many other genes.

Here's how e.g. LDLR looks now:

<img width="371" alt="LDLR_three_prime_UTR_and_CDS_fix__2022-11-05" src="https://user-images.githubusercontent.com/1334561/200123365-d115bad2-2ea6-4ce9-8e20-4e110c7e6342.png">

Confirming the fix by comparing to a reference is difficult.  That's because while there are many [gene structure diagrams that show mature mRNA for _hypothetical_ genes](https://www.google.com/search?q=spliced+exon+utr&tbm=isch), there are few _concrete examples_.  One plausible product-level conclusion about this state of the art is that these diagrams in Ideogram are novel (given few concrete examples) and scientifically insightful (given many hypothetical examples).

Fortunately, there is something of a reference concrete example of such diagrams for LDLR:

<img width="651" alt="LDLR_gene_structure_diagram_reference__Gabcova-Balaziova_et_al_2015__Ideogram_2022-11-05" src="https://user-images.githubusercontent.com/1334561/200125294-4abe095f-c1ba-4717-bd91-6cd7e791b8a9.png">

_[Source](https://www.researchgate.net/figure/Structure-of-LDL-receptor-A-schematic-representation-of-the-human-LDLR-gene-exons-are_fig1_280694654): Figure 1 in Gabcova-Balaziova D, Stanikova D, Vohnout B, Huckova M, Stanik J, Klimes I, Raslova K, Gasperikova D. Molecular-genetic aspects of familial hypercholesterolemia. Endocr Regul. 2015 Jul;49(3):164-81. doi: 10.4149/endo_2015_03_164. PMID: 26238499._

Note how the 3'-UTR is roughly the same size as (really, a bit shorter than) the CDS in the reference.  It is now the same in Ideogram mRNA diagram as well.  Before, the CDS was about 50% larger than the 3'-UTR.  This was clear when comparing against a reference, but basically unnoticeable without one.