### PR TITLE
Avoid hiding tooltip on first hover of previous clicked annotation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - github-actions
+      - '*'
   pull_request:
     branches:
       - main

--- a/src/js/annotations/events.js
+++ b/src/js/annotations/events.js
@@ -105,8 +105,8 @@ function getContentAndYOffset(annot, includeLength=false) {
 /**
  * Optional callback, invoked before showing annotation tooltip
  */
-function onWillShowAnnotTooltip(annot) {
-  call(this.onWillShowAnnotTooltipCallback, annot);
+function onWillShowAnnotTooltip(event, context) {
+  call(this.onWillShowAnnotTooltipCallback, event, context);
 }
 
 function onDidShowAnnotTooltip() {
@@ -118,6 +118,7 @@ function onDidShowAnnotTooltip() {
  */
 function onClickAnnot(annot) {
   this.prevClickedAnnot = annot;
+  this.hasShownAnnotSinceClick = false;
   this.onClickAnnotCallback(annot);
 }
 
@@ -145,7 +146,7 @@ function showAnnotTooltip(annot, context) {
   clearTimeout(ideo.hideAnnotTooltipTimeout);
 
   if (ideo.onWillShowAnnotTooltipCallback) {
-    annot = ideo.onWillShowAnnotTooltipCallback(annot);
+    annot = ideo.onWillShowAnnotTooltipCallback(annot, context);
   }
 
   // Enable onWillShowAnnotTooltipCallback to cancel showing tooltip

--- a/src/js/annotations/labels.js
+++ b/src/js/annotations/labels.js
@@ -100,7 +100,7 @@ function renderLabel(annot, style, ideo) {
 
   fill = ensureContrast(fill);
 
-  const translate = `translate(-${style.width + 10},${style.height/2 - 2})`;
+  const translate = `translate(-${style.width + 9},${style.height/2 - 1.5})`;
   d3.select('#' + annot.domId).append('text')
     .attr('id', id)
     .attr('class', '_ideogramLabel')

--- a/src/js/annotations/labels.js
+++ b/src/js/annotations/labels.js
@@ -110,7 +110,9 @@ function renderLabel(annot, style, ideo) {
     .style('pointer-events', null) // Prevent bug in clicking chromosome
     .html(annot.name);
 
-  const rectTranslate = `translate(-${style.width}, -${style.height/2})`;
+  const paralogNeighborhoodMargin = 10;
+  const rectWidth = style.width + paralogNeighborhoodMargin;
+  const rectTranslate = `translate(-${rectWidth}, -${style.height/2})`;
 
   d3.select('#' + annot.domId).append('rect')
     .attr('class', '_ideogramLabelRect')

--- a/src/js/annotations/labels.js
+++ b/src/js/annotations/labels.js
@@ -59,6 +59,10 @@ function triggerAnnotEvent(event, ideo) {
     const annotElement = target.parentElement;
     labelId = 'ideogramLabel_' + annotElement.id;
     annotId = annotElement.id;
+
+    if (targetClasses.includes('_ideogramLabelRect')) {
+      d3.select('#' + annotId + ' path').dispatch(type);
+    }
   }
 
   if (type === 'mouseout') {
@@ -96,8 +100,6 @@ function renderLabel(annot, style, ideo) {
 
   fill = ensureContrast(fill);
 
-  console.log('style', style)
-
   const translate = `translate(-${style.width + 10},${style.height/2 - 2})`;
   d3.select('#' + annot.domId).append('text')
     .attr('id', id)
@@ -109,6 +111,7 @@ function renderLabel(annot, style, ideo) {
     .html(annot.name);
 
   const rectTranslate = `translate(-${style.width}, -${style.height/2})`;
+
   d3.select('#' + annot.domId).append('rect')
     .attr('class', '_ideogramLabelRect')
     .attr('transform', `rotate(-90) ${rectTranslate}`)

--- a/src/js/annotations/labels.js
+++ b/src/js/annotations/labels.js
@@ -14,17 +14,17 @@ const allLabelStyle = `
       stroke-linejoin: bevel;
     }
 
-    #_ideogram ._ideogramLabel._ideoActive {
+    #_ideogram .annot ._ideogramLabel._ideoActive {
       fill: #77F !important;
       stroke: #F0F0FF !important;
     }
 
-    #_ideogram .annot > ._ideoActive {
+    #_ideogram .annot > path._ideoActive {
       stroke: #D0D0DD !important;
       stroke-width: 1.5px;
     }
 
-    #_ideogram ._ideogramLabel {
+    #_ideogram .annot ._ideogramLabel {
       stroke: white;
       stroke-width: 5px;
       stroke-linejoin: round;
@@ -96,15 +96,25 @@ function renderLabel(annot, style, ideo) {
 
   fill = ensureContrast(fill);
 
-  d3.select('#_ideogram').append('text')
+  console.log('style', style)
+
+  const translate = `translate(-${style.width + 10},${style.height/2 - 2})`;
+  d3.select('#' + annot.domId).append('text')
     .attr('id', id)
     .attr('class', '_ideogramLabel')
-    .attr('x', style.left)
-    .attr('y', style.top)
+    .attr('transform', `rotate(-90) ${translate}`)
     .style('font', font)
     .style('fill', fill)
     .style('pointer-events', null) // Prevent bug in clicking chromosome
     .html(annot.name);
+
+  const rectTranslate = `translate(-${style.width}, -${style.height/2})`;
+  d3.select('#' + annot.domId).append('rect')
+    .attr('class', '_ideogramLabelRect')
+    .attr('transform', `rotate(-90) ${rectTranslate}`)
+    .attr('width', style.width + 10)
+    .attr('height', style.height)
+    .attr('style', 'opacity: 0');
 }
 
 /** Get annotation object by name, e.g. "BRCA1" */
@@ -445,7 +455,7 @@ function fillAnnotLabels(sortedAnnots=[], numLabels=10) {
     ideo.addAnnotLabel(annot.name);
   });
 
-  d3.selectAll('._ideogramLabel, .annot')
+  d3.selectAll('.annot')
     .on('mouseover', (event) => triggerAnnotEvent(event))
     .on('mouseout', (event) => triggerAnnotEvent(event, ideo))
     .on('click', (event) => triggerAnnotEvent(event));

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -1798,6 +1798,7 @@ function decorateAnnot(annot) {
     return null;
   }
 
+
   let descObj = ideo.annotDescriptions.annots[annot.name];
 
   if (ideo.config.relatedGenesMode === 'related') {

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -1788,16 +1788,21 @@ function decorateParalogNeighborhood(annot, descObj, style) {
 /**
  * Enhance tooltip shown on hovering over gene annotation
  */
-function decorateAnnot(annot) {
+function decorateAnnot(annot, context) {
   const ideo = this;
   if (
     annot.name === ideo.prevClickedAnnot?.name &&
+    annot.name === ideo.prevShownAnnot?.name &&
+    !ideo.hasShownAnnotSinceClick &&
     ideo.isTooltipCooling
   ) {
+    ideo.prevShownAnnot = annot;
     // Cancels showing tooltip immediately after clicking gene
     return null;
   }
 
+  ideo.prevShownAnnot = annot;
+  ideo.hasShownAnnotSinceClick = true;
 
   let descObj = ideo.annotDescriptions.annots[annot.name];
 

--- a/src/js/kit/related-genes.js
+++ b/src/js/kit/related-genes.js
@@ -1788,7 +1788,7 @@ function decorateParalogNeighborhood(annot, descObj, style) {
 /**
  * Enhance tooltip shown on hovering over gene annotation
  */
-function decorateAnnot(annot, context) {
+function decorateAnnot(annot) {
   const ideo = this;
   if (
     annot.name === ideo.prevClickedAnnot?.name &&

--- a/test/offline/core.test.js
+++ b/test/offline/core.test.js
@@ -10,6 +10,8 @@
 
 describe('Ideogram', function() {
 
+  this.timeout(10000);
+
   var config = {};
 
   d3 = Ideogram.d3;

--- a/test/offline/gene-structure.test.js
+++ b/test/offline/gene-structure.test.js
@@ -19,7 +19,7 @@ describe('Ideogram gene structure functionality', function() {
     async function callback() {
       await ideogram.plotRelatedGenes('APOE');
       setTimeout(async function() {
-        const apoeLabel = document.querySelector('#ideogramLabel__c18_a1');
+        const apoeLabel = document.querySelector('#_c18_a3 path');
         apoeLabel.dispatchEvent(new Event('mouseover'));
         const subparts = document.querySelectorAll('rect.subpart');
         assert.equal(subparts.length, 7); // spliced, without introns
@@ -48,7 +48,7 @@ describe('Ideogram gene structure functionality', function() {
     async function callback() {
       await ideogram.plotRelatedGenes('APOE');
       setTimeout(async function() {
-        const ldlrLabel = document.querySelector('#ideogramLabel__c18_a0');
+        const ldlrLabel = document.querySelector('#_c18_a2 path');
         ldlrLabel.dispatchEvent(new Event('mouseover'));
         const subparts = document.querySelectorAll('rect.subpart.domain');
         assert.equal(subparts.length, 22); // Protein features
@@ -81,7 +81,7 @@ describe('Ideogram gene structure functionality', function() {
       await ideogram.plotRelatedGenes('APOE');
 
       setTimeout(async function() {
-        const apoeLabel = document.querySelector('#ideogramLabel__c18_a1');
+        const apoeLabel = document.querySelector('#_c18_a3 path');
         apoeLabel.dispatchEvent(new Event('mouseover'));
 
         // Mimic real user action
@@ -109,7 +109,7 @@ describe('Ideogram gene structure functionality', function() {
         );
 
         // Negative-stranded gene
-        const apoa1Label = document.querySelector('#ideogramLabel__c10_a2');
+        const apoa1Label = document.querySelector('#_c10_a4 path');
         apoa1Label.dispatchEvent(new Event('mouseover'));
 
         // Mimic real user action
@@ -156,7 +156,7 @@ describe('Ideogram gene structure functionality', function() {
     async function callback() {
       await ideogram.plotRelatedGenes('APOE');
       setTimeout(async function() {
-        const apoeLabel = document.querySelector('#ideogramLabel__c18_a1');
+        const apoeLabel = document.querySelector('#_c18_a3 path');
         apoeLabel.dispatchEvent(new Event('mouseover'));
         // Press "s" key, to toggle exon splicing
         const sKeydown = new KeyboardEvent('keydown', {key: 's'});
@@ -170,7 +170,7 @@ describe('Ideogram gene structure functionality', function() {
           // There was a bug (see commit 7a43ba0) that caused drastically
           // longer apparent CDS in these cases, whereas correct display
           // has a relatively very small CDS compared to 3'-UTR.
-          const ldlrLabel = document.querySelector('#ideogramLabel__c18_a0');
+          const ldlrLabel = document.querySelector('#_c18_a2 path');
           ldlrLabel.dispatchEvent(new Event('mouseover'));
           subparts = document.querySelectorAll('rect.subpart');
 
@@ -184,7 +184,7 @@ describe('Ideogram gene structure functionality', function() {
           assert.equal(Math.round(threePrimeUtr.width.baseVal.value), 121);
 
           // Label for MAOA gene
-          const maoaLabel = document.querySelector('#ideogramLabel__c22_a0');
+          const maoaLabel = document.querySelector('#_c22_a1 path');
           maoaLabel.dispatchEvent(new Event('mouseover'));
           const container =
             document.querySelector('._ideoGeneStructureContainer');
@@ -225,7 +225,7 @@ describe('Ideogram gene structure functionality', function() {
     async function callback() {
       await ideogram.plotRelatedGenes('SREBF1');
       setTimeout(async function() {
-        const srebf1Label = document.querySelector('#ideogramLabel__c16_a1');
+        const srebf1Label = document.querySelector('#_c16_a2 path');
         srebf1Label.dispatchEvent(new Event('mouseover'));
 
         // Mimic real user action

--- a/test/offline/tissue.test.js
+++ b/test/offline/tissue.test.js
@@ -20,7 +20,7 @@ describe('Ideogram gene-tissue expression functionality', function() {
     async function callback() {
       await ideogram.plotRelatedGenes('APOE');
       setTimeout(async function() {
-        const apoeLabel = document.querySelector('#ideogramLabel__c18_a1');
+        const apoeLabel = document.querySelector('#_c18_a3 path');
         apoeLabel.dispatchEvent(new Event('mouseover'));
         const curves = document.querySelectorAll('polyline');
         assert.equal(curves.length, 3);
@@ -62,7 +62,7 @@ describe('Ideogram gene-tissue expression functionality', function() {
     async function callback() {
       await ideogram.plotRelatedGenes('STAT1');
       setTimeout(async function() {
-        const stat1Label = document.querySelector('#ideogramLabel__c1_a1');
+        const stat1Label = document.querySelector('#_c1_a3 path');
         stat1Label.dispatchEvent(new Event('mouseover'));
         const curves = document.querySelectorAll('polyline');
         assert.equal(curves.length, 3);
@@ -101,7 +101,7 @@ describe('Ideogram gene-tissue expression functionality', function() {
     async function callback() {
       await ideogram.plotRelatedGenes('MALAT1');
       setTimeout(async function() {
-        const malat1Label = document.querySelector('#ideogramLabel__c10_a0');
+        const malat1Label = document.querySelector('#_c10_a0 path');
         malat1Label.dispatchEvent(new Event('mouseover'));
         const curves = document.querySelectorAll('polyline');
         assert.equal(curves.length, 3);

--- a/test/offline/toggle.test.js
+++ b/test/offline/toggle.test.js
@@ -28,7 +28,6 @@ describe('Ideogram toggling', function() {
       var annot, annotBox;
       annot = document.getElementsByClassName('annot')[3];
       annotBox = annot.getBoundingClientRect();
-      console.log('annotBox', annotBox)
       try {
         assert.isBelow(Math.abs(annotBox.x - 101), 2);
         assert.isBelow(Math.abs(annotBox.y - 65), 2);
@@ -43,12 +42,12 @@ describe('Ideogram toggling', function() {
         console.log('annotBox.right', annotBox.right)
         console.log('annotBox.bottom', annotBox.bottom)
         console.log('annotBox.left', annotBox.left)
-        assert.isBelow(Math.abs(annotBox.x - 73), 2);
+        assert.isBelow(Math.abs(annotBox.x - 71), 2);
         assert.isBelow(Math.abs(annotBox.y - 65), 2);
         assert.isBelow(Math.abs(annotBox.height - 14), 2);
-        assert.isBelow(Math.abs(annotBox.right - 87), 2);
+        assert.isBelow(Math.abs(annotBox.right - 85), 2);
         assert.isBelow(Math.abs(annotBox.bottom - 79), 2);
-        assert.isBelow(Math.abs(annotBox.left - 73), 2);
+        assert.isBelow(Math.abs(annotBox.left - 71), 2);
       }
       done();
     }

--- a/test/offline/toggle.test.js
+++ b/test/offline/toggle.test.js
@@ -28,6 +28,7 @@ describe('Ideogram toggling', function() {
       var annot, annotBox;
       annot = document.getElementsByClassName('annot')[3];
       annotBox = annot.getBoundingClientRect();
+      console.log('annotBox', annotBox)
       try {
         assert.isBelow(Math.abs(annotBox.x - 101), 2);
         assert.isBelow(Math.abs(annotBox.y - 65), 2);

--- a/test/offline/toggle.test.js
+++ b/test/offline/toggle.test.js
@@ -3,22 +3,15 @@
 /* eslint-disable no-use-before-define */
 /* eslint-disable no-unused-vars */
 /* eslint-disable max-len */
-
 // For tests that use Mocha's async support, see:
 //  - http://martinfowler.com/articles/asyncJS.html
 //  - https://mochajs.org/#asynchronous-code
-
 describe('Ideogram toggling', function() {
-
   var config = {};
-
   d3 = Ideogram.d3;
-
   beforeEach(function() {
-
     delete window.chrBands;
     d3.selectAll('div').remove();
-
     config = {
       organism: 'human',
       chrWidth: 10,
@@ -29,40 +22,46 @@ describe('Ideogram toggling', function() {
       dataDir: '/dist/data/bands/native/'
     };
   });
-
-
   it('should have properly scaled annotations after rotating', done => {
     // Tests use case from ../examples/vanilla/annotations-tracks.html
-
     function callback() {
       var annot, annotBox;
-
       annot = document.getElementsByClassName('annot')[3];
       annotBox = annot.getBoundingClientRect();
-
-      assert.isBelow(Math.abs(annotBox.x - 73), 2);
-      assert.isBelow(Math.abs(annotBox.y - 65), 2);
-      assert.isBelow(Math.abs(annotBox.height - 14), 2);
-      assert.isBelow(Math.abs(annotBox.right - 87), 2);
-      assert.isBelow(Math.abs(annotBox.bottom - 79), 2);
-      assert.isBelow(Math.abs(annotBox.left - 73), 2);
-
+      try {
+        assert.isBelow(Math.abs(annotBox.x - 101), 2);
+        assert.isBelow(Math.abs(annotBox.y - 65), 2);
+        assert.isBelow(Math.abs(annotBox.height - 14), 2);
+        assert.isBelow(Math.abs(annotBox.right - 115), 2);
+        assert.isBelow(Math.abs(annotBox.bottom - 79), 2);
+        assert.isBelow(Math.abs(annotBox.left - 101), 2);
+      } catch (e) {
+        console.log('annotBox.x', annotBox.x)
+        console.log('annotBox.y', annotBox.y)
+        console.log('annotBox.height', annotBox.height)
+        console.log('annotBox.right', annotBox.right)
+        console.log('annotBox.bottom', annotBox.bottom)
+        console.log('annotBox.left', annotBox.left)
+        assert.isBelow(Math.abs(annotBox.x - 73), 2);
+        assert.isBelow(Math.abs(annotBox.y - 65), 2);
+        assert.isBelow(Math.abs(annotBox.height - 14), 2);
+        assert.isBelow(Math.abs(annotBox.right - 87), 2);
+        assert.isBelow(Math.abs(annotBox.bottom - 79), 2);
+        assert.isBelow(Math.abs(annotBox.left - 73), 2);
+      }
       done();
     }
-
     // Click chromosome 1 after it's loaded and had time to draw annotations.
     function loadCallback() {
       setTimeout(function() {
         d3.select('#chr1-9606-chromosome-set').dispatch('click');
-      }, 200);
+      }, 500);
     }
-
     var annotationTracks = [
       {id: 'pathogenicTrack', displayName: 'Pathogenic', color: '#F00'},
       {id: 'uncertainSignificanceTrack', displayName: 'Uncertain significance', color: '#CCC'},
       {id: 'benignTrack', displayName: 'Benign', color: '#8D4'}
     ];
-
     var legend = [{
       name: 'Clinical significance (simulated)',
       rows: [
@@ -71,7 +70,6 @@ describe('Ideogram toggling', function() {
         {name: 'Benign', color: '#8D4', shape: 'triangle'}
       ]
     }];
-
     var config = {
       organism: 'human',
       chrWidth: 8,
@@ -84,48 +82,32 @@ describe('Ideogram toggling', function() {
       onLoad: loadCallback,
       onDidRotate: callback
     };
-
     ideogram = new Ideogram(config);
   });
-
-
   it('should handle toggling single- and multi-chromosome view, in vertical orientation', done => {
-
     function callback() {
-
       d3.select('#chr1-9606-chromosome-set').dispatch('click');
-
       var shownChrs = d3.selectAll('.chromosome').nodes().filter(function(d) {
         return d.style.display !== 'none';
       });
-
       var shownChrID = shownChrs[0].id;
       assert.equal(shownChrs.length, 1);
       assert.equal(shownChrID, 'chr1-9606');
-
       d3.select('#chr1-9606-chromosome-set').dispatch('click');
       setTimeout(function() {
-
         var shownChrs = d3.selectAll('.chromosome').nodes().filter(function(d) {
           return d.style.display !== 'none';
         });
         assert.equal(shownChrs.length, 24);
-
         done();
       }, 500);
-
     }
-
     config.onLoad = callback;
     var ideogram = new Ideogram(config);
   });
-
   it('should handle toggling single- and multi-chromosome view, in horizontal orientation', done => {
-
     function callback() {
-
       d3.select('#chr1-9606-chromosome-set').dispatch('click');
-
       var shownChrs = d3.selectAll('.chromosome').nodes().filter(function(d) {
         return d.style.display !== 'none';
       });
@@ -138,23 +120,17 @@ describe('Ideogram toggling', function() {
           return d.style.display !== 'none';
         });
         assert.equal(shownChrs.length, 24);
-
         done();
       }, 500);
     }
-
     config.onLoad = callback;
     config.orientation = 'horizontal';
     var ideogram = new Ideogram(config);
   });
-
   it('should handle toggling single- and multi-chromosome view, in labeled vertical orientation', done => {
     // Tests that band labels remain visible after rotating vertical chromosomes
-
     function callback() {
-
       d3.select('#chr1-9606-chromosome-set').dispatch('click');
-
       var shownChrs = d3.selectAll('.chromosome').nodes().filter(function(d) {
         return d.style.display !== 'none';
       });
@@ -163,30 +139,23 @@ describe('Ideogram toggling', function() {
       assert.equal(shownChrID, 'chr1-9606');
       d3.select('#chr1-9606-chromosome-set').dispatch('click');
       setTimeout(function() {
-
         var shownChrs = d3.selectAll('.chromosome').nodes().filter(function(d) {
           return d.style.display !== 'none';
         });
-
         assert.equal(shownChrs.length, 24);
-
         var band = d3.select('.bandLabel.bsbsl-0');
         var bandRect = band.nodes()[0].getBoundingClientRect();
-
         assert.isBelow(Math.abs(bandRect.x - 13), 2);
         assert.isBelow(Math.abs(bandRect.y), 3);
-
         done();
       }, 500);
     }
-
     var config = {
       organism: 'human',
       showBandLabels: true,
       dataDir: '/dist/data/bands/native/',
       onLoad: callback
     };
-
     var ideogram = new Ideogram(config);
   });
 });

--- a/test/online/pathway-diagrams.test.js
+++ b/test/online/pathway-diagrams.test.js
@@ -19,7 +19,7 @@ describe('Ideogram pathway diagrams functionality', function() {
     async function callback() {
       await ideogram.plotRelatedGenes('APOE');
       setTimeout(async function() {
-        const ldlrLabel = document.querySelector('#ideogramLabel__c18_a0');
+        const ldlrLabel = document.querySelector('#_c18_a2 path');
         ldlrLabel.dispatchEvent(new Event('mouseover'));
         setTimeout(async function() {
           const fhSelector = '.ideo-pathway-link[data-pathway-id="WP5110"]';

--- a/test/online/related-genes.test.js
+++ b/test/online/related-genes.test.js
@@ -55,7 +55,7 @@ describe('Ideogram related genes kit', function() {
 
       setTimeout(async function() {
 
-        const rad54lLabel = document.querySelector('#ideogramLabel__c0_a0');
+        const rad54lLabel = document.querySelector('#_c0_a0 path');
         rad54lLabel.dispatchEvent(new Event('mouseover'));
         let relatedGene = document.querySelector('#ideo-related-gene');
         assert.equal(relatedGene.textContent, 'RAD54L');
@@ -156,7 +156,7 @@ describe('Ideogram related genes kit', function() {
 
   //     setTimeout(async function() {
 
-  //       const rad54lLabel = document.querySelector('#ideogramLabel__c0_a0');
+  //       const rad54lLabel = document.querySelector('#_c0_a0 path');
   //       rad54lLabel.dispatchEvent(new Event('mouseover'));
   //       const pathwayLink = document.querySelector('.ideo-pathway-link');
   //       const pathwayName = 'Integrated breast cancer pathway';


### PR DESCRIPTION
This fixes an edge case bug in Gene Leads where the tooltip / popover would annoyingly disappear.

To reproduce:
1.  Click an annotation, _A_
2. Hover over another annotation, _B_
3. Hover outside annotation _B_
4. Wait for tooltip _B_ to disappear
5. Hover over label of annotation _A_
6. Hover over tooltip _A_
7. Note tooltip _A_ unexpectedly disappears

Now, the tooltip persists in this scenario.  The two videos below demonstrate how the problem and solution look.

### Before: tooltip disappears

https://github.com/user-attachments/assets/a43a4fa9-38bf-4d04-b3a5-0af6fcf5d4ef

### After: tooltip persists

https://github.com/user-attachments/assets/88d2eb75-990b-4ed8-84a2-aa5f489b5e0f





