### PR TITLE
Add UI to select any alternative transcript

### DIFF
--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -10,7 +10,7 @@
     a:hover {text-decoration: underline;}
     a, a:hover, a:visited, a:active {color: #0366d6;}
 
-    #organism-menu select, optgroup, option {float: left; font-size: 14px;}
+    select#organism-menu, optgroup, option {float: left; font-size: 14px;}
 
     #ideogram-container {z-index: -1}
 

--- a/examples/vanilla/related-genes.html
+++ b/examples/vanilla/related-genes.html
@@ -10,7 +10,7 @@
     a:hover {text-decoration: underline;}
     a, a:hover, a:visited, a:active {color: #0366d6;}
 
-    select, optgroup, option {float: left; font-size: 14px;}
+    #organism-menu select, optgroup, option {float: left; font-size: 14px;}
 
     #ideogram-container {z-index: -1}
 
@@ -49,7 +49,7 @@
     See also <a href="orthologs">Orthologs</a>.
   </p>
   <div>
-    <select>
+    <select id="organism-menu">
       <optgroup label="Model organisms">
         <option value="homo-sapiens" selected>Human (Homo sapiens)</option>
         <!-- <option value="tupaia-belangeri" selected>Tree shrew (Tupaia belangeri)</option> -->

--- a/src/js/annotations/events.js
+++ b/src/js/annotations/events.js
@@ -38,10 +38,17 @@ function startHideAnnotTooltipTimeout() {
     return;
   }
 
+  // See "Without this..." note in gene-structure.js
+  const hideMs = ideo.oneTimeDelayTooltipHideMs ?? 250;
+  delete ideo.oneTimeDelayTooltipHideMs;
+
+  // Hide tooltip after `hideMs` milliseconds
   ideo.hideAnnotTooltipTimeout = window.setTimeout(function() {
     hideAnnotTooltip();
-  }, 250);
+  }, hideMs);
 
