### PR TITLE
Protein diagrams: show unfeatured regions, enlarge

### DIFF
--- a/src/js/kit/protein-color.js
+++ b/src/js/kit/protein-color.js
@@ -17,7 +17,7 @@ const darkGrey = '#888';
 const darkGreyLine = '#AAA';
 
 const red = '#F00';
-const redLines = '#D00';
+const redLines = '#800';
 const magenta = '#922D5E';
 const magentaLines = '#D26D9E';
 const faintRed = '#CAA';
@@ -35,7 +35,7 @@ const deepBlue = '#55A';
 const deepBlueLines = '#AAF';
 
 const green = '#7D7';
-const greenLines = '#5B5';
+const greenLines = '#393';
 const seafoam = '#93E9BE';
 const seafoamLines = '#53AC7E';
 
@@ -47,7 +47,7 @@ const purpleLine = '#5800A4';
 const purple2 = '#A020F0';
 const purple2Line = '#7000C0';
 const lightPurple = '#B24BF3';
-const lightPurpleLine = '#921BC3';
+const lightPurpleLine = '#520B83';
 const veryLightPurple = '#D7A1F9';
 const veryLightPurpleLine = '#A771C9';
 
@@ -130,7 +130,6 @@ export function getColors(domainType) {
     domainType.includes('OB C-terminal domain') ||
     domainType === 'Cationic amino acid transporter, C-terminal' ||
     domainType === 'High mobility group box domain' ||
-    domainType.includes('Peptidase M2') ||
     domainType.includes('CUB domain') ||
     domainType === 'C-5 cytosine methyltransferase' ||
     domainType.includes('(G-protein), alpha subunit') ||
@@ -165,7 +164,8 @@ export function getColors(domainType) {
     domainType === 'Rad52 family' ||
     domainType === 'Oxidoreductase FAD/NAD(P)-binding' ||
     domainType.includes('Bromo adjacent') ||
-    domainType === 'HARP domain'
+    domainType === 'HARP domain' ||
+    domainType === 'FATC domain'
   ) {
     return [blue, blueLines];
   } else if (
@@ -210,7 +210,8 @@ export function getColors(domainType) {
     domainType ===
       'Calcium/calmodulin-dependent protein kinase II, association-domain' ||
     domainType === 'Bromodomain' ||
-    domainType === 'SLIDE domain'
+    domainType === 'SLIDE domain' ||
+    domainType === 'Peptidase M24'
   ) {
     return [deepBlue, deepBlueLines];
   } else if (

--- a/src/js/kit/protein-color.js
+++ b/src/js/kit/protein-color.js
@@ -51,7 +51,9 @@ const lightPurpleLine = '#921BC3';
 const veryLightPurple = '#D7A1F9';
 const veryLightPurpleLine = '#A771C9';
 
-const brown = '#964B00';
+const darkBrown = '#964B00';
+const darkBrownLine = '#C67B30';
+const brown = '#B86D22';
 const brownLine = '#C67B30';
 const lightBrown = '#DACDBA';
 const lightBrownLine = '#BAAB9A';
@@ -63,6 +65,12 @@ const yellowLine = '#CCC89A';
 
 const lightOrange = '#FFEA66';
 const lightOrangeLine = '#FFB466';
+
+const veryLightGreen = '#DFD';
+const veryLightGreenLine = '#ABA';
+
+const veryLightBrown = '#FCEFDC';
+const veryLightBrownLine = '#DCCDBC';
 
 export function getColors(domainType) {
 
@@ -79,6 +87,14 @@ export function getColors(domainType) {
     domainType === 'Lumenal'
   ) {
     return [lightOrange, lightOrangeLine];
+  } else if (
+    domainType === 'Mitochondrial matrix'
+  ) {
+    return [veryLightGreen, veryLightGreenLine];
+  } else if (
+    domainType === 'Mitochondrial intermembrane'
+  ) {
+    return [veryLightBrown, veryLightBrownLine];
   }
 
 
@@ -86,7 +102,10 @@ export function getColors(domainType) {
     domainType.includes('conserved site') || // https://www.google.com/search?q=pymol+conserved+site+color&tbm=isch
     domainType.includes('conserved domain') ||
     domainType === 'WGR domain' ||
-    domainType === 'R3H domain'
+    domainType === 'R3H domain' ||
+    domainType.includes('QLQ') ||
+    domainType === 'Sema domain' ||
+    domainType.includes('catalytic domain')
   ) {
     return [magenta, magentaLines];
   } else if (
@@ -97,12 +116,12 @@ export function getColors(domainType) {
     domainType === 'BRCA1, serine-rich domain' ||
     domainType === 'Tower domain' || // Important in BRCA2
     domainType.endsWith('attachment site') ||
-    domainType.endsWith('amyloid-beta peptide')
+    domainType.endsWith('amyloid-beta peptide') ||
+    domainType === 'Reverse transcriptase domain'
   ) {
     return [red, redLines];
   } else if (
-    // Enzymatic domains, C-terminal regions, and misnellaneou
-    domainType.includes('catalytic domain') ||
+    // Enzymatic domains, C-terminal regions, and miscellaneous
     domainType.includes('kinase domain') ||
     domainType === 'PIK-related kinase, FAT' ||
     domainType.includes('trypsin domain') ||
@@ -132,13 +151,21 @@ export function getColors(domainType) {
     domainType.includes('Serpin domain') ||
     domainType === 'Peptidase C14,  p20 domain' ||
     domainType === 'PWWP domain' ||
-    domainType === 'GPCR, rhodopsin-like, 7TM' ||
     domainType === 'Peptidoglycan binding-like' ||
     domainType === 'MAD homology 1, Dwarfin-type' ||
     domainType === 'F-actin binding' ||
-    domainType.includes('Glycoside hydrolase') && domainType.endsWith('domain') ||
+    (
+      domainType.includes('Glycoside hydrolase') &&
+      domainType.endsWith('domain')
+    ) ||
     domainType === 'p53 tumour suppressor family' ||
-    domainType === 'Pointed domain'
+    domainType === 'Pointed domain' ||
+    domainType.includes('DNA binding') ||
+    domainType === 'Helix-hairpin-helix domain' ||
+    domainType === 'Rad52 family' ||
+    domainType === 'Oxidoreductase FAD/NAD(P)-binding' ||
+    domainType.includes('Bromo adjacent') ||
+    domainType === 'HARP domain'
   ) {
     return [blue, blueLines];
   } else if (
@@ -156,7 +183,8 @@ export function getColors(domainType) {
     domainType.includes('OB1') ||
     domainType.includes('OB3') ||
     domainType.includes('OB domain') ||
-    domainType === 'Fork head domain'
+    domainType === 'Fork head domain' ||
+    domainType === 'Histone deacetylase domain'
   ) {
     return [lightBlue, lightBlueLine];
   } else if (
@@ -177,7 +205,11 @@ export function getColors(domainType) {
     domainType === 'Ets domain' ||
     domainType === 'P domain' ||
     domainType.includes('bHLH') ||
-    domainType === 'Ras-associating (RA) domain'
+    domainType === 'Ras-associating (RA) domain' ||
+    domainType ===
+      'Calcium/calmodulin-dependent protein kinase II, association-domain' ||
+    domainType === 'Bromodomain' ||
+    domainType === 'SLIDE domain'
   ) {
     return [deepBlue, deepBlueLines];
   } else if (
@@ -194,16 +226,20 @@ export function getColors(domainType) {
     domainType === 'Amino acid/polyamine transporter I' ||
     domainType === 'Peptidase M10, metallopeptidase' ||
     domainType === 'Metallothionein' ||
+    domainType === 'DDHD domain' ||
     domainType === 'Zinc finger C2H2-type' ||
     domainType === 'Zinc finger, PARP-type' ||
     domainType.endsWith('tail domain') ||
     domainType === 'SET domain' ||
     domainType.includes('transactivation domain 2') ||
-    domainType === 'Phosphopantetheine binding ACP domain'
+    domainType === 'Phosphopantetheine binding ACP domain' ||
+    domainType === 'Multicopper oxidase, second cupredoxin domain' ||
+    domainType === 'Helicase, C-terminal'
   ) {
     return [green, greenLines];
   } else if (
     domainType === 'SH3 domain' ||
+    domainType === 'Variant SH3 domain' ||
     domainType.includes('copper-binding') ||
     domainType === 'Sushi/SCR/CCP domain' ||
     domainType.includes('Receptor L-domain') ||
@@ -212,6 +248,7 @@ export function getColors(domainType) {
     domainType.includes('Interleukin') && domainType.includes('family') ||
     domainType === 'Sirtuin family, catalytic core domain' ||
     domainType === 'Amine oxidase' ||
+    domainType.includes('peroxidase') ||
     domainType.includes('lid domain') ||
     domainType.includes('prodomain') ||
     domainType === 'Pre-SET domain' ||
@@ -220,7 +257,9 @@ export function getColors(domainType) {
     domainType.includes('esterase') ||
     domainType.endsWith('Claudin superfamily') ||
     domainType === 'Retinoblastoma-associated protein, A-box' ||
-    domainType.includes('Between PH and SH2')
+    domainType.includes('Between PH and SH2') ||
+    domainType === 'Chromogranin A/B/C' ||
+    domainType.includes('Helicase')
   ) {
     return [seafoam, seafoamLines];
   }
@@ -233,7 +272,9 @@ export function getColors(domainType) {
     domainType.endsWith('phosphatase domain') ||
     domainType === 'Class I myosin tail homology domain' ||
     domainType === 'Myosin tail' ||
-    domainType === 'Acyl transferase'
+    domainType === 'Acyl transferase' ||
+    domainType === 'Sodium/solute symporter' ||
+    domainType.includes('foci domain')
   ) {
     return [pink, pinkLine];
   } else if (
@@ -241,16 +282,19 @@ export function getColors(domainType) {
     domainType === 'CD20-like family' ||
     domainType === 'Calponin homology domain' ||
     domainType.includes('ATPase') ||
+    domainType.includes('ATP coupling domain') ||
     domainType.includes('globular domain') ||
     domainType === 'Mitochondrial substrate/solute carrier' ||
     domainType === 'Major facilitator,  sugar transporter-like' ||
+    domainType === 'Major facilitator, sugar transporter-like' ||
     domainType === 'Sodium:neurotransmitter symporter' ||
     domainType === 'Fibronectin type III' ||
     domainType === 'Myosin head, motor domain' ||
     domainType.startsWith('Methyltransferase') ||
     domainType === 'Rhodanese-like domain' ||
     domainType.startsWith('Thyroglobulin') ||
-    domainType === 'Retinoblastoma-associated protein, B-box'
+    domainType === 'Retinoblastoma-associated protein, B-box' ||
+    domainType === 'C-type lectin-like'
   ) {
     return [veryLightPurple, veryLightPurpleLine];
   } else if (
@@ -261,10 +305,15 @@ export function getColors(domainType) {
     domainType.includes('ectodomain') ||
     domainType.endsWith('receptor domain') ||
     domainType.endsWith('receptor domain 4') ||
+    domainType === 'MAM domain' ||
+    domainType === 'IPT domain' ||
     domainType.endsWith('extracellular') ||
     domainType === 'WW domain' ||
     domainType.includes('MHC class II') && !domainType.includes('C-terminal') ||
-    domainType === 'TNFR/NGFR cysteine-rich region'
+    domainType === 'TNFR/NGFR cysteine-rich region' ||
+    domainType === 'Frizzled domain' ||
+    domainType === 'Netrin module, non-TIMP type' ||
+    domainType === 'CFTR regulator domain'
   ) {
     return [lightPurple, lightPurpleLine];
   } else if (
@@ -296,7 +345,11 @@ export function getColors(domainType) {
     domainType === 'PAS domain' ||
     domainType === 'PAS fold' ||
     domainType === 'Polyketide synthase, dehydratase domain' ||
-    domainType === 'G-patch domain'
+    domainType === 'Flavodoxin/nitric oxide synthase' ||
+    domainType === 'G-patch domain' ||
+    domainType === 'GPCR, rhodopsin-like, 7TM' ||
+    domainType === 'GPCR, family 2, secretin-like' ||
+    domainType === 'Chromo domain'
   ) {
     return [orange, orangeLines];
   } else if (
@@ -315,9 +368,16 @@ export function getColors(domainType) {
     domainType === 'MCM domain' ||
     domainType.endsWith('reductase-like') ||
     domainType === 'Lipase' ||
-    domainType === 'Phospholipase A2 domain'
+    domainType === 'Phospholipase A2 domain' ||
+    domainType === 'Notch domain' ||
+    domainType.includes('LCCL domain') ||
+    domainType.includes('SANT-like')
   ) {
     return [lightBrown, lightBrownLine];
+  } else if (
+    domainType === 'Notch, NOD domain'
+  ) {
+    return [brown, brownLine];
   } else if (
     // Transmembrane, etc.
     domainType.includes('transmembrane domain') ||
@@ -326,16 +386,21 @@ export function getColors(domainType) {
     domainType.includes('cytoplasmic domain') ||
     domainType.includes('membrane glycoprotein') ||
     domainType === 'CD36 family' ||
-    domainType == 'Hypoxia-inducible factor, alpha subunit' ||
+    domainType === 'Hypoxia-inducible factor, alpha subunit' ||
+    domainType === 'Hypoxia-inducible factor, alpha subunit-like' ||
     domainType === 'PKD domain' ||
     domainType.includes('regulatory domain') ||
     domainType.endsWith('E2 domain') ||
-    domainType === 'PLAT/LH2 domain'
+    domainType === 'PLAT/LH2 domain' ||
+    domainType === 'Notch, NODP domain' ||
+    domainType === 'Syndecan/Neurexin domain' ||
+    domainType === 'Zona pellucida domain'
   ) {
-    return [brown, brownLine];
+    return [darkBrown, darkBrownLine];
   } else if (
-    // Death, ubiquitination
+    // Death, ubiquitination, apoptosis, etc.
     domainType === 'CARD domain' ||
+    domainType === 'DAPIN domain' ||
     domainType === 'Death effector domain' ||
     domainType === 'Death domain' ||
     domainType === 'Ubiquitin-associated domain' ||
@@ -343,7 +408,8 @@ export function getColors(domainType) {
     domainType.includes('unknown function') ||
     domainType.startsWith('Uncharacterised') ||
     domainType.toLowerCase().includes('ubiquitin-like domain') ||
-    domainType.includes('necrosis')
+    domainType.includes('necrosis') ||
+    domainType.includes('Bcl-2')
   ) {
     return [darkGrey, darkGreyLine];
   } else if (
@@ -370,11 +436,13 @@ export function getColors(domainType) {
   } else if (
     domainType.toLowerCase().includes('zinc finger') ||
     domainType.toLowerCase().includes('transcription factor') ||
+    domainType === 'BRK domain' ||
     domainType.includes('FAD-binding')
   ) {
     return [green, greenLines];
   } else if (
-    domainType.endsWith('receptor')
+    domainType.endsWith('receptor') ||
+    domainType.includes('cysteine rich')
   ) {
     return [lightPurple, lightPurpleLine];
   } else if (

--- a/src/js/kit/protein-color.js
+++ b/src/js/kit/protein-color.js
@@ -177,6 +177,7 @@ export function getColors(domainType) {
     domainType.endsWith('head') ||
     domainType.endsWith('C2 domain') ||
     domainType === 'Pleckstrin homology domain' ||
+    domainType === 'DEP domain' ||
     domainType === 'Post-SET domain' ||
     domainType.includes('Glycoside hydrolase') ||
     domainType === 'Pyridoxal phosphate-dependent decarboxylase' ||
@@ -242,7 +243,6 @@ export function getColors(domainType) {
     domainType === 'Variant SH3 domain' ||
     domainType.includes('copper-binding') ||
     domainType === 'Sushi/SCR/CCP domain' ||
-    domainType.includes('Receptor L-domain') ||
     domainType.includes('Coagulation factor 5/8') ||
     domainType === 'Basic-leucine zipper domain' ||
     domainType.includes('Interleukin') && domainType.includes('family') ||
@@ -259,12 +259,11 @@ export function getColors(domainType) {
     domainType === 'Retinoblastoma-associated protein, A-box' ||
     domainType.includes('Between PH and SH2') ||
     domainType === 'Chromogranin A/B/C' ||
-    domainType.includes('Helicase')
+    domainType.includes('Helicase') ||
+    domainType.endsWith('pro-domain')
   ) {
     return [seafoam, seafoamLines];
-  }
-
-  else if (
+  } else if (
     // Immunoglobulin domains are colored in the pink-purple spectrum
     domainType === 'Immunoglobulin-like domain' ||
     domainType === 'Major facilitator superfamily domain' ||
@@ -274,11 +273,14 @@ export function getColors(domainType) {
     domainType === 'Myosin tail' ||
     domainType === 'Acyl transferase' ||
     domainType === 'Sodium/solute symporter' ||
-    domainType.includes('foci domain')
+    domainType.includes('foci domain') ||
+    domainType.includes('Receptor L-domain') ||
+    domainType === 'Wnt'
   ) {
     return [pink, pinkLine];
   } else if (
     domainType === 'Immunoglobulin' ||
+    domainType === 'Immunoglobulin domain' ||
     domainType === 'CD20-like family' ||
     domainType === 'Calponin homology domain' ||
     domainType.includes('ATPase') ||
@@ -288,7 +290,6 @@ export function getColors(domainType) {
     domainType === 'Major facilitator,  sugar transporter-like' ||
     domainType === 'Major facilitator, sugar transporter-like' ||
     domainType === 'Sodium:neurotransmitter symporter' ||
-    domainType === 'Fibronectin type III' ||
     domainType === 'Myosin head, motor domain' ||
     domainType.startsWith('Methyltransferase') ||
     domainType === 'Rhodanese-like domain' ||
@@ -317,15 +318,18 @@ export function getColors(domainType) {
   ) {
     return [lightPurple, lightPurpleLine];
   } else if (
+    domainType === 'Fibronectin type III' ||
     domainType === 'Immunoglobulin C2-set' ||
     domainType.includes('immunoglobulin C2-set') ||
     domainType.includes('protein interaction') ||
-    domainType.includes('interacting')
+    domainType.includes('interacting') ||
+    domainType === 'Dishevelled protein domain'
   ) {
     return [purple, purpleLine];
   } else if (
     domainType === 'Immunoglobulin V-set domain' ||
-    domainType.includes('MHC class I') && !domainType.includes('C-terminal')
+    domainType.includes('MHC class I') && !domainType.includes('C-terminal') ||
+    domainType === 'Frizzled/Smoothened, 7TM'
   ) {
     return [darkPurple, darkPurpleLine];
   } else if (domainType === 'Immunoglobulin I-set') {
@@ -341,6 +345,7 @@ export function getColors(domainType) {
     domainType.startsWith('von Willebrand factor') ||
     domainType.endsWith('merisation domain') || // e.g. di- / tetramerisation
     domainType.endsWith('merisation motif') || // e.g. di- / tetramerisation
+    domainType === 'DIX domain' ||
     domainType === 'Ferritin-like diiron domain' ||
     domainType === 'PAS domain' ||
     domainType === 'PAS fold' ||
@@ -349,7 +354,8 @@ export function getColors(domainType) {
     domainType === 'G-patch domain' ||
     domainType === 'GPCR, rhodopsin-like, 7TM' ||
     domainType === 'GPCR, family 2, secretin-like' ||
-    domainType === 'Chromo domain'
+    domainType === 'Chromo domain' ||
+    domainType === 'Cytochrome P450'
   ) {
     return [orange, orangeLines];
   } else if (

--- a/src/js/kit/protein.js
+++ b/src/js/kit/protein.js
@@ -97,11 +97,11 @@ function getFeatureSvg(feature, cds, isPositiveStrand, hasTopology) {
 
   // Perhaps make these configurable, later
   let y = 40;
-  let height = 10;
+  let height = 14;
   const isTopology = isTopologyFeature(feature);
   let topoAttr = '';
   if (hasTopology) {
-    y = 50;
+    y = 48;
     if (isTopology) {
       featureType = featureType.slice(4);
       y = 40;
@@ -133,7 +133,7 @@ function getFeatureSvg(feature, cds, isPositiveStrand, hasTopology) {
 
   const [color, lineColor] = getColors(featureType);
 
-  const addTopBottom = hasTopology && !isTopology;
+  const addTopBottom = !isTopology;
   const line =
     getFeatureBorderLines(x, y, width, height, lineColor, addTopBottom);
   const domainSvg =
@@ -156,13 +156,13 @@ function isEligibleforProteinSvg(gene, ideo) {
 }
 
 function getProteinRect(cds, hasTopology) {
-  const y = hasTopology ? '53.5' : '43.5';
+  const y = hasTopology ? '53' : '45';
   const fill = hasTopology ? 'BBB' : 'DDD';
-  const stroke = hasTopology ? '555' : 'CCC';
+  const stroke = hasTopology ? '555' : '777';
   const proteinRect =
     `<rect class="_ideoProteinLine"` +
       `x="${cds.px.start}" width="${cds.px.length}" ` +
-      `y="${y}" height="3" ` +
+      `y="${y}" height="4" ` +
       `fill="#${fill}" ` +
       `stroke="#${stroke}" ` +
     `/>`;

--- a/src/js/kit/protein.js
+++ b/src/js/kit/protein.js
@@ -155,6 +155,20 @@ function isEligibleforProteinSvg(gene, ideo) {
   );
 }
 
+function getProteinRect(cds, hasTopology) {
+  const y = hasTopology ? '53.5' : '43.5';
+  const fill = hasTopology ? 'BBB' : 'DDD';
+  const stroke = hasTopology ? '555' : 'CCC';
+  const proteinRect =
+    `<rect class="_ideoProteinLine"` +
+      `x="${cds.px.start}" width="${cds.px.length}" ` +
+      `y="${y}" height="3" ` +
+      `fill="#${fill}" ` +
+      `stroke="#${stroke}" ` +
+    `/>`;
+  return proteinRect;
+}
+
 /** Get SVG showing 2D protein features, e.g. domains from InterPro */
 export function getProteinSvg(
   structureName, subparts, isPositiveStrand, ideo
@@ -176,16 +190,24 @@ export function getProteinSvg(
 
   const hasTopology = domains.some(d => isTopologyFeature(d));
 
+  const topologies = [];
   for (let i = 0; i < domains.length; i++) {
     const domain = domains[i];
     const isTopology = isTopologyFeature(domain);
     const svg = getFeatureSvg(domain, cds, isPositiveStrand, hasTopology);
-    features.push([svg, isTopology]);
+    if (isTopology) {
+      topologies.push(svg);
+    } else {
+      features.push(svg);
+    }
   }
 
-  // Sort non-topology features last, so they're on top
-  features =
-    features.sort((a, b) => (a[1] === b[1])? 0 : a[1]? -1 : 1).map(e => e[0]);
+  // Order SVG so protein domains, sites, etc. are in front,
+  // then unannotated protein,
+  // then protein topology features
+  const proteinRect = getProteinRect(cds, hasTopology);
+  topologies.push(proteinRect);
+  features = topologies.concat(features);
 
   const proteinSvg =
     `<g id="_ideoProtein">${features.join('')}</g>`;


### PR DESCRIPTION
This refines protein diagrams to visually connect and polish biological features, clarifying the graphics for biologists.

Previously, protein features were small and unconnected to each other.  That's common for linear diagrams of proteins, but it's not ideal.  The diagrams represent a _contiguous_ molecule, not merely a series of features.  So now, protein diagrams in Ideogram.js have a visually diminutive but clear line that runs through the entire length of the protein.  This emphasizes the real continuity of the molecule.  It also often reveals that e.g. proteins often don't end where their Pfam entries end.

Features are now also larger.  New top and bottom borders visually distinguish the protein.  Missing Pfam entries were fixed, and many features were color-mapped.  Altogether, this graphical polish makes the protein biology notably clearer.

Here is how it looks.

### LDLR far before
In v1.42.0:
<img width="879" alt="LDLR_without_protein_topology__Ideogram_2023-06-24" src="https://github.com/eweitz/ideogram/assets/1334561/d089fd57-9b56-42f3-98d9-cd470059bccd">

### LDLR soon before
Immediately preceding look:
<img width="885" alt="LDLR_with_protein_topology__Ideogram_2023-06-24" src="https://github.com/eweitz/ideogram/assets/1334561/968e93ad-fa3c-4c00-a539-3dac47571d37">

### LDLR after
With changes described above:
<img width="864" alt="LDLR_with_unfeatured_regions__Ideogram_2023-07-10" src="https://github.com/eweitz/ideogram/assets/1334561/53421767-7177-4034-9c08-41d47650d8ea">

### PSCK9 far before
In v1.42.0:
<img width="750" alt="PSCK9_as_of_v1-42-0__Ideogram_2023-07-10" src="https://github.com/eweitz/ideogram/assets/1334561/aae5754d-cf7c-4f6b-b263-351b05b58355">

### PSCK9 after
With changes described above:
<img width="758" alt="PSCK9_with_unfeatured_regions__Ideogram_2023-07-10" src="https://github.com/eweitz/ideogram/assets/1334561/8ee544db-ba50-454a-9e07-80c93650cc03">

### PSCK7 far before
In v1.42.0:
<img width="753" alt="PSCK7_as_of_v1-42-0__Ideogram_2023-07-10" src="https://github.com/eweitz/ideogram/assets/1334561/c8fcb9aa-6e6f-4013-9e0c-5cfba8b2dccf">

### PSCK7 after
With changes described above:
<img width="754" alt="PSCK7_with_unfeatured_regions__Ideogram_2023-07-10" src="https://github.com/eweitz/ideogram/assets/1334561/4ff9e5a7-57cd-4702-b2ac-458275eec926">
