### PR TITLE
Fix splice bug when 1st UTR and exon exactly align

### DIFF
--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -226,9 +226,15 @@ function swapUTRsForward(subparts, isPositiveStrand) {
   const utr = isPositiveStrand ? utr3 : utr5;
   const hasUtr = subparts.some(subpart => subpart[0] === utr);
 
-  if (subparts[0][0] === 'exon' && subparts[1][0] === utr3) {
-    // Accounts for edge case in e.g. canonical transcript SCARB1-201
-    return swappedSubparts;
+  if (subparts[0][0] === 'exon') {
+    const rawUtr = isPositiveStrand ? utr5 : utr3;
+    if (subparts[1][0] === rawUtr) {
+      // Accounts for uncommon case in e.g. canonical transcript SCARB1-201
+      // and alternative transcript MAOA-204 in which the first UTR subpart
+      // is exactly equal in length to the first exon, and that exon subpart
+      // is ordered first among subparts in the transcript.
+      return swappedSubparts;
+    }
   }
 
   subparts.forEach((subpart, i) => {

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -226,6 +226,11 @@ function swapUTRsForward(subparts, isPositiveStrand) {
   const utr = isPositiveStrand ? utr3 : utr5;
   const hasUtr = subparts.some(subpart => subpart[0] === utr);
 
+  if (subparts[0][0] === 'exon' && subparts[1][0] === utr3) {
+    // Accounts for edge case in e.g. canonical transcript SCARB1-201
+    return swappedSubparts;
+  }
+
   subparts.forEach((subpart, i) => {
     if (i === 0) return;
     const prevSubpart = subparts[i - 1];
@@ -656,7 +661,6 @@ function drawIntrons(prelimSubparts, matureSubparts, ideo) {
   });
 
   document.querySelectorAll('.intron').forEach(subpartDOM => {
-
     addSubpartHoverListener(subpartDOM, ideo);
   });
 }

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -226,13 +226,18 @@ function swapUTRsForward(subparts, isPositiveStrand) {
   const utr = isPositiveStrand ? utr3 : utr5;
   const hasUtr = subparts.some(subpart => subpart[0] === utr);
 
-  if (subparts[0][0] === 'exon') {
+  if (
+    subparts.length >= 3 &&
+    subparts[0][0] === 'exon' && subparts[2][0] === 'exon'
+  ) {
     const rawUtr = isPositiveStrand ? utr5 : utr3;
     if (subparts[1][0] === rawUtr) {
       // Accounts for uncommon case in e.g. canonical transcript SCARB1-201
       // and alternative transcript MAOA-204 in which the first UTR subpart
       // is exactly equal in length to the first exon, and that exon subpart
       // is ordered first among subparts in the transcript.
+      // The subparts[2][0] clause accounts for cases like APOE-201, which
+      // have multi-subpart first UTRs.
       return swappedSubparts;
     }
   }

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -239,7 +239,7 @@ function swapUTRsForward(subparts, isPositiveStrand) {
         !isPositiveStrand && prevIsUtr3 ||
         isPositiveStrand && prevIsUtr5 && (
           // Account for multi-part UTRs, as in e.g.
-          // canonicals for FAM111B and SCARB1, andd alternative MAOA-204
+          // canonicals for FAM111B and SCARB1, and alternative MAOA-204
           subpart[1] !== prevSubpart[1] + prevSubpart[2] - 1
         )
       )

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -236,8 +236,10 @@ function swapUTRsForward(subparts, isPositiveStrand) {
 
     if (
       isExon && hasUtr && (
-        !isPositiveStrand && prevIsUtr3 ||
-        isPositiveStrand && prevIsUtr5 && (
+        (
+          !isPositiveStrand && prevIsUtr3 ||
+          isPositiveStrand && prevIsUtr5
+        ) && (
           // Account for multi-part UTRs, as in e.g.
           // canonicals for FAM111B and SCARB1, and alternative MAOA-204
           subpart[1] !== prevSubpart[1] + prevSubpart[2] - 1

--- a/test/offline/gene-structure.test.js
+++ b/test/offline/gene-structure.test.js
@@ -193,7 +193,9 @@ describe('Ideogram gene structure functionality', function() {
           container.dispatchEvent(new Event('mouseenter'));
 
           const menu = document.querySelector('#_ideoGeneStructureMenu');
-          // MAOA-204, uncommon case of exon before first UTR in Ideogram data
+          // MAOA-204, case of exon before first UTR in Ideogram data
+          // Happens in 4-10% of transcripts
+          // Context: https://github.com/eweitz/ideogram/pull/337
           menu.options[1].selected = true;
           menu.dispatchEvent(new Event('change', {'bubbles': true}));
 

--- a/test/offline/gene-structure.test.js
+++ b/test/offline/gene-structure.test.js
@@ -246,9 +246,9 @@ describe('Ideogram gene structure functionality', function() {
           const subpart1 = subparts[0];
           const x = subpart1.getAttribute('x');
           const width = subpart1.getAttribute('width');
-          const color = subpart1.getAttribute('color');
-          assert.equal(Math.round(x), 247);
-          assert.equal(Math.round(width), 3);
+          const color = subpart1.getAttribute('fill');
+          assert.equal(Math.round(parseFloat(x)), 247);
+          assert.equal(Math.round(parseFloat(width)), 3);
           assert.equal(color, '#DAA521');
           done();
         }, 1000);

--- a/test/offline/gene-structure.test.js
+++ b/test/offline/gene-structure.test.js
@@ -160,13 +160,13 @@ describe('Ideogram gene structure functionality', function() {
       setTimeout(async function() {
         const apoeLabel = document.querySelector('#ideogramLabel__c18_a1');
         apoeLabel.dispatchEvent(new Event('mouseover'));
-
         // Press "s" key, to toggle exon splicing
         const sKeydown = new KeyboardEvent('keydown', {key: 's'});
         document.dispatchEvent(sKeydown);
-        const subparts = document.querySelectorAll('rect.subpart');
+        let subparts = document.querySelectorAll('rect.subpart');
         assert.equal(subparts.length, 10); // includes introns
 
+        document.dispatchEvent(sKeydown);
         setTimeout(async function() {
           // The last exon of gene LDLR includes both CDS and 3'-UTR
           // There was a bug (see commit 7a43ba0) that caused drastically
@@ -174,6 +174,7 @@ describe('Ideogram gene structure functionality', function() {
           // has a relatively very small CDS compared to 3'-UTR.
           const ldlrLabel = document.querySelector('#ideogramLabel__c18_a0');
           ldlrLabel.dispatchEvent(new Event('mouseover'));
+          subparts = document.querySelectorAll('rect.subpart');
 
           const lastExon = subparts[18];
           const threePrimeUtr = subparts[19];
@@ -184,9 +185,27 @@ describe('Ideogram gene structure functionality', function() {
           assert.equal(Math.round(threePrimeUtr.x.baseVal.value), 129);
           assert.equal(Math.round(threePrimeUtr.width.baseVal.value), 121);
 
-        }, 500);
+          // Label for MAOA gene
+          const maoaLabel = document.querySelector('#ideogramLabel__c22_a0');
+          maoaLabel.dispatchEvent(new Event('mouseover'));
+          const container =
+            document.querySelector('._ideoGeneStructureContainer');
+          container.dispatchEvent(new Event('mouseenter'));
 
-        done();
+          const menu = document.querySelector('#_ideoGeneStructureMenu');
+          // MAOA-204, uncommon case of exon before first UTR in Ideogram data
+          menu.options[1].selected = true;
+          menu.dispatchEvent(new Event('change', {'bubbles': true}));
+
+          document.dispatchEvent(sKeydown);
+          setTimeout(async function() {
+            const firstUtr = document.querySelector('.five-prime-utr');
+            assert.equal(firstUtr.x.baseVal.value, 0);
+            assert.equal(Math.round(firstUtr.width.baseVal.value), 4);
+            assert.equal(firstUtr.getAttribute('fill'), '#155069');
+            done();
+          }, 1000);
+        }, 1000);
       }, 500);
     }
 
@@ -231,10 +250,8 @@ describe('Ideogram gene structure functionality', function() {
           assert.equal(Math.round(x), 247);
           assert.equal(Math.round(width), 3);
           assert.equal(color, '#DAA521');
-
+          done();
         }, 1000);
-
-        done();
       }, 500);
     }
 


### PR DESCRIPTION
This fixes a bug seen upon splicing some RNA diagrams, e.g. by clicking the scissors button.

It occurred when the first UTR subpart is exactly equal in length to the first exon, and that exon subpart is ordered first among subparts in the transcript.  The spliced pre-mRNA would could misordered subparts, which would further degrade with each toggle.

Examples:
* Canonical transcript SCARB1-201
* Alternative transcript MAOA-204

Altogether, it manifested in 4% of canonical transcripts for protein-coding genes (834 / 20015), and 10% of all protein-coding transcripts (6802 / 70593).  It's fixed now, as confirmed by manual and automated tests.

This also fixes an invalid test for a related issue.

<details>

<summary>Analysis code</summary>

```js
affecteds = []
canonicalAffecteds = []
all = []
genes = []
Object.entries(ideogram.geneStructureCache).forEach(([geneName, transcripts], i) => {
    genes.push(geneName)
    affected = transcripts.find(t => {
      all.push(t);
      sp = t.subparts;
      return sp.length >= 3 && sp[0][0] === 'exon' && sp[2][0] === 'exon' && ["3'-UTR", "5'-UTR"].includes(sp[1][0]);
    });
    if (affected) {
      affecteds.push(affected);
      if (affected.name.endsWith('-201')) canonicalAffecteds.push(affected)
    }
  });
console.log(`# affected: ${affecteds.length}`)
console.log(`# affected canonical: ${canonicalAffecteds.length}`)
console.log(`# total transcripts: ${all.length}`)
console.log(`# total protein-coding genes: ${genes.length}`)
console.log(`% affected: ${100 * affecteds.length / all.length}`)
console.log(`% genes with canonical affected: ${100 * canonicalAffecteds.length / genes.length}`)
VM24:18 # affected: 6802
VM24:19 # affected canonical: 834
VM24:20 # total transcripts: 70593
VM24:21 # total protein-coding genes: 20015
VM24:22 % affected: 9.635516269318488
VM24:23 % genes with canonical affected: 4.1668748438671
```
</details>