### PR TITLE
Fix rotate-on-click for chromosomes fetched from NCBI

### DIFF
--- a/src/js/model-adapter.js
+++ b/src/js/model-adapter.js
@@ -48,7 +48,7 @@ export class ModelNoBandsAdapter extends ModelAdapter {
         },
         bp: {
           start: 1,
-          stop: this._model.bpLength
+          stop: this._model.bpLength ?? this._model.length
         },
         iscn: {
           start: 1,

--- a/src/js/views/chromosome-model.js
+++ b/src/js/views/chromosome-model.js
@@ -101,7 +101,7 @@ function getChrModelScaffold(chr, bands, chrName, ideo) {
   var hasBands = (typeof bands !== 'undefined');
 
   if (hasBands) {
-    const lastBand = bands[bands.length - 1];
+    const lastBand = bands.slice(-1)[0];
     chr.name = chrName;
     chr.length = lastBand[ideo.coordinateSystem].stop;
 

--- a/test/online/custom-organism.test.js
+++ b/test/online/custom-organism.test.js
@@ -46,4 +46,27 @@ describe('Ideogram custom organism support', function() {
     });
   });
 
+  it('rotates chromosomes lacking native bands', done => {
+    // Tests fix for https://github.com/eweitz/ideogram/issues/330
+
+    function callback() {
+      let chr1 = document.querySelector('#chr1-29760');
+      const height = Math.round(chr1.getBoundingClientRect().height);
+      assert.equal(height, 304);
+      chr1.dispatchEvent(new Event('click', {bubbles: true}));
+      setTimeout(function() {
+        chr1 = document.querySelector('#chr1-29760');
+        const width = Math.round(chr1.getBoundingClientRect().width);
+        assert.equal(width, 545);
+        chr1.dispatchEvent(new Event('click', {bubbles: true}));
+        done();
+      }, 1000);
+    }
+
+    const ideogram = new Ideogram({
+      organism: 'vitis-vinifera',
+      onLoad: callback
+    });
+  });
+
 });


### PR DESCRIPTION
This fixes rotation-on-click for chromosomes that lack native cytogenetic banding data.

Previously, if a genome were fetched from NCBI, clicking a chromosome would rotate it, then the chromosome would disappear.  This was due to a slightly misconfigured length property for such chromosomes.

Now, length is properly set, and such chromosomes rotate as expected upon click.  A new automated test protects against regression.

Here's how the fix looks in grape (_Vitis vinifera_); compare to bug visuals in #330.


https://user-images.githubusercontent.com/1334561/207322611-aa323d24-6d56-4741-88e3-1f1452e6f8d4.mov