+  // Enable clients to not show tooltip immediately after clicking gene,
+  // e.g. in related genes kit
   ideo.isTooltipCooling = true;
   ideo.hideAnnotTooltipCounter = window.setTimeout(function() {
     ideo.isTooltipCooling = false;
@@ -113,34 +120,6 @@ function onClickAnnot(annot) {
 // /** Get list of annotation objects by names, e.g. ["BRCA1", "APOE"] */
 // function getAnnotsByName(annotNames, ideo) {
 //   return annotNames.map(name => getAnnotByName(name, ideo));
-// }
-
-// /** Briefly show a circle around specified annotations */
-// function pulseAnnots(annotNames, ideo, duration=2000) {
-//   const annots = getAnnotsByName(annotNames, ideo);
-//   const circle = getShapes(ideo.config.annotationHeight + 2).circle;
-//   const ids = annots.map(annot => annot.domId);
-
-//   d3.selectAll(ids).each(function() {
-//     d3.select('#' + this)
-//       .insert('path', ':first-child')
-//       .attr('class', '_ideogramAnnotPulse')
-//       .attr('d', circle)
-//       .attr('fill-opacity', 0.5)
-//       .attr('fill', 'yellow')
-//       .attr('stroke', 'orange');
-//   });
-
-//   const annotPulses = d3.selectAll('._ideogramAnnotPulse');
-//   annotPulses.transition()
-//     .duration(duration) // fade out for `duration` milliseconds
-//     .style('opacity', 0)
-//     .style('pointer-events', 'none')
-//     .on('end', function(d, i) {
-//       if (i === annotPulses.size() - 1) {
-//         annotPulses.remove();
-//       }
-//     });
 // }
 
 /**

--- a/src/js/annotations/legend.js
+++ b/src/js/annotations/legend.js
@@ -16,7 +16,7 @@ var legendStyle =
   '#_ideogramLegend li {float: none; margin: 0;}' +
   '#_ideogramLegend ul span {position: relative; left: -15px;} ';
 
-function getIcon(row, ideo) {
+export function getIcon(row, ideo) {
   var icon, triangleAttrs, circleAttrs, rectAttrs,
     fill = 'fill="' + row.color + '" style="stroke: #AAA;"',
     shape = row.shape;
@@ -33,6 +33,9 @@ function getIcon(row, ideo) {
       if (ideo.config.orientation === 'vertical') {
         // Orient arrows in legend as they are in annotations
         transform = ' transform="rotate(90, 7, 7)"';
+      }
+      if (ideo.config.orientation === 'down') {
+        transform = ' transform="rotate(180, 7, 7)"';
       }
       icon = '<path ' + triangleAttrs + transform + ' ' + fill + '></path>';
     }

--- a/src/js/init/caches/cache.js
+++ b/src/js/init/caches/cache.js
@@ -95,7 +95,7 @@ const allCacheProps = {
     parseFn: parseInteractionCache // Remove when workers work
   },
   geneStructure: {
-    metadata: 'GeneStructure', dir: 'gene-structures',
+    metadata: 'GeneStructure', dir: 'gene-structures-all',
     fn: setGeneStructureCache,
     // worker: geneStructureCacheWorker // Uncomment when workers work
     parseFn: parseGeneStructureCache // Remove when workers work

--- a/src/js/init/caches/gene-structure-cache-worker.js
+++ b/src/js/init/caches/gene-structure-cache-worker.js
@@ -59,10 +59,10 @@ export function parseCache(rawTsv, perfTimes) {
     const splitLine = line.trim().split(/\t/);
 
     const [
-      transcriptName, biotypeCompressed, strand
+      name, biotypeCompressed, strand
     ] = splitLine.slice(0, 3);
 
-    const gene = transcriptName.split('-').slice(0, -1).join('-');
+    const gene = name.split('-').slice(0, -1).join('-');
 
     const rawSubparts = splitLine.slice(3);
     const subparts = deserializeSubparts(rawSubparts, subpartKeys);
@@ -71,13 +71,18 @@ export function parseCache(rawTsv, perfTimes) {
 
     // E.g. ACE2-201, protein_coding, -, <array of exon or UTR arrays>
     const feature = {
-      transcriptName,
+      name,
       biotype,
       strand,
       subparts
     };
 
-    featuresByGene[gene] = feature;
+    if (gene in featuresByGene) {
+      featuresByGene[gene].push(feature);
+    } else {
+      featuresByGene[gene] = [feature];
+    }
+
   };
   const t1 = performance.now();
   perfTimes.parseCacheLoop = Math.round(t1 - t0);

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -363,7 +363,7 @@ export function addGeneStructureListeners(ideo) {
 }
 
 function getSpliceToggleHoverTitle(spliceExons) {
-  return spliceExons ? 'Insert introns (s)' : 'Splice exons (s)';
+  return spliceExons ? 'Unsplice exons (s)' : 'Splice exons (s)';
 }
 
 function getSpliceToggle(ideo) {
@@ -490,11 +490,11 @@ function drawIntrons(prelimSubparts, matureSubparts, ideo) {
 function toggleSplice(ideo) {
   ideo.spliceExons = !ideo.spliceExons;
   const spliceExons = ideo.spliceExons;
-  const structureName = getSelectedStructure(ideo);
-  // console.log('structureName')
-  // console.log(structureName)
+  const structure = getSelectedStructure(ideo);
+  console.log('structure')
+  console.log(structure)
   const [, prelimSubparts, matureSubparts] =
-    getGeneStructureSvg(structureName, ideo, spliceExons);
+    getGeneStructureSvg(structure, ideo, spliceExons);
 
   const addedIntrons = document.querySelectorAll('.intron').length > 0;
   if (!spliceExons && !addedIntrons) {

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -877,7 +877,9 @@ function getSvg(geneStructure, ideo, spliceExons=false) {
 function getMenuArrows() {
 
   // Get attributes
-  const style = 'width: 12px; height: 12px; cursor: pointer;';
+  const style =
+    'width: 12px; height: 12px; cursor: pointer;' +
+    'user-select: none;'; // Prevent distracting highlight on quick clicks
   const downStyle = `style="${style}; margin-left: 5px;"`;
   const upStyle = `style="${style}; margin-left: 2px;"`;
   const cls = 'class="_ideoMenuArrow"';

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -91,6 +91,8 @@ function updateGeneStructure(ideo, offset=0) {
   container.innerHTML = svg;
   updateHeader(ideo.spliceExons, isCanonical);
   writeFooter(container);
+  ideo.addedSubpartListeners = false;
+  addHoverListeners(ideo);
 }
 
 /** Get name of transcript currently selected in menu */
@@ -283,6 +285,11 @@ function navigateSubparts(event) {
   if (subparts.length === 0) return; // E.g. paralog neighborhoods, lncRNA
   const cls = '_ideoHoveredSubpart';
   const subpart = document.querySelector(`.${cls}`);
+  if (!subpart) {
+    event.stopPropagation();
+    event.preventDefault();
+    return;
+  }
   let i;
   subparts.forEach((el, index) => {
     if (el.classList.contains(cls)) {

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -625,8 +625,9 @@ function toggleSplice(ideo) {
       updateHeader(spliceExons, isCanonical);
 
       const transcriptLengthBp = getTranscriptLengthBp(subparts, spliceExons);
+      const prettyLength = transcriptLengthBp.toLocaleString()
       const tlbpDOM = document.querySelector('#_ideoTranscriptLengthBp');
-      tlbpDOM.innerText = `${transcriptLengthBp} bp`;
+      tlbpDOM.innerText = `${prettyLength} bp`;
     });
 }
 
@@ -637,7 +638,7 @@ function getTranscriptLengthBp(subparts, spliceExons=false) {
   const lastSubpart = subparts.slice(-1)[0];
   const lastStart = lastSubpart[1];
   const lastLength = lastSubpart[2];
-  const exonFill = exons.length - 1;
+  const exonFill = spliceExons ? exons.length - 1 : 0;
 
   const transcriptLengthBp = lastStart + lastLength + exonFill;
   return transcriptLengthBp;
@@ -671,7 +672,8 @@ function getSubpartSummary(subpartType, total, index, strand, lengthBp) {
   if (strand === '-') index = total - index + 1;
   const numOfTotal = total > 1 ? `${index} of ${total} ` : '';
   const prettyType = subpartType[0].toUpperCase() + subpartType.slice(1);
-  const html = `${prettyType} ${numOfTotal}${pipe} ${lengthBp} bp`;
+  const prettyLength = lengthBp.toLocaleString();
+  const html = `${prettyType} ${numOfTotal}${pipe} ${prettyLength} bp`;
   const summary = `data-subpart="${html}"`;
   return summary;
 }
@@ -725,7 +727,7 @@ function getSvg(geneStructure, ideo, spliceExons=false) {
     spliceToggle.title = title;
   }
 
-  const featureLengthPx = 250;
+  const featureLengthPx = 250 - 2; // Snip to avoid overextending
 
   const intronHeight = 1;
   const intronColor = 'black';
@@ -822,11 +824,11 @@ function getSvg(geneStructure, ideo, spliceExons=false) {
   }
 
   const transcriptLengthBp = getTranscriptLengthBp(subparts, spliceExons);
-
+  const prettyLength = transcriptLengthBp.toLocaleString();
   const footerDetails = [
     `${totalBySubpart['exon']} exons`,
-    `<span id='_ideoTranscriptLengthBp'>${transcriptLengthBp} bp</span> `,
-    // `${strand} strand`
+    `<span id='_ideoTranscriptLengthBp'>${prettyLength} bp</span> `,
+    `${strand} strand`
   ];
   const biotypeText = geneStructure.biotype.replace(/_/g, ' ');
   if (biotypeText !== 'protein coding') {

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -103,19 +103,28 @@ function getGeneFromStructureName(structureName) {
 
 /** Get name of transcript currently selected in menu */
 function getSelectedStructure(ideo, offset=0) {
+  let selectedIndex, structureName;
+
   const menu = document.querySelector('#_ideoGeneStructureMenu');
-  const numOptions = menu.options.length;
-  const baseIndex = menu.selectedIndex;
-  let selectedIndex = baseIndex + offset;
-  if (selectedIndex >= numOptions) {
+  if (!menu) {
+    const svg = document.querySelector('._ideoGeneStructure');
+    structureName = svg.getAttribute('data-ideo-gene-structure-name');
     selectedIndex = 0;
-  } else if (selectedIndex < 0) {
-    selectedIndex = numOptions - 1;
+  } else {
+    const numOptions = menu.options.length;
+    const baseIndex = menu.selectedIndex;
+    selectedIndex = baseIndex + offset;
+    if (selectedIndex >= numOptions) {
+      selectedIndex = 0;
+    } else if (selectedIndex < 0) {
+      selectedIndex = numOptions - 1;
+    }
+    structureName = menu.options[selectedIndex].value;
   }
-  const structureName = menu.options[selectedIndex].value;
   const gene = getGeneFromStructureName(structureName);
   const geneStructure =
     ideo.geneStructureCache[gene].find(gs => gs.name === structureName);
+
 
   return [geneStructure, selectedIndex];
 }

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -159,6 +159,9 @@ function toggleSpliceByKeyboard(event) {
   if (event.key === 's') {
     const spliceToggle = document.querySelector('._ideoSpliceToggle input');
     if (!spliceToggle) return;
+
+    const subpartText = document.querySelector('#_ideoSubpartText')
+    if (subpartText) subpartText.innerHTML = '&nbsp;';
     spliceToggle.dispatchEvent(new MouseEvent('click'));
   }
 }
@@ -364,6 +367,7 @@ function getMenuContainer() {
 
 function addSubpartHoverListener(subpartDOM, ideo) {
   const subpart = subpartDOM;
+
   // On hovering over subpart, highlight it and show details
   subpart.addEventListener('mouseenter', event => {
     removeHighlights();
@@ -374,8 +378,10 @@ function addSubpartHoverListener(subpartDOM, ideo) {
     ideo.originalTooltipFooter = footer.innerHTML;
     const subpartText = subpart.getAttribute('data-subpart');
     const trimmedFoot = footer.innerHTML.replace('&nbsp;', '');
+    const style = 'style="margin-bottom: -10px"';
+    const id = 'id="_ideoSubpartText"';
     footer.innerHTML =
-      `<div style="margin-bottom: -10px">${subpartText}</div>${trimmedFoot}`;
+      `<div ${id} ${style}">${subpartText}</div>${trimmedFoot}`;
     const menuContainer = getMenuContainer();
     menuContainer.style.marginTop = '';
   });
@@ -586,8 +592,6 @@ function toggleSplice(ideo) {
   ideo.spliceExons = !ideo.spliceExons;
   const spliceExons = ideo.spliceExons;
   const [structure, selectedIndex] = getSelectedStructure(ideo);
-  console.log('structure')
-  console.log(structure)
   const isCanonical = (selectedIndex === 0);
   const [, prelimSubparts, matureSubparts] =
     getSvg(structure, ideo, spliceExons);

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -109,6 +109,7 @@ function getSelectedStructure(ideo, offset=0) {
   const menu = document.querySelector('#_ideoGeneStructureMenu');
   if (!menu) {
     const svg = document.querySelector('._ideoGeneStructure');
+    if (!svg) return null; // No gene structure is available, e.g. for miRNA
     structureName = svg.getAttribute('data-ideo-gene-structure-name');
     selectedIndex = 0;
   } else {
@@ -462,6 +463,8 @@ function writeStrandInFooter(ideo) {
 }
 
 export function addGeneStructureListeners(ideo) {
+  const structure = getSelectedStructure(ideo);
+  if (structure === null) return; // Bail for e.g. miRNA
   addSpliceToggleListeners(ideo);
   addHoverListeners(ideo);
   addMenuListeners(ideo);

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -454,10 +454,11 @@ function addHoverListeners(ideo) {
 }
 
 function writeStrandInFooter(ideo) {
+  const strand = getSelectedStructure(ideo)[0].strand;
+  if (strand === '+') return; // Don't remark if strand is the default
   const tooltipFooter = document.querySelector('._ideoTooltipFooter');
-  const structure = getSelectedStructure(ideo)[0];
   tooltipFooter.innerText =
-    tooltipFooter.innerText.replace(')', `, ${structure.strand})`);
+    tooltipFooter.innerText.replace(')', `, ${strand})`);
 }
 
 export function addGeneStructureListeners(ideo) {

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -438,10 +438,18 @@ function addHoverListeners(ideo) {
   });
 }
 
+function writeStrandInFooter(ideo) {
+  const tooltipFooter = document.querySelector('._ideoTooltipFooter');
+  const structure = getSelectedStructure(ideo)[0];
+  tooltipFooter.innerText =
+    tooltipFooter.innerText.replace(')', `, ${structure.strand})`);
+}
+
 export function addGeneStructureListeners(ideo) {
   addSpliceToggleListeners(ideo);
   addHoverListeners(ideo);
   addMenuListeners(ideo);
+  writeStrandInFooter(ideo);
 }
 
 function getSpliceToggleHoverTitle(spliceExons) {
@@ -827,8 +835,7 @@ function getSvg(geneStructure, ideo, spliceExons=false) {
   const prettyLength = transcriptLengthBp.toLocaleString();
   const footerDetails = [
     `${totalBySubpart['exon']} exons`,
-    `<span id='_ideoTranscriptLengthBp'>${prettyLength} bp</span> `,
-    `${strand} strand`
+    `<span id='_ideoTranscriptLengthBp'>${prettyLength} bp</span> `
   ];
   const biotypeText = geneStructure.biotype.replace(/_/g, ' ');
   if (biotypeText !== 'protein coding') {

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -398,7 +398,7 @@ function addSubpartHoverListener(subpartDOM, ideo) {
     footer.innerHTML =
       `<div ${id} ${style}">${subpartText}</div>${trimmedFoot}`;
     const menuContainer = getMenuContainer();
-    menuContainer.style.marginTop = '';
+    if (menuContainer) menuContainer.style.marginTop = '';
   });
 
   // On hovering out, de-highlight and hide details
@@ -407,7 +407,7 @@ function addSubpartHoverListener(subpartDOM, ideo) {
     const footer = getFooter();
     footer.innerHTML = ideo.originalTooltipFooter;
     const menuContainer = getMenuContainer();
-    menuContainer.style.marginTop = '4px';
+    if (menuContainer) menuContainer.style.marginTop = '4px';
   });
 }
 
@@ -648,9 +648,10 @@ function toggleSplice(ideo) {
 
       updateHeader(spliceExons, isCanonical);
 
-      const transcriptLengthBp = getTranscriptLengthBp(subparts, spliceExons);
-      const prettyLength = transcriptLengthBp.toLocaleString()
       const tlbpDOM = document.querySelector('#_ideoTranscriptLengthBp');
+      if (!tlbpDOM) return;
+      const transcriptLengthBp = getTranscriptLengthBp(subparts, spliceExons);
+      const prettyLength = transcriptLengthBp.toLocaleString();
       tlbpDOM.innerText = `${prettyLength} bp`;
     });
 }

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -839,15 +839,10 @@ function getMenu(gene, ideo, selectedName) {
   }).join('');
 
   const id = '_ideoGeneStructureMenu';
-  // const style = 'style="display: inline"';
-  const style = 'style="' +
-    'float: right; ' +
-    'position: relative; top: -3px;' +
-    '"';
   const menu =
     `<div style="margin-bottom: 8px; clear: both;">` +
-      `<label for="${id}" style="margin-right: 5px">Transcript:</label> ` +
-      `<select id="${id}" name="${id}" ${style}>${options}</select>` +
+      `<label for="${id}">Transcript:</label> ` +
+      `<select id="${id}" name="${id}">${options}</select>` +
     `</div>`;
   return menu;
 }

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -358,8 +358,8 @@ function navigateSubparts(event) {
   event.preventDefault();
 }
 
-function getMenuDOM() {
-  return document.querySelector('#_ideoGeneStructureMenu');
+function getMenuContainer() {
+  return document.querySelector('#_ideoGeneStructureMenuContainer');
 }
 
 function addSubpartHoverListener(subpartDOM, ideo) {
@@ -375,9 +375,9 @@ function addSubpartHoverListener(subpartDOM, ideo) {
     const subpartText = subpart.getAttribute('data-subpart');
     const trimmedFoot = footer.innerHTML.replace('&nbsp;', '');
     footer.innerHTML =
-      `<div style="margin-bottom: -12px">${subpartText}</div>${trimmedFoot}`;
-    const menu = getMenuDOM();
-    menu.style.marginTop = '0px';
+      `<div style="margin-bottom: -10px">${subpartText}</div>${trimmedFoot}`;
+    const menuContainer = getMenuContainer();
+    menuContainer.style.marginTop = '';
   });
 
   // On hovering out, de-highlight and hide details
@@ -385,8 +385,8 @@ function addSubpartHoverListener(subpartDOM, ideo) {
     event.target.classList.remove('_ideoHoveredSubpart');
     const footer = getFooter();
     footer.innerHTML = ideo.originalTooltipFooter;
-    const menu = getMenuDOM();
-    menu.style.marginTop = '2px';
+    const menuContainer = getMenuContainer();
+    menuContainer.style.marginTop = '4px';
   });
 }
 
@@ -839,8 +839,10 @@ function getMenu(gene, ideo, selectedName) {
   }).join('');
 
   const id = '_ideoGeneStructureMenu';
+  const containerId = '_ideoGeneStructureMenuContainer';
+  const style = 'margin-bottom: 4px; margin-top: 4px; clear: both;';
   const menu =
-    `<div style="margin-bottom: 4px; margin-top: 2px; clear: both;">` +
+    `<div id="${containerId}" style="${style}">` +
       `<label for="${id}">Transcript:</label> ` +
       `<select id="${id}" name="${id}">${options}</select>` +
     `</div>`;

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -160,7 +160,7 @@ function toggleSpliceByKeyboard(event) {
     const spliceToggle = document.querySelector('._ideoSpliceToggle input');
     if (!spliceToggle) return;
 
-    const subpartText = document.querySelector('#_ideoSubpartText')
+    const subpartText = document.querySelector('#_ideoSubpartText');
     if (subpartText) subpartText.innerHTML = '&nbsp;';
     spliceToggle.dispatchEvent(new MouseEvent('click'));
   }
@@ -623,17 +623,33 @@ function toggleSplice(ideo) {
       });
 
       updateHeader(spliceExons, isCanonical);
+
+      const transcriptLengthBp = getTranscriptLengthBp(subparts, spliceExons);
+      const tlbpDOM = document.querySelector('#_ideoTranscriptLengthBp');
+      tlbpDOM.innerText = `${transcriptLengthBp} bp`;
     });
+}
+
+function getTranscriptLengthBp(subparts, spliceExons=false) {
+  const exons = subparts.filter(sp => sp[0] === 'exon');
+  if (spliceExons) subparts = exons;
+
+  const lastSubpart = subparts.slice(-1)[0];
+  const lastStart = lastSubpart[1];
+  const lastLength = lastSubpart[2];
+  const exonFill = exons.length - 1;
+
+  const transcriptLengthBp = lastStart + lastLength + exonFill;
+  return transcriptLengthBp;
 }
 
 /** Merge subpart type, pixel-x position, and pixel width to each subpart */
 function addPositions(subparts) {
-  const lastSubpart = subparts.slice(-1)[0];
-  const featureLengthBp = lastSubpart[1] + lastSubpart[2];
+  const transcriptLengthBp = getTranscriptLengthBp(subparts);
 
-  const featureLengthPx = 250;
+  const transcriptLengthPx = 250;
 
-  const bpPerPx = featureLengthBp / featureLengthPx;
+  const bpPerPx = transcriptLengthBp / transcriptLengthPx;
 
   for (let i = 0; i < subparts.length; i++) {
     const subpart = subparts[i];
@@ -805,9 +821,12 @@ function getSvg(geneStructure, ideo, spliceExons=false) {
       `style="${sharedStyle} left: -10px;"`;
   }
 
+  const transcriptLengthBp = getTranscriptLengthBp(subparts, spliceExons);
+
   const footerDetails = [
     `${totalBySubpart['exon']} exons`,
-    `${strand} strand`
+    `<span id='_ideoTranscriptLengthBp'>${transcriptLengthBp} bp</span> `,
+    // `${strand} strand`
   ];
   const biotypeText = geneStructure.biotype.replace(/_/g, ' ');
   if (biotypeText !== 'protein coding') {

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -1,8 +1,7 @@
 import {d3} from '../lib';
-import {getIcon} from '../annotations/legend'
+import {getIcon} from '../annotations/legend';
 
 const y = 15;
-
 
 // Subtle visual delimiter; separates horizontally adjacent fields in UI
 const pipe = `<span style='color: #CCC'>|</span>`;
@@ -437,13 +436,20 @@ function addHoverListeners(ideo) {
     const tooltip = document.querySelector('._ideogramTooltip');
     tooltip.addEventListener('change', () => {
       updateGeneStructure(ideo);
+
+      // Without this, selecting a new transcript will close the tooltip if
+      // the selected <option> screen position is outside the tooltip (as
+      // is often the case in genes with many transcripts, like TP53).
+      ideo.oneTimeDelayTooltipHideMs = 2000; // wait 2.0 s instead of 0.25 s
     });
   });
   container.addEventListener('mouseleave', () => {
+    ideo.oneTimeDelayTooltipHideMs = 2000; // See "Without this..." note above
     const footer = getFooter();
     footer.innerHTML = '';
     ideo.addedMenuListeners = false;
     document.removeEventListener('keydown', navigateSubparts);
+
   });
 
   if (ideo.addedSubpartListeners) return;

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -358,6 +358,10 @@ function navigateSubparts(event) {
   event.preventDefault();
 }
 
+function getMenuDOM() {
+  return document.querySelector('#_ideoGeneStructureMenu');
+}
+
 function addSubpartHoverListener(subpartDOM, ideo) {
   const subpart = subpartDOM;
   // On hovering over subpart, highlight it and show details
@@ -365,16 +369,15 @@ function addSubpartHoverListener(subpartDOM, ideo) {
     removeHighlights();
     // Highlight hovered subpart, adding an aura around it
     event.target.classList.add('_ideoHoveredSubpart');
-
     // Show details
     const footer = getFooter();
     ideo.originalTooltipFooter = footer.innerHTML;
     const subpartText = subpart.getAttribute('data-subpart');
-    const trimmedFoot =
-      footer.innerHTML
-        .replace('&nbsp;', '')
-        .replace('Transcript', '<br/>Transcript');
-    footer.innerHTML = `<br/>${subpartText}${trimmedFoot}`;
+    const trimmedFoot = footer.innerHTML.replace('&nbsp;', '');
+    footer.innerHTML =
+      `<div style="margin-bottom: -12px">${subpartText}</div>${trimmedFoot}`;
+    const menu = getMenuDOM();
+    menu.style.marginTop = '0px';
   });
 
   // On hovering out, de-highlight and hide details
@@ -382,6 +385,8 @@ function addSubpartHoverListener(subpartDOM, ideo) {
     event.target.classList.remove('_ideoHoveredSubpart');
     const footer = getFooter();
     footer.innerHTML = ideo.originalTooltipFooter;
+    const menu = getMenuDOM();
+    menu.style.marginTop = '2px';
   });
 }
 
@@ -581,6 +586,8 @@ function toggleSplice(ideo) {
   ideo.spliceExons = !ideo.spliceExons;
   const spliceExons = ideo.spliceExons;
   const [structure, selectedIndex] = getSelectedStructure(ideo);
+  console.log('structure')
+  console.log(structure)
   const isCanonical = (selectedIndex === 0);
   const [, prelimSubparts, matureSubparts] =
     getSvg(structure, ideo, spliceExons);
@@ -820,13 +827,6 @@ function getSvg(geneStructure, ideo, spliceExons=false) {
 }
 
 function getMenu(gene, ideo, selectedName) {
-  if (
-    'geneStructureCache' in ideo === false ||
-    gene in ideo.geneStructureCache === false
-  ) {
-    return null;
-  }
-
   const structures = ideo.geneStructureCache[gene];
 
   const options = structures.map(structure => {
@@ -840,7 +840,7 @@ function getMenu(gene, ideo, selectedName) {
 
   const id = '_ideoGeneStructureMenu';
   const menu =
-    `<div style="margin-bottom: 8px; clear: both;">` +
+    `<div style="margin-bottom: 4px; margin-top: 2px; clear: both;">` +
       `<label for="${id}">Transcript:</label> ` +
       `<select id="${id}" name="${id}">${options}</select>` +
     `</div>`;

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -904,7 +904,17 @@ function getMenuArrows() {
 
 /** Get menu for all transcripts for this gene */
 function getMenu(gene, ideo, selectedName) {
+  const containerId = '_ideoGeneStructureMenuContainer';
+  const style = 'margin-bottom: 4px; margin-top: 4px; clear: both;';
+
   const structures = ideo.geneStructureCache[gene];
+
+  if (structures.length === 1) {
+    const name = structures[0].name;
+    const line =
+      `<div id="${containerId}" style="${style}">Transcript: ${name}</div>`;
+    return line;
+  }
 
   const options = structures.map(structure => {
     const name = structure.name;
@@ -916,8 +926,6 @@ function getMenu(gene, ideo, selectedName) {
   }).join('');
 
   const id = '_ideoGeneStructureMenu';
-  const containerId = '_ideoGeneStructureMenuContainer';
-  const style = 'margin-bottom: 4px; margin-top: 4px; clear: both;';
 
   const menuArrows = getMenuArrows();
 

--- a/test/offline/gene-structure.test.js
+++ b/test/offline/gene-structure.test.js
@@ -50,6 +50,7 @@ describe('Ideogram gene structure functionality', function() {
 
       // Positive-stranded gene
       await ideogram.plotRelatedGenes('APOE');
+
       setTimeout(async function() {
         const apoeLabel = document.querySelector('#ideogramLabel__c18_a1');
         apoeLabel.dispatchEvent(new Event('mouseover'));
@@ -74,8 +75,9 @@ describe('Ideogram gene structure functionality', function() {
         assert.equal(
           exonText2,
           'Exon 2 of 4 | 66 bp' +
-          'Transcript name: APOE-201' +
-          '4 exons | protein coding | + strand'
+          'Transcript: APOE-201APOE-204APOE-203APOE-202' +
+          'Next transcript (down arrow)Previous transcript (up arrow)' +
+          '4 exons | 1,166 bp '
         );
 
         // Negative-stranded gene
@@ -95,13 +97,12 @@ describe('Ideogram gene structure functionality', function() {
 
         // Navigate subparts by pressing arrow key
         document.dispatchEvent(left);
-        const exon3Text = footer.textContent;
+        const exon3Text = footer.textContent.slice(0, 20);
         assert.equal(
           exon3Text,
-          'Exon 3 of 4 | 157 bp' +
-          'Transcript name: APOE-201' +
-          '4 exons | protein coding | + strand'
+          'Exon 3 of 4 | 157 bp'
         );
+
         done();
       }, 500);
     }


### PR DESCRIPTION
This lets you see all transcripts for a gene, one at a time.  It also shows spliced or unspliced transcript length.

Previously, only the canonical transcript was shown.  Genes usually have multiple transcripts, and the alternative transcripts can be important.  Now, building on data in #321 (though only using gzip compression for now),  these can be seen directly in Ideogram.  This lets users learn at a glance how many other transcripts exist for their gene of interest, as well as their gene structure.  

Also previously, only the gene's length was shown.  "Gene length" is slightly abstract, as a gene is essentially a conceptual container for one or more immature transcripts.  "Transcript length" is a more specific kind of gene length, and more directly corresponds to the length of the molecules that get measured in, say, modern gene expression assays.  Gene length is still shown in the default tooltip, but transcript length is now shown upon hovering over the gene structure diagram.

This also refines the positioning and display logic for data on strand and biotype.

Here's how it looks:

https://user-images.githubusercontent.com/1334561/202910948-4f210ff6-b5e8-4a12-a023-95da53de63a0.mov
