### PR TITLE
Refine object constancy, handling of unfound genes, subpart hover text

### DIFF
--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -287,8 +287,14 @@
     }
 
     function displayError(error) {
-      document.querySelector('#ideogram-container').innerHTML =
-          `<div style="color:red; text-align: center;">${error}</div>`;
+      const container = document.querySelector('#ideogram-container');
+      container.style.visibility = 'hidden';
+      container.insertAdjacentHTML(
+        'beforeBegin',
+        `<div id="ideogram-error" style="color:red; text-align: center;">
+          ${error}
+        </div>`
+      );
     }
 
     // Process text input for the "Search" field.
@@ -303,6 +309,8 @@
       try {
         await ideogram.plotRelatedGenes(urlParams.q);
         document.querySelector('#ideogram-container').style.visibility = '';
+        const errorElement = document.querySelector('#ideogram-error');
+        if (errorElement) errorElement.remove();
       } catch(error) {
         displayError(error);
       }
@@ -313,6 +321,8 @@
         if ('q' in urlParams) {
           await ideogram.plotRelatedGenes(urlParams['q']);
           document.querySelector('#ideogram-container').style.visibility = '';
+          const errorElement = document.querySelector('#ideogram-error');
+          if (errorElement) errorElement.remove();
         } else {
           await ideogram.plotRelatedGenes();
         }

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -10,44 +10,22 @@
     a:hover {text-decoration: underline;}
     a, a:hover, a:visited, a:active {color: #0366d6;}
 
-    select, optgroup, option {
-      float: left;
-      font-size: 14px;
-    }
+    select, optgroup, option {float: left; font-size: 14px;}
 
     #ideogram-container {z-index: -1}
 
     #search-container {
-      height: 26px;
-      float: left;
-      position: relative;
-      top: -4px;
-      margin-left: 10px;
+      height: 26px; float: left; position: relative; top: -4px; margin-left: 10px;
     }
 
     #search-genes {
-      padding-left: 3px;
-      width: 200px;
-      height: 20px;
-      font-size: 14px;
-      border-radius: 3px;
-      border: 1px solid #888;
+      padding-left: 3px; width: 200px; height: 20px; font-size: 14px; border-radius: 3px; border: 1px solid #888;
     }
 
     #search-button {
-      height: 23px;
-      width: 23px;
-      font-size: 24px;
-      background: #58F;
-      color: #FFF;
-      display: inline-block;
-      position: relative;
-      top: 2px;
-      left: -25px;
-      border-radius: 3px;
-      text-align: center;
-      padding-top: 1px;
-      cursor: pointer;
+      height: 23px; width: 23px; font-size: 24px; background: #58F; color: #FFF; display: inline-block;
+      position: relative; top: 2px; left: -25px; padding-top: 1px;
+      border-radius: 3px; text-align: center; cursor: pointer;
     }
 
     ._ideogramTooltip th, ._ideogramTooltip td {

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -267,6 +267,9 @@
     function displayError(error) {
       const container = document.querySelector('#ideogram-container');
       container.style.visibility = 'hidden';
+
+      const errorElement = document.querySelector('#ideogram-error');
+      if (errorElement) errorElement.remove();
       container.insertAdjacentHTML(
         'beforeBegin',
         `<div id="ideogram-error" style="color:red; text-align: center;">

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -473,6 +473,7 @@ function toggleSplice(ideo) {
   d3.select('._ideoGeneStructure').selectAll('.subpart')
     .data(subparts)
     .transition()
+    .duration(750)
     .attr('x', (d, i) => subparts[i][3].x)
     .attr('width', (d, i) => subparts[i][3].width)
     .on('end', (d, i) => {

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -684,9 +684,9 @@ function getGeneStructureSvg(gene, ideo, spliceExons=false) {
 
   const footerData =
     `<br/>Transcript name: ${geneStructure.transcriptName}<br/>` + [
-      `Exons: ${totalBySubpart['exon']}`,
-      `Biotype: ${geneStructure.biotype.replace(/_/g, ' ')}`,
-      `Strand: ${strand}`
+      `${totalBySubpart['exon']} exons`,
+      `${geneStructure.biotype.replace(/_/g, ' ')}`,
+      `${strand} strand`
     ].join(` ${pipe} `);
   const geneStructureSvg =
     `<svg class="_ideoGeneStructure" ` +

--- a/test/offline/gene-structure.test.js
+++ b/test/offline/gene-structure.test.js
@@ -75,7 +75,7 @@ describe('Ideogram gene structure functionality', function() {
           exonText2,
           'Exon 2 of 4 | 66 bp' +
           'Transcript name: APOE-201' +
-          'Exons: 4 | Biotype: protein coding | Strand: +'
+          '4 exons | protein coding | + strand'
         );
 
         // Negative-stranded gene
@@ -100,7 +100,7 @@ describe('Ideogram gene structure functionality', function() {
           exon3Text,
           'Exon 3 of 4 | 157 bp' +
           'Transcript name: APOE-201' +
-          'Exons: 4 | Biotype: protein coding | Strand: +'
+          '4 exons | protein coding | + strand'
         );
         done();
       }, 500);


### PR DESCRIPTION
This lets users more easily visually track exons when splicing.  It also fixes an edge-case bug in the related genes kit.

[Previously](#320), the exon splice animation completed in 250 ms.  That's a bit too fast to track which transcript subparts end of where after splicing exons in or out.  Now, the animation is slowed down 3x, to 750 ms, making it realistic to follow the animation with your eyes.

Here's how it looks -- old low constancy in first scene, new high constancy in second scene:

https://user-images.githubusercontent.com/1334561/201238942-5ae1ccad-35ca-46b0-b05f-5da4734a4299.mp4

Also, the "Related genes" example now has better handling of unfound genes.  Before, search a known gene (e.g. "ACE2") after an unknown gene ("asdf") threw a blocking error.  It required refreshing the page to fix; not good.  Now, searching known after unknown seamlessly returns expected results for the known searched gene.

Finally, subpart hover text was also trimmed for slightly less visual noise.