### PR TITLE
Reframe tissue curves on hover, enriching expression comparison

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,6 +20,7 @@ module.exports = function(config) {
       'test/online/**.test.js',
       // 'test/online/related-genes.test.js',
       // 'test/offline/gene-structure.test.js',
+      // 'test/offline/tissue.test.js',
       {pattern: 'dist/data/**', watched: false, included: false, served: true, nocache: false}
     ],
 

--- a/scripts/python/cache/protein_cache.py
+++ b/scripts/python/cache/protein_cache.py
@@ -314,14 +314,12 @@ def sort_proteins(proteins, organism, canonical_ids):
         gene = "".join(protein[1].split('-')[:-1])
         proteins_with_genes.append([gene] + protein)
 
-
     doms = proteins_with_genes
     doms = sorted(
         doms,
         key=lambda d: d[1] in canonical_ids, reverse=True
     )
     proteins_with_genes = doms
-
 
     # Sort genes by interest rank, and put unranked genes last
     trimmed_proteins = sorted(

--- a/scripts/python/cache/tissue_cache.py
+++ b/scripts/python/cache/tissue_cache.py
@@ -101,7 +101,7 @@ def get_summary(expressions):
         if s > 0:
             summary.append(round(s, 2))
 
-    if len(summary) == 5:
+    if len(summary) >= 4:
         num_bins = 10
         size = (max - min) / num_bins
         quantile_counts = [0] * num_bins
@@ -246,6 +246,8 @@ def summarize_top_tissues_by_gene(input_dir):
                 summary = summary_by_gene_by_tissue[gene][tissue]
                 if len(summary) == 15: # 5 for box plot, 10 for KDE deciles
                     median = summary[2]
+                elif len(summary) == 14: # for minimum with a value of 0
+                    median = summary[1]
                 else:
                     median = 0
                 medians_by_tissue_index.append([tissue, median])
@@ -259,8 +261,8 @@ def summarize_top_tissues_by_gene(input_dir):
             ]
             for tissue in top_tissues_by_median:
                 summary = summary_by_gene_by_tissue[gene][tissue]
-                if len(summary) < 5:
-                    # Skip summaries that lack enough points for a median
+                if len(summary) < 4:
+                    # Skip summaries that where Q1 (or higher percentile) is 0
                     continue
                 summary = ';'.join([str(s) for s in summary])
                 if summary == '':

