### PR TITLE
Enable interactive legend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # ideogram
 
-[![Build Status](https://api.travis-ci.com/eweitz/ideogram.svg?branch=master)](https://app.travis-ci.com/github/eweitz/ideogram)
-[![Coverage Status](https://coveralls.io/repos/github/eweitz/ideogram/badge.svg)](https://coveralls.io/github/eweitz/ideogram)
+[Ideogram.js](https://eweitz.github.io/ideogram/) is a JavaScript library for [chromosome visualization](https://speakerdeck.com/eweitz/designing-genome-visualizations-with-ideogramjs).
 
-[Ideogram.js](https://eweitz.github.io/ideogram/) is a JavaScript library for [chromosome visualization](https://speakerdeck.com/eweitz/designing-genome-visualizations-with-ideogramjs). 
-
-Ideogram supports drawing and animating genome-wide datasets for [human](https://eweitz.github.io/ideogram/human), [mouse](https://eweitz.github.io/ideogram/mouse), and [many other eukaryotes](https://eweitz.github.io/ideogram/eukaryotes).  The [Ideogram API](https://github.com/eweitz/ideogram/blob/master/api.md) for annotations supports [histograms](https://eweitz.github.io/ideogram/annotations-histogram), [heatmaps](https://eweitz.github.io/ideogram/annotations-heatmap), [overlays](https://eweitz.github.io/ideogram/annotations-overlaid), and points of arbitrary shape and color layered in [tracks](https://eweitz.github.io/ideogram/annotations-tracks). Ideogram can depict haploid, [diploid](https://eweitz.github.io/ideogram/ploidy-basic) or higher ploidy genomes (e.g. plants), as well as aneuploidy, [genetic recombination](https://eweitz.github.io/ideogram/ploidy-recombination), and [homologous features](https://eweitz.github.io/ideogram/homology-basic) between chromosomes. 
+Ideogram supports drawing and animating genome-wide datasets for [human](https://eweitz.github.io/ideogram/human), [mouse](https://eweitz.github.io/ideogram/mouse), and [many other eukaryotes](https://eweitz.github.io/ideogram/eukaryotes).  The [Ideogram API](https://github.com/eweitz/ideogram/blob/master/api.md) for annotations supports [histograms](https://eweitz.github.io/ideogram/annotations-histogram), [heatmaps](https://eweitz.github.io/ideogram/annotations-heatmap), [overlays](https://eweitz.github.io/ideogram/annotations-overlaid), and points of arbitrary shape and color layered in [tracks](https://eweitz.github.io/ideogram/annotations-tracks). Ideogram can depict haploid, [diploid](https://eweitz.github.io/ideogram/ploidy-basic) or higher ploidy genomes (e.g. plants), as well as aneuploidy, [genetic recombination](https://eweitz.github.io/ideogram/ploidy-recombination), and [homologous features](https://eweitz.github.io/ideogram/homology-basic) between chromosomes.
 
 Ideogram can be embedded as a [reusable component](https://github.com/eweitz/ideogram#usage) in any web page or application, and leverages D3.js and SVG to achieve fast, crisp client-side rendering. You can also integrate Ideogram with JavaScript frameworks like [Angular](https://github.com/eweitz/ideogram/tree/master/examples/angular), [React](https://github.com/eweitz/ideogram/tree/master/examples/react), and [Vue](https://github.com/eweitz/ideogram/tree/master/examples/vue), as well as data science platforms like [R](https://github.com/eweitz/ideogram/tree/master/examples/r) and [Jupyter Notebook](https://github.com/eweitz/ideogram/tree/master/examples/jupyter).
 
@@ -63,7 +60,7 @@ import Ideogram from 'ideogram';
 
 Many more usage examples are available at https://eweitz.github.io/ideogram/.
 
-You can also find examples of integrating Ideogram with JavaScript frameworks like [Angular](https://github.com/eweitz/ideogram/tree/master/examples/angular), [React](https://github.com/eweitz/ideogram/tree/master/examples/react), and [Vue](https://github.com/eweitz/ideogram/tree/master/examples/vue), as well as data science platforms like [R](https://github.com/eweitz/ideogram/tree/master/examples/r) and [Jupyter Notebook](https://github.com/eweitz/ideogram/tree/master/examples/jupyter). 
+You can also find examples of integrating Ideogram with JavaScript frameworks like [Angular](https://github.com/eweitz/ideogram/tree/master/examples/angular), [React](https://github.com/eweitz/ideogram/tree/master/examples/react), and [Vue](https://github.com/eweitz/ideogram/tree/master/examples/vue), as well as data science platforms like [R](https://github.com/eweitz/ideogram/tree/master/examples/r) and [Jupyter Notebook](https://github.com/eweitz/ideogram/tree/master/examples/jupyter).
 
 
 # API

--- a/examples/vanilla/gene-leads.html
+++ b/examples/vanilla/gene-leads.html
@@ -208,8 +208,13 @@
     }
 
     /** Ideogram has no 3rd party analytics, but lets you easily hook in your own */
-    function reportRelatedGenes() {
+    function reportFoundGenes() {
       console.log(this.relatedGenesAnalytics)
+    }
+
+    /** Ideogram has no 3rd party analytics, but lets you easily hook in your own */
+    function reportLegendMetrics() {
+      console.log('Hovered legend')
     }
 
     /** Upon clicking a triangular annotation or tooltip, plot that gene */
@@ -239,7 +244,8 @@
       container: '#ideogram-container',
       // fontFamily: "'Montserrat', sans-serif",
       onLoad: plotGeneFromUrl,
-      onPlotRelatedGenes: reportRelatedGenes,
+      onPlotFoundGenes: reportFoundGenes,
+      onHoverLegend: reportLegendMetrics,
       showGeneStructureInTooltip: true,
       showProteinInTooltip: true,
       onClickAnnot

--- a/src/js/annotations/labels.js
+++ b/src/js/annotations/labels.js
@@ -378,7 +378,7 @@ function getIsYOverlap(o, n, p) {
 }
 
 /** Label as many annotations as possible, without overlap */
-function fillAnnotLabels(sortedAnnots=[]) {
+function fillAnnotLabels(sortedAnnots=[], numLabels=10) {
   const ideo = this;
 
   sortedAnnots = deepCopy(sortedAnnots); // copy by value
@@ -447,7 +447,6 @@ function fillAnnotLabels(sortedAnnots=[]) {
     spacedLayouts.push(layout);
   });
 
-  let numLabels = 10;
   const config = ideo.config;
   if (
     'relatedGenesMode' in config &&

--- a/src/js/annotations/legend.js
+++ b/src/js/annotations/legend.js
@@ -7,7 +7,7 @@
 import {d3, getTextSize, round} from '../lib';
 
 var legendStyle =
-  '#_ideogramLegend {font: 12px Arial; overflow: auto;} ' +
+  '#_ideogramLegend {font: 12px Arial; overflow: auto; cursor: default;} ' +
   '#_ideogramLegend svg {float: left;} ' +
   '#_ideogramLegend ul {' +
     'position: relative; left: -14px; list-style: none; float: left; ' +

--- a/src/js/kit/gene-structure.js
+++ b/src/js/kit/gene-structure.js
@@ -77,7 +77,6 @@ const css =
     font-style: italic;
   }
   ${tippyCss}
-  ${tippyLightCss}
 
   .tippy-box {
     font-size: 12px;

--- a/src/js/kit/protein-color.js
+++ b/src/js/kit/protein-color.js
@@ -222,7 +222,8 @@ export function getColors(domainType) {
     domainType.includes('eIF-4 gamma, MA3') || // e.g. PDCD4
     domainType === 'Troponin' || // e.g. TNNT1
     domainType === 'SKI/SNO/DAC domain' || // SKIL gene
-    domainType.toLowerCase().includes('large ribosom') // RPLP0
+    domainType.toLowerCase().includes('large ribosom') || // RPLP0
+    domainType.includes('KA1') // e.g. MARK2
   ) {
     return [redderFaintRed, redderFaintRedLine];
   } else if (
@@ -365,6 +366,7 @@ export function getColors(domainType) {
     domainType === 'Phosphopantetheine binding ACP domain' ||
     domainType === 'Multicopper oxidase, second cupredoxin domain' ||
     domainType === 'Helicase, C-terminal' ||
+    domainType.includes('presequence') || // e.g. ALAS2
     domainType.endsWith('CC3') // e.g. PRKDC
   ) {
     return [green, greenLine];
@@ -404,6 +406,7 @@ export function getColors(domainType) {
     domainType.includes(' activation domain') ||
     domainType.includes('activating region') ||
     domainType === 'Thioesterase' ||
+    domainType.toLowerCase().includes('thiored') || // e.g. TXNDC12
     domainType.includes('esterase') ||
     domainType.endsWith('Claudin superfamily') ||
     domainType === 'Retinoblastoma-associated protein, A-box' ||
@@ -429,6 +432,7 @@ export function getColors(domainType) {
     domainType.includes('PB1') ||
     domainType.includes('multifunctional domain') ||
     domainType.includes('MutS, core') ||
+    domainType === 'RAP domain' || // RNA-binding, e.g. FASTK
     domainType.endsWith('CC5') // e.g. PRKDC
   ) {
     return [seafoam, seafoamLine];
@@ -837,7 +841,9 @@ export function getColors(domainType) {
   ) {
     return [magenta, magentaLines];
   } else if (
-    domainType.includes(' TM ') // transmembrane, as in e.g. RYR1
+    domainType.includes('TM') || // transmembrane, as in e.g. RYR1
+    domainType.toLowerCase().includes('transmembrane') ||
+    domainType.toLowerCase().includes('trans-membrane')
   ) {
     return [darkBrown, darkBrownLine];
   } else if (

--- a/src/js/kit/protein.js
+++ b/src/js/kit/protein.js
@@ -220,7 +220,7 @@ function getProteinRect(cds, hasTopology) {
  * Example: LDLR
  */
 export function getHasTopology(gene, ideo) {
-  const hasTopology = ideo.proteinCache[gene].some(entry => {
+  const hasTopology = ideo.proteinCache[gene]?.some(entry => {
     return entry.protein.some(
       feature => isTopologyFeature(feature)
     );

--- a/src/js/kit/protein.js
+++ b/src/js/kit/protein.js
@@ -134,7 +134,7 @@ function getFeatureSvg(feature, cds, isPositiveStrand, hasTopology) {
         // E.g. SCARB1-201 canonical isoform, C-terminal cytoplasmic domain
         !isPositiveStrand && featurePx.x + featurePx.width > cds.px.length + 3
       ) {
-        console.log(`Truncate protein topology feature: ${featureDigest}`);
+        console.debug(`Truncate protein topology feature: ${featureDigest}`);
         width -= (featurePx.x + featurePx.width) - cds.px.length;
         if (!isPositiveStrand) {
           x += width;
@@ -145,7 +145,7 @@ function getFeatureSvg(feature, cds, isPositiveStrand, hasTopology) {
       if (width < 0) {
         // E.g. LDLR-202 alternative isoform, multiple features
         const issue = 'Width < 0, omit protein topology feature';
-        console.log(`${issue}: ${featureDigest}`);
+        console.debug(`${issue}: ${featureDigest}`);
         return '';
       };
     }

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -671,7 +671,7 @@ function drawNeighborhoods(neighborhoodAnnots, ideo) {
 }
 
 /** Plot paralog neighborhoods */
-function overplotParalogs(annots, ideo) {
+function plotParalogNeighborhoods(annots, ideo) {
   if (!ideo.config.showParalogNeighborhoods) return;
 
   if (ideo.neighborhoodAnnots?.length > 0) {
@@ -965,15 +965,7 @@ function getTippyConfig() {
   };
 }
 
-function moveLegend(ideo, extraPad=0) {
-  const ideoInnerDom = document.querySelector('#_ideogramInnerWrap');
-  const decorPad = setRelatedDecorPad({}).legendPad;
-  const left = decorPad + 20 + extraPad;
-  const legendStyle = `position: absolute; top: 15px; left: ${left}px`;
-  const legend = document.querySelector('#_ideogramLegend');
-  ideoInnerDom.prepend(legend);
-  legend.style = legendStyle;
-
+function initInteractiveLegend(ideo) {
   // Highlight and filter annotations by type on hovering over legend entries
   function highlight(event) {
     const li = event.target;
@@ -1053,6 +1045,19 @@ function moveLegend(ideo, extraPad=0) {
     tippy('._ideoLegendEntry[data-tippy-content]', tippyConfig);
 }
 
+function moveLegend(ideo, extraPad=0) {
+  const ideoInnerDom = document.querySelector('#_ideogramInnerWrap');
+  const decorPad = setRelatedDecorPad({}).legendPad;
+  const left = decorPad + 20 + extraPad;
+  const legendStyle = `position: absolute; top: 15px; left: ${left}px`;
+
+  const legend = document.querySelector('#_ideogramLegend');
+  ideoInnerDom.prepend(legend);
+  legend.style = legendStyle;
+
+  initInteractiveLegend(ideo);
+}
+
 /** Filter annotations to only include those in configured list */
 function applyAnnotsIncludeList(annots, ideo) {
 
@@ -1079,7 +1084,7 @@ function processInteractions(annot, ideo) {
     finishPlotRelatedGenes('interacting', ideo);
 
     ideo.time.rg.interactions = timeDiff(t0);
-    overplotParalogs(annots, ideo);
+    plotParalogNeighborhoods(annots, ideo);
 
     resolve();
   });
@@ -1093,7 +1098,7 @@ function processParalogs(annot, ideo) {
     const annots = await fetchParalogs(annot, ideo);
     ideo.relatedAnnots.push(...annots);
     finishPlotRelatedGenes('paralogous', ideo);
-    overplotParalogs(annots, ideo);
+    plotParalogNeighborhoods(annots, ideo);
 
     ideo.time.rg.paralogs = timeDiff(t0);
 
@@ -1853,6 +1858,7 @@ function _initRelatedGenes(config, annotsInList) {
 
   const kitDefaults = Object.assign({
     showParalogNeighborhoods: true,
+    isLegendInteractive: true,
     relatedGenesMode: 'related',
     useCache: true,
     awaitCache: true

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -929,43 +929,11 @@ function highlightByType(li, ideo) {
   }
 }
 
-/** Persist a legend entry highlight:
- *
- * On click of entry that isn't highlight, dehighlight all, highlight clicked, persist
- * On click of entry that is highlighted, dehighlight all, remove persist
- *
- * On mouseout of entry, dehighlight all, but re-highlight persisted
- */
-function toggleHighlightByType(li, ideo) {
-
-  if (!li.getAttribute('data-persist-highlight')) {
-    // Toggle on
-    const persisted = document.querySelector('[data-persist-highlight]');
-    if (persisted) persisted.removeAttribute('data-persist-highlight');
-    highlightByType(li, ideo);
-    li.setAttribute('data-persist-highlight', true);
-  } else {
-    // Toggle off
-    li.removeAttribute('data-persist-highlight');
-    // const persistTypegetLegendType(li)
-    dehighlightAll(ideo, true);
-  }
-}
-
 /** Remove highlight / filter upon hovering out of legend entry */
-function dehighlightAll(ideo, preservePersisted=false) {
-
-  let persistedType;
-  if (preservePersisted) {
-    const persistedLi = document.querySelector('[data-persist-highlight]');
-    persistedType = getLegendType(persistedLi);
-  }
-
+function dehighlightAll(ideo) {
   document.querySelectorAll('#_ideogramLegend li').forEach(li => {
-    if (preservePersisted) {
-      li.style.color = 'black';
-      li.style.backgroundColor = 'white';
-    }
+    li.style.color = 'black';
+    li.style.backgroundColor = 'white';
   });
 
   ideo.flattenAnnots().forEach(annot => {
@@ -1013,16 +981,18 @@ function moveLegend(ideo, extraPad=0) {
     const li = event.target;
     return highlightByType(li, ideo);
   }
-  // Highlight and filter annotations by type on hovering over legend entries
-  function toggleHighlight(event) {
-    const li = event.target;
-    return toggleHighlightByType(li, ideo);
-  }
+  // // Highlight and filter annotations by type on hovering over legend entries
+  // WIP: 14373b18319e99febd91816fbc0c1b2e0f20f277
+  // function toggleHighlight(event) {
+  //   const li = event.target;
+  //   return toggleHighlightByType(li, ideo);
+  // }
   function dehighlight() {
     dehighlightAll(ideo);
   }
   document.querySelectorAll('#_ideogramLegend li').forEach(li => {
-    li.addEventListener('click', toggleHighlight);
+    // li.addEventListener('click', toggleHighlight);
+    // WIP: 14373b18319e99febd91816fbc0c1b2e0f20f277
     li.addEventListener('mouseenter', highlight);
     li.addEventListener('mouseleave', dehighlight);
 

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -993,7 +993,10 @@ function moveLegend(ideo, extraPad=0) {
       'interacting': 'Adjacent in a biochemical pathway, per WikiPathways',
       'paralogous': 'Evolutionarily related by a duplication event, per Ensembl'
     };
-    const tippy = `data-tippy-content="${tippyContentMap[legendType]}"`;
+    // const placement = 'data-tippy-placement="top-end"';
+    const placement = '';
+    const tippy =
+      `data-tippy-content="${tippyContentMap[legendType]}" ${placement}`;
     const reset = 'position: inherit; left: inherit';
     // const glossary = 'text-decoration: underline dashed;';
     // const style = `style="${glossary} ${reset}`;
@@ -1009,7 +1012,6 @@ function moveLegend(ideo, extraPad=0) {
   const css =
     `<style>
     ${tippyCss}
-    ${tippyLightCss}
 
     .tippy-box {
       font-size: 12px;
@@ -1022,6 +1024,8 @@ function moveLegend(ideo, extraPad=0) {
   const legendDom = document.querySelector('#_ideogramLegend');
   legendDom.insertAdjacentHTML('afterBegin', css);
   const tippyConfig = getTippyConfig();
+  tippyConfig.maxWidth = 180;
+  tippyConfig.offset = [-30, 10];
   ideo.legendTippy =
     tippy('._ideoLegendEntry[data-tippy-content]', tippyConfig);
 }

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -905,8 +905,7 @@ function getLegendEntryColor(li) {
 }
 
 /** Highlight / filter upon hovering over legend entry */
-function highlightByType(event, ideo) {
-  const li = event.target;
+function highlightByType(li, ideo) {
   li.style.color = '#00C';
   li.style.backgroundColor = '#EEF';
 
@@ -930,11 +929,43 @@ function highlightByType(event, ideo) {
   }
 }
 
+/** Persist a legend entry highlight:
+ *
+ * On click of entry that isn't highlight, dehighlight all, highlight clicked, persist
+ * On click of entry that is highlighted, dehighlight all, remove persist
+ *
+ * On mouseout of entry, dehighlight all, but re-highlight persisted
+ */
+function toggleHighlightByType(li, ideo) {
+
+  if (!li.getAttribute('data-persist-highlight')) {
+    // Toggle on
+    const persisted = document.querySelector('[data-persist-highlight]');
+    if (persisted) persisted.removeAttribute('data-persist-highlight');
+    highlightByType(li, ideo);
+    li.setAttribute('data-persist-highlight', true);
+  } else {
+    // Toggle off
+    li.removeAttribute('data-persist-highlight');
+    // const persistTypegetLegendType(li)
+    dehighlightAll(ideo, true);
+  }
+}
+
 /** Remove highlight / filter upon hovering out of legend entry */
-function dehighlightAll(ideo) {
+function dehighlightAll(ideo, preservePersisted=false) {
+
+  let persistedType;
+  if (preservePersisted) {
+    const persistedLi = document.querySelector('[data-persist-highlight]');
+    persistedType = getLegendType(persistedLi);
+  }
+
   document.querySelectorAll('#_ideogramLegend li').forEach(li => {
-    li.style.color = 'black';
-    li.style.backgroundColor = 'white';
+    if (preservePersisted) {
+      li.style.color = 'black';
+      li.style.backgroundColor = 'white';
+    }
   });
 
   ideo.flattenAnnots().forEach(annot => {
@@ -979,12 +1010,19 @@ function moveLegend(ideo, extraPad=0) {
 
   // Highlight and filter annotations by type on hovering over legend entries
   function highlight(event) {
-    return highlightByType(event, ideo);
+    const li = event.target;
+    return highlightByType(li, ideo);
+  }
+  // Highlight and filter annotations by type on hovering over legend entries
+  function toggleHighlight(event) {
+    const li = event.target;
+    return toggleHighlightByType(li, ideo);
   }
   function dehighlight() {
     dehighlightAll(ideo);
   }
   document.querySelectorAll('#_ideogramLegend li').forEach(li => {
+    li.addEventListener('click', toggleHighlight);
     li.addEventListener('mouseenter', highlight);
     li.addEventListener('mouseleave', dehighlight);
 

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -906,8 +906,7 @@ function getLegendEntryColor(li) {
 
 /** Highlight / filter upon hovering over legend entry */
 function highlightByType(li, ideo) {
-  li.style.color = '#00C';
-  li.style.backgroundColor = '#EEF';
+  li.classList += ' active';
 
   const selectedColor = getLegendEntryColor(li);
 
@@ -932,8 +931,7 @@ function highlightByType(li, ideo) {
 /** Remove highlight / filter upon hovering out of legend entry */
 function dehighlightAll(ideo) {
   document.querySelectorAll('#_ideogramLegend li').forEach(li => {
-    li.style.color = 'black';
-    li.style.backgroundColor = 'white';
+    li.classList.remove('active');
   });
 
   ideo.flattenAnnots().forEach(annot => {
@@ -979,7 +977,10 @@ function moveLegend(ideo, extraPad=0) {
   // Highlight and filter annotations by type on hovering over legend entries
   function highlight(event) {
     const li = event.target;
-    return highlightByType(li, ideo);
+    highlightByType(li, ideo);
+    if (ideo.onHoverLegendCallback) {
+      ideo.onHoverLegendCallback();
+    }
   }
   // // Highlight and filter annotations by type on hovering over legend entries
   // WIP: 14373b18319e99febd91816fbc0c1b2e0f20f277
@@ -998,8 +999,12 @@ function moveLegend(ideo, extraPad=0) {
 
     const legendType = getLegendType(li);
     const tippyContentMap = {
-      'interacting': 'Adjacent in a biochemical pathway, per WikiPathways',
-      'paralogous': 'Evolutionarily related by a duplication event, per Ensembl'
+      'interacting':
+        'Adjacent to searched gene in a biochemical pathway, ' +
+        'per WikiPathways',
+      'paralogous':
+        'Evolutionarily related to searched gene ' +
+        'by a duplication event, per Ensembl'
     };
     // const placement = 'data-tippy-placement="top-end"';
     const placement = '';
@@ -1027,6 +1032,16 @@ function moveLegend(ideo, extraPad=0) {
 
     .tippy-content {
       padding: 3px 7px;
+    }
+
+    #_ideogramLegend li {
+      padding-left: 5px;
+      border-radius: 2px;
+    }
+
+    #_ideogramLegend li.active {
+      color: #00C;
+      background-color: #EEF;
     }
     </style>`;
   const legendDom = document.querySelector('#_ideogramLegend');
@@ -1975,6 +1990,11 @@ function initSearchIdeogram(kitDefaults, config, annotsInList) {
   // Called upon completing last plot, including all related genes
   if (config.onPlotFoundGenes) {
     ideogram.onPlotFoundGenesCallback = config.onPlotFoundGenes;
+  }
+
+  // Called upon completing last plot, including all related genes
+  if (config.onHoverLegend) {
+    ideogram.onHoverLegendCallback = config.onHoverLegend;
   }
 
   ideogram.getTooltipAnalytics = getRelatedGenesTooltipAnalytics;


### PR DESCRIPTION
This adds an interactive legend to the [Related Genes](https://eweitz.github.io/ideogram/gene-leads?org=homo-sapiens&q=LDLR) kit.  It filters annotations by type, and defines the type in a tooltip.

Here's how it looks!

https://github.com/eweitz/ideogram/assets/1334561/a0d001cd-ed5b-4943-a43d-83884d1346ca