--- a/src/js/init/caches/cache-lib.js
+++ b/src/js/init/caches/cache-lib.js
@@ -93,9 +93,9 @@ export async function cacheFetch(url) {
     // If cache miss, then fetch, decompress, and put response in cache
     const rawResponse = await fetch(url);
     const blob = await rawResponse.blob();
-    const contentLength = blob.size;
     const uint8Array = new Uint8Array(await blob.arrayBuffer());
     const data = strFromU8(decompressSync(uint8Array));
+    const contentLength = data.length;
     const decompressedResponse = new Response(
       new Blob([data], {type: 'text/tab-separated-values'}),
       {headers: new Headers({'Content-Length': contentLength})}

--- a/src/js/init/caches/tissue-cache-worker.js
+++ b/src/js/init/caches/tissue-cache-worker.js
@@ -47,10 +47,8 @@ async function getTissueExpressions(gene, ideo) {
     const rawValues = rawExpressions[i].split(';');
     const numValues = rawValues.length;
     if (numValues === 15) {
-      console.log('rawValues 14', rawValues)
       rawValues.splice(1, 0, 0); // Insert number 0 at position 1
     } else if (numValues === 14) {
-      console.log('rawValues 13', rawValues)
       // Min. and Q1 are 0
       rawValues.splice(1, 0, 0);
       rawValues.splice(1, 0, 0);

--- a/src/js/init/caches/tissue-cache-worker.js
+++ b/src/js/init/caches/tissue-cache-worker.js
@@ -45,6 +45,16 @@ async function getTissueExpressions(gene, ideo) {
   const rawExpressions = geneDataLine.split('\t').slice(1);
   for (let i = 0; i < rawExpressions.length; i++) {
     const rawValues = rawExpressions[i].split(';');
+    const numValues = rawValues.length;
+    if (numValues === 15) {
+      console.log('rawValues 14', rawValues)
+      rawValues.splice(1, 0, 0); // Insert number 0 at position 1
+    } else if (numValues === 14) {
+      console.log('rawValues 13', rawValues)
+      // Min. and Q1 are 0
+      rawValues.splice(1, 0, 0);
+      rawValues.splice(1, 0, 0);
+    }
     const tissueId = rawValues[0];
     const boxMetrics = rawValues.slice(1, 6);
     const min = parseFloat(boxMetrics[0]);

--- a/src/js/kit/protein-color.js
+++ b/src/js/kit/protein-color.js
@@ -600,7 +600,8 @@ export function getColors(domainType) {
     domainType.includes('Citron') ||
     domainType === 'RIH domain' ||
     domainType.toLowerCase().includes('sclerostin') || // e.g. SOSTDC1
-    domainType === 'ZU5 domain' // e.g. TJP1
+    domainType === 'ZU5 domain' || // e.g. TJP1
+    domainType === 'Piezo domain' // e.g. PIEZO1
   ) {
     return [yellow, yellowLine];
   }
@@ -894,7 +895,9 @@ export function getColors(domainType) {
 
     domainType.includes('interacting') ||
 
-    domainType.includes('domain IV') // e.g. EEF2
+    domainType.includes('domain IV') || // e.g. EEF2
+
+    domainType.toLowerCase().includes('immunoglobulin domain')
   ) {
     return [purple, purpleLine];
   } else if (

--- a/src/js/kit/protein-color.js
+++ b/src/js/kit/protein-color.js
@@ -161,7 +161,8 @@ export function getColors(domainType) {
     domainType === 'Globin' ||
     domainType === 'GPS motif' ||
     domainType.includes('D-like') ||
-    domainType.toLowerCase().includes('insertion domain') // e.g. RPLP0
+    domainType.toLowerCase().includes('insertion domain') || // e.g. RPLP0
+    domainType === 'Macro domain' // e.g. MACROH2A1
   ) {
     return [magenta, magentaLines];
   } else if (
@@ -606,7 +607,8 @@ export function getColors(domainType) {
     domainType === 'RIH domain' ||
     domainType.toLowerCase().includes('sclerostin') || // e.g. SOSTDC1
     domainType === 'ZU5 domain' || // e.g. TJP1
-    domainType === 'Piezo domain' // e.g. PIEZO1
+    domainType === 'Piezo domain' || // e.g. PIEZO1
+    domainType === 'Histone H2A/H2B/H3' // e.g. H2AZ1
   ) {
     return [yellow, yellowLine];
   }
@@ -834,7 +836,8 @@ export function getColors(domainType) {
     domainType.includes('winged helix') ||
     domainType.toLowerCase().includes('dehydrogenase') ||
     domainType.includes('BAR') ||
-    domainType.includes('metal')
+    domainType.includes('metal') ||
+    domainType.includes('redoxin')
   ) {
     return [green, greenLine];
   } else if (

--- a/src/js/kit/protein-color.js
+++ b/src/js/kit/protein-color.js
@@ -226,7 +226,9 @@ export function getColors(domainType) {
     domainType === 'SKI/SNO/DAC domain' || // SKIL gene
     domainType.toLowerCase().includes('large ribosom') || // RPLP0
     domainType.includes('KA1') || // e.g. MARK2
-    domainType === 'V(D)J recombination-activating protein 1' // e.g. RAG1
+    domainType === 'V(D)J recombination-activating protein 1' || // e.g. RAG1
+    domainType.toLowerCase().includes('opiod') || // e.g. PDYN
+    domainType === 'Corticotropin-releasing factor' // e.g. CRH
   ) {
     return [redderFaintRed, redderFaintRedLine];
   } else if (
@@ -235,7 +237,8 @@ export function getColors(domainType) {
     domainType === 'HSR domain' ||
     domainType.includes('MutS, clamp') ||
     domainType.includes('S5 domain 2-like') || // e.g. MLH1 in ACMG
-    domainType.endsWith('CC1/2') // e.g. PRKDC
+    domainType.endsWith('CC1/2') || // e.g. PRKDC
+    domainType.includes('MUN') // e.g. UNC13C
   ) {
     return [darkGreen, darkGreenLine];
   } else if (
@@ -282,7 +285,8 @@ export function getColors(domainType) {
     domainType.endsWith('C2 domain') ||
     domainType.includes('tri-helix bundle domain') || // e.g. MYBPC3
     domainType.includes('Cx50') || // e.g. GJA8
-    domainType.includes('tyrosine-rich')
+    domainType.includes('tyrosine-rich') ||
+    domainType === 'Filaggrin' // e.g. FLG
   ) {
     return [blue, blueLine];
   } else if (
@@ -343,7 +347,8 @@ export function getColors(domainType) {
     domainType === 'Tuberin-type domain' ||
     domainType === 'Ras-like guanine nucleotide exchange factor, N-terminal' ||
     domainType.includes('factor-binding protein') || // as in IGFBP3
-    domainType.includes('GPD') // e.g. MUTYH in ACMG
+    domainType.includes('GPD') || // e.g. MUTYH in ACMG
+    domainType === 'ELM2 domain' // e.g. MTA2
   ) {
     return [darkBlue, darkBlueLine];
   } else if (
@@ -670,7 +675,8 @@ export function getColors(domainType) {
     domainType.includes('lipase') ||
     domainType.includes('CRAL') || // e.g. NF1
     domainType.includes('SAND') ||
-    domainType.toLowerCase().includes('HSP')
+    domainType.toLowerCase().includes('hsp') ||
+    domainType.toLowerCase().includes('bombesin') // e.g. GRP
   ) {
     return [lightBrown, lightBrownLine];
   } else if (
@@ -762,11 +768,14 @@ export function getColors(domainType) {
     domainType === 'BCL7' || // e.g. BCL7A
     domainType.endsWith('repeat ring region') || // e.g. TRRAP
 
+    domainType.includes('PANDER') || // e.g. FAM3C
+
     // GPCRs
     domainType === 'GPCR, rhodopsin-like, 7TM' ||
     domainType === 'GPCR, family 2, secretin-like' ||
     domainType === 'GPCR, family 3, nine cysteines domain' ||
-    domainType === 'G-protein coupled receptor'
+    domainType === 'G-protein coupled receptor' ||
+    domainType.toLowerCase().includes('orexin') // e.g. HCRTR2
   ) {
     return [darkOrange, darkOrangeLines];
   } else if (
@@ -858,7 +867,8 @@ export function getColors(domainType) {
     domainType.includes('endonuclease') ||
     domainType.toLowerCase().includes('splicing factor') ||
     domainType.toLowerCase().includes('interferon') ||
-    domainType === 'Tropomyosin' // e.g. TPM1
+    domainType === 'Tropomyosin' || // e.g. TPM1
+    domainType.includes('R1 domain') // e.g. MTA2
   ) {
     return [magenta, magentaLines];
   } else if (

--- a/src/js/kit/tissue.js
+++ b/src/js/kit/tissue.js
@@ -31,7 +31,7 @@ function refineTissueName(rawName) {
   return name;
 }
 
-function setPxOffset(tissueExpressions, maxPx=80, relative=true, leftPx=0) {
+function setPxOffset(tissueExpressions, maxPx=70, relative=true, leftPx=0) {
   let maxExpression = 0;
 
   const metrics = ['max', 'q3', 'median', 'q1', 'min'];
@@ -94,8 +94,8 @@ function getMoreOrLessToggle(gene, height, tissueExpressions, ideo) {
   const moreOrLess =
     !ideo.showTissuesMore ? `Less...` : 'More...';
   const mlStyle = 'style="cursor: pointer;px;"';
-  const left = `left: ${!ideo.showTissuesMore ? 10 : -41}px;`;
-  const top = 'top: -2px;';
+  const left = `left: ${!ideo.showTissuesMore ? 1 : -50}px;`;
+  const top = 'top: -1px;';
   const mltStyle =
     `style="position: relative; ${left} ${top} font-size: ${height}px"`
   const moreOrLessToggleHtml =
@@ -361,7 +361,7 @@ function addDetailedCurve(traceDom, ideo) {
   const tissueExpressions = ideo.tissueExpressionsByGene[gene];
 
   let teObject = tissueExpressions.find(t => t.tissue === tissue);
-  const maxWidthPx = 245; // Same width as RNA & protein diagrams
+  const maxWidthPx = 225; // Same width as RNA & protein diagrams
   const leftPx = 35;
   teObject = setPxOffset(
     [teObject], maxWidthPx, false, leftPx
@@ -389,11 +389,12 @@ function addDetailedCurve(traceDom, ideo) {
   const footer = document.querySelector('._ideoTooltipFooter');
   footer.style.display = 'none';
 
-  const style = 'style="position: relative; top: 2px; left: -5px;"';
-  const svgHeight = 116.5; // Keeps tooltip bottom flush with prior state
+  const svgHeight = 119.5; // Keeps tooltip bottom flush with prior state
+  const style = `style="position: relative; height: ${svgHeight}px"`;
+  const svgStyle = 'style="position: absolute; top: 2px; left: -5px;"';
   const container =
     `<div class="_ideoDistributionContainer" ${style}>` +
-    `<svg width="300px" height="${svgHeight}px">` +
+    `<svg width="280px" height="${svgHeight}px" ${svgStyle}>` +
     metricTicks +
     distributionCurve +
     medianLine +
@@ -407,7 +408,8 @@ function addDetailedCurve(traceDom, ideo) {
 
 /** Get mini distribution curves and  */
 function getExpressionPlotHtml(gene, tissueExpressions, ideo) {
-  tissueExpressions = setPxOffset(tissueExpressions);
+  const maxWidth = 48;
+  tissueExpressions = setPxOffset(tissueExpressions, maxWidth);
 
   const height = 12;
 
@@ -436,7 +438,7 @@ function getExpressionPlotHtml(gene, tissueExpressions, ideo) {
     // not merely the (potentially very small) diagram itself
     const containerAttrs =
       `height="${height + 2}" ` +
-      `width="80px" ` +
+      `width="${maxWidth}px" ` +
       'fill="#FFF" ' +
       'opacity="0" ' +
       `x="0" ` +
@@ -445,16 +447,19 @@ function getExpressionPlotHtml(gene, tissueExpressions, ideo) {
       dataTissue;
 
     const textAttrs =
-      `y="${y + height - 1.5}" ` +
+      `y="${y + height}" ` +
       `style="font-size: ${height}px;" ` +
-      'x="90" ' +
+      `x="${maxWidth + 10}" ` +
       dataTissue;
+
+    const curveWidth = offsetsWithHeight.max - offsetsWithHeight.min;
+    const refinedMedianLine = curveWidth > 8 ? medianLine : '';
 
     return (
       '<g>' +
       `<text ${textAttrs}>${tissue}</text>` +
       distributionCurve +
-      medianLine +
+      refinedMedianLine +
       `<rect ${containerAttrs} class="_ideoExpressionTrace" />` +
       '</g>'
     );
@@ -463,11 +468,12 @@ function getExpressionPlotHtml(gene, tissueExpressions, ideo) {
   const plotAttrs = `style="margin-top: 15px; margin-bottom: -15px;"`;
   const cls = 'class="_ideoTissuePlotTitle"';
   const titleAttrs = `${cls} style="margin-bottom: 4px;"`;
+  const style = `style="position: relative; left: 10px"`;
   const plotHtml =
     '<div>' +
       `<div class="_ideoTissueExpressionPlot" ${plotAttrs}>
         <div ${titleAttrs}>Reference expression by tissue:</div>
-        <svg height="${y + height + 2}">${rects}</svg>
+        <svg width="275" height="${y + height + 2}" ${style}>${rects}</svg>
         ${moreOrLessToggleHtml}
       </div>` +
     '</div>';
@@ -505,14 +511,11 @@ export function addTissueListeners(ideo) {
   }
 
   document.querySelectorAll('._ideoExpressionTrace').forEach(trace => {
-    const medianLine = trace.parentNode.querySelector('._ideoExpressionMedian');
     trace.addEventListener('mouseenter', () => {
-      medianLine.dispatchEvent(new Event('mouseenter'));
       colorTissueText(trace, '#338');
       addDetailedCurve(trace, ideo);
     });
     trace.addEventListener('mouseleave', () => {
-      medianLine.dispatchEvent(new Event('mouseleave'));
       colorTissueText(trace, '#000');
       removeDetailedCurve(trace, ideo);
     });

--- a/src/js/kit/tissue.js
+++ b/src/js/kit/tissue.js
@@ -332,7 +332,7 @@ function getMetricTicks(teObject, height) {
     `<text x="${minExpTextX}" y="${expTextY}" >${minExp}</text>`;
 
   const nameAttrs =
-    `x="${mid - 70}" y="${y + 46}"`;
+    `x="${mid - 40}" y="${y + 46}"`;
   const sampleAttrs =
     `x="${mid - 70}" y="${y + 59}"`;
 

--- a/src/js/kit/tissue.js
+++ b/src/js/kit/tissue.js
@@ -304,9 +304,6 @@ function getMetricTicks(teObject, height) {
 
   // Align "Median" to right of tick if text would clash with "Min."
   const isMinMedSoftCollide = minTextEndX >= medianX;
-  console.log('isMinMedSoftCollide', isMinMedSoftCollide)
-  console.log('minTextEndX', minTextEndX)
-  console.log('medianX', medianX)
   if (isMinMedSoftCollide) {
     medianX = median;
     medianExpX = median;
@@ -334,10 +331,6 @@ function getMetricTicks(teObject, height) {
     `<text x="${minTextX}" y="${textY}" >${minRawText}.</text>` +
     `<text x="${minExpTextX}" y="${expTextY}" >${minExp}</text>`;
 
-  console.log('isMinMedCollide', isMinMedCollide)
-  console.log('minTextEndX', minTextEndX)
-  console.log('medianX', medianX)
-
   const nameAttrs =
     `x="${mid - 70}" y="${y + 46}"`;
   const sampleAttrs =
@@ -348,7 +341,7 @@ function getMetricTicks(teObject, height) {
     minText +
     maxText +
     medianText +
-    `<text ${nameAttrs}>Expression distribution (TPM)</text>` +
+    `<text ${nameAttrs}>Expression (TPM)</text>` +
     `<text ${sampleAttrs}>Samples: ${teObject.samples} | Source: GTEx</text>` +
     `</g>`
   );
@@ -429,10 +422,6 @@ function getExpressionPlotHtml(gene, tissueExpressions, ideo) {
     const color = `#${teObject.color}`;
     const borderColor = adjustBrightness(color, 0.85);
 
-    const offsets = teObject.px;
-    const width = offsets.q3 - offsets.q1;
-    const x = offsets.q1;
-
     const [distributionCurve, offsetsWithHeight] = getCurve(
       teObject, y, height, color, borderColor
     );
@@ -441,13 +430,7 @@ function getExpressionPlotHtml(gene, tissueExpressions, ideo) {
       offsetsWithHeight, y, height, color
     );
 
-    const boxAttrs =
-      `height="${height - 0.5}" ` +
-      `width="${width}" ` +
-      `x="${x}" ` +
-      `y="${y}" ` +
-      `fill="${color}" ` +
-      `stroke="${borderColor}" stroke-width="1px" `;
+    const dataTissue = `data-tissue="${teObject.tissue}"`;
 
     // Invisible; enables tooltip upon hover anywhere in diagram area,
     // not merely the (potentially very small) diagram itself
@@ -459,21 +442,19 @@ function getExpressionPlotHtml(gene, tissueExpressions, ideo) {
       `x="0" ` +
       `y="${y}" ` +
       `data-gene="${gene}" ` +
-      `data-tissue="${teObject.tissue}"`;
+      dataTissue;
 
     const textAttrs =
       `y="${y + height - 1.5}" ` +
       `style="font-size: ${height}px;" ` +
-      'x="90"';
+      'x="90" ' +
+      dataTissue;
 
     return (
       '<g>' +
       `<text ${textAttrs}>${tissue}</text>` +
-      // whiskers.min +
-      // `<rect ${boxAttrs} />` +
       distributionCurve +
       medianLine +
-      // whiskers.max +
       `<rect ${containerAttrs} class="_ideoExpressionTrace" />` +
       '</g>'
     );
@@ -506,6 +487,12 @@ function updateTissueExpressionPlot(ideo) {
   addTissueListeners(ideo);
 }
 
+function colorTissueText(traceDom, color) {
+  const tissue = traceDom.getAttribute('data-tissue');
+  const tissueTextDom = document.querySelector(`text[data-tissue="${tissue}"]`);
+  tissueTextDom.setAttribute('fill', color);
+}
+
 export function addTissueListeners(ideo) {
   const moreOrLess = document.querySelector('._ideoMoreOrLessTissue');
   if (moreOrLess) {
@@ -521,10 +508,12 @@ export function addTissueListeners(ideo) {
     const medianLine = trace.parentNode.querySelector('._ideoExpressionMedian');
     trace.addEventListener('mouseenter', () => {
       medianLine.dispatchEvent(new Event('mouseenter'));
+      colorTissueText(trace, '#338');
       addDetailedCurve(trace, ideo);
     });
     trace.addEventListener('mouseleave', () => {
       medianLine.dispatchEvent(new Event('mouseleave'));
+      colorTissueText(trace, '#000');
       removeDetailedCurve(trace, ideo);
     });
   });

--- a/src/js/kit/tissue.js
+++ b/src/js/kit/tissue.js
@@ -166,8 +166,14 @@ function getMetricLineAttrs(offsets, metric, y, height, isShifted=false) {
     x = MINI_CURVE_WIDTH + 1;
     isTruncated = true;
   }
-  const metricHeight =
+  let metricHeight =
     !isTruncated ? offsets[metric + 'Height'] : MINI_CURVE_HEIGHT;
+
+  if (isNaN(metricHeight)) {
+    // Seen upon e.g. hovering over "Artery - Coronary" in STAT1
+    metricHeight = MINI_CURVE_HEIGHT;
+  }
+
   const top = height - metricHeight;
   const y1 = top + y + 0.5;
   const y2 = top + y + metricHeight;
@@ -556,7 +562,7 @@ function getExpressionPlotHtml(gene, tissueExpressions, ideo) {
       dataTissue;
 
     return (
-      '<g>' +
+      `<g data-group-tissue="${teObject.tissue}">` +
       `<text ${textAttrs}>${tissue}</text>` +
       distributionCurve +
       medianLine +

--- a/src/js/kit/tissue.js
+++ b/src/js/kit/tissue.js
@@ -345,7 +345,9 @@ function removeDetailedCurve() {
   container.remove();
 
   const structureDom = document.querySelector('._ideoGeneStructureContainer');
-  structureDom.style.display = '';
+  if (structureDom) {
+    structureDom.style.display = '';
+  }
   const footer = document.querySelector('._ideoTooltipFooter');
   footer.style.display = '';
 }
@@ -488,11 +490,17 @@ function addDetailedCurve(traceDom, ideo) {
   const metricTicks = getMetricTicks(teObject, height);
 
   // Hide RNA & protein diagrams, footer
+  let ledgeDom;
   const structureDom = document.querySelector('._ideoGeneStructureContainer');
+  const footer = document.querySelector('._ideoTooltipFooter');
   if (structureDom) { // Account for e.g. ncRNA, like MALAT1
+    ledgeDom = structureDom;
     structureDom.style.display = 'none';
-    const footer = document.querySelector('._ideoTooltipFooter');
     footer.style.display = 'none';
+  } else {
+    ledgeDom = footer;
+    const plotContainer = document.querySelector('._ideoTissuePlotContainer');
+    plotContainer.setAttribute('style', 'margin-bottom: 20px');
   }
 
   const svgHeight = 119.5; // Keeps tooltip bottom flush with prior state
@@ -509,7 +517,7 @@ function addDetailedCurve(traceDom, ideo) {
     `</svg>` +
     '</div>';
 
-  structureDom.insertAdjacentHTML('beforebegin', container);
+  ledgeDom.insertAdjacentHTML('beforebegin', container);
 }
 
 function getMiniCurveY(i, height) {
@@ -571,12 +579,18 @@ function getExpressionPlotHtml(gene, tissueExpressions, ideo) {
     );
   }).join('');
 
+  let containerStyle = '';
+  const hasStructure = gene in ideo.geneStructureCache;
+  if (!hasStructure) { // e.g. MALAT1
+    containerStyle = 'style="margin-bottom: 10px;"';
+  }
+
   const plotAttrs = `style="margin-top: 15px; margin-bottom: -15px;"`;
   const cls = 'class="_ideoTissuePlotTitle"';
   const titleAttrs = `${cls} style="margin-bottom: 4px;"`;
   const style = `style="position: relative; left: 10px"`;
   const plotHtml =
-    '<div>' +
+    `<div class="_ideoTissuePlotContainer" ${containerStyle}>` +
       `<div class="_ideoTissueExpressionPlot" ${plotAttrs}>
         <div ${titleAttrs}>Reference expression by tissue</div>
         <svg width="275" height="${y + height + 2}" ${style}>${rects}</svg>

--- a/test/offline/tissue.test.js
+++ b/test/offline/tissue.test.js
@@ -70,12 +70,49 @@ describe('Ideogram gene-tissue expression functionality', function() {
         const lungSelector = 'rect[data-tissue="Lung"]';
         const lungCurve = document.querySelector(lungSelector);
         lungCurve.dispatchEvent(new Event('mouseenter'));
-        console.log('lungCurve', lungCurve)
         const cellsEbv = 'Cells_EBV-transformed_lymphocytes';
         const cellsEbvSelector =
           `[data-group-tissue="${cellsEbv}"] ._ideoExpressionMedian`;
         const medianTick = document.querySelector(cellsEbvSelector);
         assert.equal(medianTick.style.display, 'none');
+
+        done();
+      }, 500);
+    }
+
+    function onClickAnnot(annot) {
+      ideogram.plotRelatedGenes(annot.name);
+    }
+
+    var config = {
+      organism: 'Homo sapiens', // Also tests standard, non-slugged name
+      onLoad: callback,
+      dataDir: '/dist/data/bands/native/',
+      cacheDir: '/dist/data/cache/',
+      onClickAnnot,
+      showGeneStructureInTooltip: true,
+      showParalogNeighborhoods: true
+    };
+
+    const ideogram = Ideogram.initRelatedGenes(config);
+  });
+
+  it('handles lncRNA gene', done => {
+    async function callback() {
+      await ideogram.plotRelatedGenes('MALAT1');
+      setTimeout(async function() {
+        const malat1Label = document.querySelector('#ideogramLabel__c10_a0');
+        malat1Label.dispatchEvent(new Event('mouseover'));
+        const curves = document.querySelectorAll('polyline');
+        assert.equal(curves.length, 3);
+
+        const ovarySelector = 'rect[data-tissue="Ovary"]';
+        const ovaryCurve = document.querySelector(ovarySelector);
+        ovaryCurve.dispatchEvent(new Event('mouseenter'));
+        const detailCurve =
+          document.querySelector('._ideoDistributionContainer');
+        assert.equal(detailCurve.style.height, '119.5px');
+        ovaryCurve.dispatchEvent(new Event('mouseleave'));
 
         done();
       }, 500);

--- a/test/offline/tissue.test.js
+++ b/test/offline/tissue.test.js
@@ -58,4 +58,44 @@ describe('Ideogram gene-tissue expression functionality', function() {
     const ideogram = Ideogram.initRelatedGenes(config);
   });
 
+  it('hides median when curve is very narrow', done => {
+    async function callback() {
+      await ideogram.plotRelatedGenes('STAT1');
+      setTimeout(async function() {
+        const stat1Label = document.querySelector('#ideogramLabel__c1_a1');
+        stat1Label.dispatchEvent(new Event('mouseover'));
+        const curves = document.querySelectorAll('polyline');
+        assert.equal(curves.length, 3);
+
+        const lungSelector = 'rect[data-tissue="Lung"]';
+        const lungCurve = document.querySelector(lungSelector);
+        lungCurve.dispatchEvent(new Event('mouseenter'));
+        console.log('lungCurve', lungCurve)
+        const cellsEbv = 'Cells_EBV-transformed_lymphocytes';
+        const cellsEbvSelector =
+          `[data-group-tissue="${cellsEbv}"] ._ideoExpressionMedian`;
+        const medianTick = document.querySelector(cellsEbvSelector);
+        assert.equal(medianTick.style.display, 'none');
+
+        done();
+      }, 500);
+    }
+
+    function onClickAnnot(annot) {
+      ideogram.plotRelatedGenes(annot.name);
+    }
+
+    var config = {
+      organism: 'Homo sapiens', // Also tests standard, non-slugged name
+      onLoad: callback,
+      dataDir: '/dist/data/bands/native/',
+      cacheDir: '/dist/data/cache/',
+      onClickAnnot,
+      showGeneStructureInTooltip: true,
+      showParalogNeighborhoods: true
+    };
+
+    const ideogram = Ideogram.initRelatedGenes(config);
+  });
+
 });

--- a/test/offline/tissue.test.js
+++ b/test/offline/tissue.test.js
@@ -1,0 +1,61 @@
+
+/* eslint-disable no-new */
+
+// Tests use cases from ../examples/vanilla/related-genes
+
+describe('Ideogram gene-tissue expression functionality', function() {
+
+  // Account for latency
+  this.timeout(10000);
+
+  d3 = Ideogram.d3;
+
+  beforeEach(function() {
+
+    delete window.chrBands;
+    d3.selectAll('div').remove();
+  });
+
+  it('shows mini curve, more curves, detailed curve', done => {
+    async function callback() {
+      await ideogram.plotRelatedGenes('APOE');
+      setTimeout(async function() {
+        const apoeLabel = document.querySelector('#ideogramLabel__c18_a1');
+        apoeLabel.dispatchEvent(new Event('mouseover'));
+        const curves = document.querySelectorAll('polyline');
+        assert.equal(curves.length, 3);
+
+        const moreLink = document.querySelector('._ideoMoreOrLessTissue');
+        moreLink.dispatchEvent(new Event('click'));
+        const moreCurves = document.querySelectorAll('polyline');
+        assert.equal(moreCurves.length, 10);
+
+        const adrenalSelector = 'rect[data-tissue="Adrenal_Gland"]';
+        const adrenalCurve = document.querySelector(adrenalSelector);
+        adrenalCurve.dispatchEvent(new Event('mouseenter'));
+        const medianTick = document.querySelector('._ideoExpressionMedian');
+        const tickColor = medianTick.getAttribute('stroke');
+        assert.equal(tickColor, '#1c791c');
+
+        done();
+      }, 500);
+    }
+
+    function onClickAnnot(annot) {
+      ideogram.plotRelatedGenes(annot.name);
+    }
+
+    var config = {
+      organism: 'Homo sapiens', // Also tests standard, non-slugged name
+      onLoad: callback,
+      dataDir: '/dist/data/bands/native/',
+      cacheDir: '/dist/data/cache/',
+      onClickAnnot,
+      showGeneStructureInTooltip: true,
+      showParalogNeighborhoods: true
+    };
+
+    const ideogram = Ideogram.initRelatedGenes(config);
+  });
+
+});


### PR DESCRIPTION
This helps compare gene expression in the focused tissue to that in other tissues, via an animated change in perspective.

https://github.com/eweitz/ideogram/assets/1334561/9506ec73-9a35-466d-9488-04cbef2c4d33

Previously (#365), a given gene's expression in almost all of the top-expressed tissues couldn't be finely compared.  That's because one of the ten tissues often has a maximum expression drastically higher than all the others.  The most expressed tissue -- having a maximum so much greater than that in all the other tissues, and often a major outlier even _within_ that tissue -- would cause the distribution curves for all other tissues to be quite small and narrow.  The distribution in other tissues was often indiscernible, beyond looking "very low". 

Now, expression in those non-dominant tissues (which is often biologically relevant) can be compared in detail.

The focused tissue becomes the new coordinate reference for all tissues.  The reference tissue gets scaled and translated to occupy the full width available to mini-curves.  Other mini-curves get transformed to be viewed from the perspective of the focused tissue.  To clarify what's happening, the coordinate reframing is animated.  The expression distribution curves change form in a brief, smooth transition rather than a discontinuous snap from start to end state.  This makes the novel scientific visualization technique more engaging and intuitive.

Other aspects of distribution curves, and protein feature colors, were also refined.
